### PR TITLE
Add --deploy flag to build script

### DIFF
--- a/song-book-builder.rb
+++ b/song-book-builder.rb
@@ -94,7 +94,7 @@ end
 if options[:deploy]
   step("🚀", "Deploying to josh.ch/songs") do
     remote = "maroni@greip.uberspace.de:/var/www/virtual/maroni/josh.ch/songs/"
-    output = `rsync -avz --delete index.html style/ #{remote} 2>&1`
+    output = `rsync -avz --delete index.html style #{remote} 2>&1`
     print "\n#{output}" unless output.strip.empty?
   end
 end

--- a/song-book-builder.rb
+++ b/song-book-builder.rb
@@ -94,8 +94,8 @@ end
 if options[:deploy]
   step("🚀", "Deploying to josh.ch/songs") do
     remote = "maroni@greip.uberspace.de:/var/www/virtual/maroni/josh.ch/songs/"
-    output = `rsync -avz --delete index.html style #{remote} 2>&1`
-    print "\n#{output}" unless output.strip.empty?
+    puts
+    system("rsync -avz --delete index.html style #{remote}")
   end
 end
 

--- a/song-book-builder.rb
+++ b/song-book-builder.rb
@@ -2,11 +2,12 @@
 
 require 'optparse'
 
-options = { pdf: false }
+options = { pdf: false, deploy: false }
 
 OptionParser.new do |opts|
   opts.banner = "Usage: song-book-builder.rb [options]"
   opts.on("--pdf", "Generate PDF (slow)") { options[:pdf] = true }
+  opts.on("--deploy", "Deploy to josh.ch/songs via rsync") { options[:deploy] = true }
 end.parse!
 
 def step(emoji, label)
@@ -86,6 +87,14 @@ if options[:pdf]
   step("📄", "Generating print.pdf (DeckTape)") do
     print_file = "#{URI::encode(File.expand_path(File.dirname(__FILE__))).to_s}/print.html"
     output = `decktape -s 1600x1200 file://#{print_file} print.pdf 2>&1`
+    print "\n#{output}" unless output.strip.empty?
+  end
+end
+
+if options[:deploy]
+  step("🚀", "Deploying to josh.ch/songs") do
+    remote = "maroni@greip.uberspace.de:/var/www/virtual/maroni/josh.ch/songs/"
+    output = `rsync -avz --delete index.html style/ #{remote} 2>&1`
     print "\n#{output}" unless output.strip.empty?
   end
 end


### PR DESCRIPTION
## Summary

- Adds a `--deploy` flag that rsyncs `index.html` and `style/` to josh.ch/songs via rsync
- Streams rsync output live during the deploy step

## Usage

```bash
./song-book-builder.rb --deploy        # build + deploy
./song-book-builder.rb --pdf --deploy  # build + PDF + deploy
```

## Test plan

- [x] Run `./song-book-builder.rb --deploy` and verify files appear on https://josh.ch/songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)