### PR TITLE
Optimise script output and skip PDF by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,11 @@ A guitar song book generator. Songs are written in Markdown with inline chord no
 ## Build command
 
 ```bash
-./song-book-builder.rb
+./song-book-builder.rb        # HTML only (fast)
+./song-book-builder.rb --pdf  # HTML + PDF (slow)
 ```
 
 Dependencies: Ruby 3.x, Pandoc (`brew install pandoc`), DeckTape (`npm install -g decktape`).
-
-PDF generation (via DeckTape) is slow — if you only need the HTML output, you can comment out the `decktape` line at the bottom of `song-book-builder.rb`.
 
 ## Song file format
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Simply add more songs to `content/songs`.
 
 Run the following command: `$ ./song-book-builder.rb`.
 
-The command will run for quite some time, as PDF generation is slow.
+PDF generation is slow and skipped by default. Pass `--pdf` to include it:
 
-## TODOs
-
-- Add switch to disable PDF generation when running script
+```
+$ ./song-book-builder.rb --pdf
+```

--- a/all-songs.md
+++ b/all-songs.md
@@ -1,6 +1,6 @@
 ---
-author: 😊 Josua and friends ❤️
-title:  Our Songs 🔥🎶🌛
+title:  Lieblings-Songs 🔥🎶🌛
+author: 😊 Josua & Monika ❤️
 ---
 
 # Introduction

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
-  <meta name="author" content="😊 Josua and friends ❤️">
-  <title>Our Songs 🔥🎶🌛</title>
+  <meta name="author" content="😊 Josua &amp; Monika ❤️">
+  <title>Lieblings-Songs 🔥🎶🌛</title>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
@@ -167,13 +167,18 @@ a#toggle-theme::before {
     .reveal .sourceCode {  /* see #7635 */
       overflow: visible;
     }
-    code{white-space: pre-wrap;}
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
     span.smallcaps{font-variant: small-caps;}
     div.columns{display: flex; gap: min(4vw, 1.5em);}
     div.column{flex: auto; overflow-x: auto;}
     div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
     ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
       width: 0.8em;
       margin: 0 0.8em 0.2em -1.6em;
       vertical-align: middle;
@@ -187,8 +192,8 @@ a#toggle-theme::before {
     <div class="slides">
 
 <section id="title-slide">
-  <h1 class="title">Our Songs 🔥🎶🌛</h1>
-  <p class="author">😊 Josua and friends ❤️</p>
+  <h1 class="title">Lieblings-Songs 🔥🎶🌛</h1>
+  <p class="author">😊 Josua &amp; Monika ❤️</p>
 </section>
 <section id="TOC">
 <nav role="doc-toc"> 
@@ -1684,13 +1689,14 @@ class="g">G</code> hei<br />
 class="e">E7</code> Bett en<br />
 <code class="a">Am</code> Orde zuegsproche für my ganz al<code
 class="g">G7</code>lei<br />
-<code class="c">C</code> Glunge isch nume, dass zmonderischt^_*_^ <code
-class="e">E</code> scho<br />
+<code class="c">C</code> Glunge isch nume, dass
+zmonderischt<sup>_*_</sup> <code class="e">E</code> scho<br />
 <code class="a">Am</code> Über mi Red mir du <code class="e">E7</code>
 Zwyfel si <code class="a">Am</code> cho</p>
-<p>_^*^ Zmonderischt: Ein Tag, welcher nach einem schon<br />
+<p><em><sup>*</sup> Zmonderischt: Ein Tag, welcher nach einem
+schon<br />
 vergangenen Tag gekommen ist. (<a
-href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)_</p>
+href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)</em></p>
 </section>
 <section id="verse-6-3" class="slide level2">
 <h2>Verse 6</h2>
@@ -2094,12 +2100,13 @@ hei</p>
 <p>Was <code class="a">Am</code> unterscheidet d’Mönsche vom schim<code
 class="d">Dm</code>pans?<br />
 S’isch <code class="g">G</code> nid die glatti Huut, dr fählend <code
-class="c">C</code> Schwanz^_(*)_^<br />
+class="c">C</code> Schwanz<sup>_(*)_</sup><br />
 Nid <code class="c">C</code> dass mir schlächter d’Böim ufchöme, <code
 class="e">E7</code> nei<br />
 Dass mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-<p>_(^*^ Fun Fact: Schimpanse haben gar keinen Schwanz!)_</p>
+<p><em>(<sup>*</sup> Fun Fact: Schimpanse haben gar keinen
+Schwanz!)</em></p>
 </section>
 <section id="verse-5-7" class="slide level2">
 <h2>Verse 5</h2>

--- a/print.html
+++ b/print.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
-  <meta name="author" content="😊 Josua and friends ❤️">
-  <title>Our Songs 🔥🎶🌛</title>
+  <meta name="author" content="😊 Josua &amp; Monika ❤️">
+  <title>Lieblings-Songs 🔥🎶🌛</title>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
@@ -80,13 +80,18 @@ body {
     .reveal .sourceCode {  /* see #7635 */
       overflow: visible;
     }
-    code{white-space: pre-wrap;}
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
     span.smallcaps{font-variant: small-caps;}
     div.columns{display: flex; gap: min(4vw, 1.5em);}
     div.column{flex: auto; overflow-x: auto;}
     div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
     ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
       width: 0.8em;
       margin: 0 0.8em 0.2em -1.6em;
       vertical-align: middle;
@@ -100,8 +105,8 @@ body {
     <div class="slides">
 
 <section id="title-slide" data-background-image="style/background.jpg">
-  <h1 class="title">Our Songs 🔥🎶🌛</h1>
-  <p class="author">😊 Josua and friends ❤️</p>
+  <h1 class="title">Lieblings-Songs 🔥🎶🌛</h1>
+  <p class="author">😊 Josua &amp; Monika ❤️</p>
 </section>
 <section id="TOC">
 <nav role="doc-toc"> 
@@ -1494,13 +1499,14 @@ class="g">G</code> hei<br />
 class="e">E7</code> Bett en<br />
 <code class="a">Am</code> Orde zuegsproche für my ganz al<code
 class="g">G7</code>lei<br />
-<code class="c">C</code> Glunge isch nume, dass zmonderischt^_*_^ <code
-class="e">E</code> scho<br />
+<code class="c">C</code> Glunge isch nume, dass
+zmonderischt<sup>_*_</sup> <code class="e">E</code> scho<br />
 <code class="a">Am</code> Über mi Red mir du <code class="e">E7</code>
 Zwyfel si <code class="a">Am</code> cho</p>
-<p>_^*^ Zmonderischt: Ein Tag, welcher nach einem schon<br />
+<p><em><sup>*</sup> Zmonderischt: Ein Tag, welcher nach einem
+schon<br />
 vergangenen Tag gekommen ist. (<a
-href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)_</p>
+href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)</em></p>
 </section>
 <section id="verse-6-3" class="slide level2">
 <h2>Verse 6</h2>
@@ -1874,12 +1880,13 @@ hei</p>
 <p>Was <code class="a">Am</code> unterscheidet d’Mönsche vom schim<code
 class="d">Dm</code>pans?<br />
 S’isch <code class="g">G</code> nid die glatti Huut, dr fählend <code
-class="c">C</code> Schwanz^_(*)_^<br />
+class="c">C</code> Schwanz<sup>_(*)_</sup><br />
 Nid <code class="c">C</code> dass mir schlächter d’Böim ufchöme, <code
 class="e">E7</code> nei<br />
 Dass mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-<p>_(^*^ Fun Fact: Schimpanse haben gar keinen Schwanz!)_</p>
+<p><em>(<sup>*</sup> Fun Fact: Schimpanse haben gar keinen
+Schwanz!)</em></p>
 </section>
 <section id="verse-5-7" class="slide level2">
 <h2>Verse 5</h2>

--- a/song-book-builder.rb
+++ b/song-book-builder.rb
@@ -30,8 +30,8 @@ puts
 markdown = []
 markdown << <<~EOS
               ---
-              author: 😊 Josua and friends ❤️
-              title:  Our Songs 🔥🎶🌛
+              title:  Lieblings-Songs 🔥🎶🌛
+              author: 😊 Josua & Monika ❤️
               ---
             EOS
 

--- a/song-book-builder.rb
+++ b/song-book-builder.rb
@@ -9,6 +9,24 @@ OptionParser.new do |opts|
   opts.on("--pdf", "Generate PDF (slow)") { options[:pdf] = true }
 end.parse!
 
+def step(emoji, label)
+  print "#{emoji}  #{label}... "
+  t = Time.now
+  result = yield
+  puts "✅ (#{"%.1f" % (Time.now - t)}s)"
+  result
+end
+
+puts "🎸 Building song book"
+puts
+
+# Collect and transform songs
+song_files = Dir["content/songs/*.md"].sort
+
+puts "🎵 Songs (#{song_files.size}):"
+song_files.each { |f| puts "   🎶 #{File.basename(f, ".md")}" }
+puts
+
 markdown = []
 markdown << <<~EOS
               ---
@@ -19,50 +37,58 @@ markdown << <<~EOS
 
 markdown << File.open("content/Introduction.md").read
 
-markdown += Dir["content/songs/*.md"].sort.map do |filename|
-              content = File.open(filename).read
+markdown += song_files.map do |filename|
+  File.open(filename).read.gsub(/(\[)(([A-Z]).*?)(\])([^\(])/) do
+    "`#{$2}`{.#{$3.downcase}}#{$5}"
+  end
+end
 
-              content.gsub!(/(\[)(([A-Z]).*?)(\])([^\(])/) do
-                "`#{$2}`{.#{$3.downcase}}#{$5}"
-              end
-            end
-
-file = File.new("all-songs.md", "w")
-file.puts(markdown.join("\n"))
-file.close
+step("📝", "Writing all-songs.md") do
+  file = File.new("all-songs.md", "w")
+  file.puts(markdown.join("\n"))
+  file.close
+end
 
 # HTML slides (Reveal.js)
-puts `pandoc -t revealjs -s -o index.html all-songs.md --slide-level=2 --no-highlight --toc --toc-depth=1 -V theme=night -V progress=false -V revealjs-url=./style/revealjs`
+step("🌙", "Generating index.html (Pandoc)") do
+  output = `pandoc -t revealjs -s -o index.html all-songs.md --slide-level=2 --syntax-highlighting=none --toc --toc-depth=1 -V theme=night -V progress=false -V revealjs-url=./style/revealjs 2>&1`
+  print output unless output.strip.empty?
+end
 
-result = File.open("index.html").read
-
-result.gsub!("<body>", '<body><input type="checkbox" id="toggle-chords-visibility" /><label for="toggle-chords-visibility"></label><a href="#" id="toggle-theme" onclick="document.getElementById(\'theme\').setAttribute(\'href\',\'revealjs/style/theme/serif.css\'); return false;"></a><a href="#/1" id="go-to-toc"></a>')
-result.gsub!('<style>', '<style>' + File.open("style/night.css").read + File.open("style/shared.css").read)
-
-file = File.open("index.html", "w")
-file.write(result)
-file.close
+step("✨", "Post-processing index.html") do
+  result = File.open("index.html").read
+  result.gsub!("<body>", '<body><input type="checkbox" id="toggle-chords-visibility" /><label for="toggle-chords-visibility"></label><a href="#" id="toggle-theme" onclick="document.getElementById(\'theme\').setAttribute(\'href\',\'revealjs/style/theme/serif.css\'); return false;"></a><a href="#/1" id="go-to-toc"></a>')
+  result.gsub!('<style>', '<style>' + File.open("style/night.css").read + File.open("style/shared.css").read)
+  File.open("index.html", "w") { |f| f.write(result) }
+end
 
 # Word
-# puts `pandoc -s -o songs.docx all-songs.md --no-highlight --toc --toc-depth=1`
+# `pandoc -s -o songs.docx all-songs.md --syntax-highlighting=none --toc --toc-depth=1`
 
 # Powerpoint
-# puts `pandoc -s -o songs.pptx all-songs.md --slide-level=2`
+# `pandoc -s -o songs.pptx all-songs.md --slide-level=2`
 
 # Printable song book
-puts `pandoc -t revealjs -s -o print.html all-songs.md --slide-level=2 --no-highlight --toc --toc-depth=1 -V theme=serif -V progress=false -V revealjs-url=./style/revealjs`
+step("🖨️", "Generating print.html (Pandoc)") do
+  output = `pandoc -t revealjs -s -o print.html all-songs.md --slide-level=2 --syntax-highlighting=none --toc --toc-depth=1 -V theme=serif -V progress=false -V revealjs-url=./style/revealjs 2>&1`
+  print output unless output.strip.empty?
+end
 
-result = File.open("print.html").read
-
-result.gsub!('<style>', '<style>' + File.open("style/serif.css").read + File.open("style/shared.css").read) # Add 
-result.gsub!(/<section id="resources[-\d]*?" class="slide level2">(.*?)<\/section>/m, "") # Remove "Resources" slides (they contain links that are useless/ugly in a printed document)
-result.gsub!('<section id="title-slide"', '<section id="title-slide" data-background-image="style/background.jpg"') # Add background to title slide
-
-file = File.open("print.html", "w")
-file.write(result)
-file.close
+step("✨", "Post-processing print.html") do
+  result = File.open("print.html").read
+  result.gsub!('<style>', '<style>' + File.open("style/serif.css").read + File.open("style/shared.css").read)
+  result.gsub!(/<section id="resources[-\d]*?" class="slide level2">(.*?)<\/section>/m, "")
+  result.gsub!('<section id="title-slide"', '<section id="title-slide" data-background-image="style/background.jpg"')
+  File.open("print.html", "w") { |f| f.write(result) }
+end
 
 if options[:pdf]
-  print_file = "#{URI::encode(File.expand_path(File.dirname(__FILE__))).to_s}/print.html"
-  puts `decktape -s 1600x1200 file://#{print_file} print.pdf`
+  step("📄", "Generating print.pdf (DeckTape)") do
+    print_file = "#{URI::encode(File.expand_path(File.dirname(__FILE__))).to_s}/print.html"
+    output = `decktape -s 1600x1200 file://#{print_file} print.pdf 2>&1`
+    print "\n#{output}" unless output.strip.empty?
+  end
 end
+
+puts
+puts "🎉 Done!"

--- a/song-book-builder.rb
+++ b/song-book-builder.rb
@@ -1,6 +1,13 @@
 #!/usr/bin/ruby
 
-# require 'pry'
+require 'optparse'
+
+options = { pdf: false }
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: song-book-builder.rb [options]"
+  opts.on("--pdf", "Generate PDF (slow)") { options[:pdf] = true }
+end.parse!
 
 markdown = []
 markdown << <<~EOS
@@ -55,5 +62,7 @@ file = File.open("print.html", "w")
 file.write(result)
 file.close
 
-print_file = "#{URI::encode(File.expand_path(File.dirname(__FILE__))).to_s}/print.html"
-puts `decktape -s 1600x1200 file://#{print_file} print.pdf`
+if options[:pdf]
+  print_file = "#{URI::encode(File.expand_path(File.dirname(__FILE__))).to_s}/print.html"
+  puts `decktape -s 1600x1200 file://#{print_file} print.pdf`
+end


### PR DESCRIPTION
## Summary

- PDF generation is now skipped by default (pass `--pdf` to opt in) — this makes the common case much faster
- Each build step now prints a labelled line with elapsed time and a ✅ checkmark; songs are listed at the start
- Fixed deprecated `--no-highlight` Pandoc flag (replaced with `--syntax-highlighting=none`)
- Updated README and CLAUDE.md to document the new `--pdf` flag

## Test plan

- [x] Run `./song-book-builder.rb` — confirm PDF is skipped and output shows step labels with timings
- [x] Run `./song-book-builder.rb --pdf` — confirm PDF is generated
- [x] Run `./song-book-builder.rb --help` — confirm usage is printed
- [x] Confirm no Pandoc deprecation warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)