### PR TITLE
Add ./dev watch script: rebuild and live-reload on change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,10 @@ A guitar song book generator. Songs are written in Markdown with inline chord no
 ./build           # HTML only (fast)
 ./build --pdf     # HTML + PDF (slow)
 ./build --deploy  # HTML + deploy to songs.josh.ch
+./dev             # Watch, rebuild, deploy, and live-reload on every change
 ```
 
-Dependencies: Ruby 3.x, Pandoc (`brew install pandoc`), DeckTape (`npm install -g decktape`).
+Dependencies: Ruby 3.x, Pandoc (`brew install pandoc`), DeckTape (`npm install -g decktape`), fswatch (`brew install fswatch`), browser-sync (`npm install -g browser-sync`).
 
 ## Song file format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A guitar song book generator. Songs are written in Markdown with inline chord no
 ./build           # HTML only (fast)
 ./build --pdf     # HTML + PDF (slow)
 ./build --deploy  # HTML + deploy to songs.josh.ch
-./dev             # Watch, rebuild, deploy, and live-reload on every change
+./dev             # Watch, rebuild, and live-reload on every change
 ```
 
 Dependencies: Ruby 3.x, Pandoc (`brew install pandoc`), DeckTape (`npm install -g decktape`), fswatch (`brew install fswatch`), browser-sync (`npm install -g browser-sync`).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A live version is at [songs.josh.ch](https://songs.josh.ch).
 LANG=en_US.UTF-8 ./build           # HTML only (fast)
 LANG=en_US.UTF-8 ./build --pdf     # HTML + PDF (slow)
 LANG=en_US.UTF-8 ./build --deploy  # HTML + deploy to songs.josh.ch
-LANG=en_US.UTF-8 ./dev             # Watch, rebuild, deploy, and live-reload on every change
+LANG=en_US.UTF-8 ./dev             # Watch, rebuild, and live-reload on every change
 ```
 
 > `LANG=en_US.UTF-8` is required because song files contain non-ASCII characters.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A live version is at [songs.josh.ch](https://songs.josh.ch).
 - [Ruby](https://www.ruby-lang.org/) 3.x
 - [Pandoc](https://pandoc.org/): `brew install pandoc`
 - [DeckTape](https://github.com/astefanutti/decktape) (PDF only): `npm install -g decktape`
+- [fswatch](https://github.com/emcrisostomo/fswatch) (dev watch only): `brew install fswatch`
+- [browser-sync](https://browsersync.io/) (dev watch only): `npm install -g browser-sync`
 
 ## Build
 
@@ -24,6 +26,7 @@ A live version is at [songs.josh.ch](https://songs.josh.ch).
 LANG=en_US.UTF-8 ./build           # HTML only (fast)
 LANG=en_US.UTF-8 ./build --pdf     # HTML + PDF (slow)
 LANG=en_US.UTF-8 ./build --deploy  # HTML + deploy to songs.josh.ch
+LANG=en_US.UTF-8 ./dev             # Watch, rebuild, deploy, and live-reload on every change
 ```
 
 > `LANG=en_US.UTF-8` is required because song files contain non-ASCII characters.

--- a/dev
+++ b/dev
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Watch source files, rebuild, deploy, and reload the browser on every change.
+# Watch source files, rebuild, and reload the browser on every change.
 # Dependencies: fswatch (brew install fswatch), browser-sync (npm install -g browser-sync)
 set -uo pipefail
 
 trap 'kill $(jobs -p) 2>/dev/null; exit' INT TERM EXIT
 
-echo "🎸 Initial build & deploy..."
-./build --deploy
+echo "🎸 Initial build..."
+./build
 
 echo "🌐 Starting browser-sync on http://localhost:3000 ..."
 browser-sync start --server --files "index.html" --no-notify &
@@ -14,6 +14,6 @@ browser-sync start --server --files "index.html" --no-notify &
 echo "👀 Watching content/, style/, build for changes..."
 fswatch -o content/ style/ build | while read -r; do
   echo ""
-  echo "🔄 Change detected — rebuilding & deploying..."
-  ./build --deploy || true
+  echo "🔄 Change detected — rebuilding..."
+  ./build || true
 done

--- a/dev
+++ b/dev
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Watch source files, rebuild, deploy, and reload the browser on every change.
+# Dependencies: fswatch (brew install fswatch), browser-sync (npm install -g browser-sync)
+set -uo pipefail
+
+trap 'kill $(jobs -p) 2>/dev/null; exit' INT TERM EXIT
+
+echo "🎸 Initial build & deploy..."
+./build --deploy
+
+echo "🌐 Starting browser-sync on http://localhost:3000 ..."
+browser-sync start --server --files "index.html" --no-notify &
+
+echo "👀 Watching content/, style/, build for changes..."
+fswatch -o content/ style/ build | while read -r; do
+  echo ""
+  echo "🔄 Change detected — rebuilding & deploying..."
+  ./build --deploy || true
+done


### PR DESCRIPTION
## Summary

- Adds a `./dev` script that watches `content/`, `style/`, and `build` with `fswatch`
- On each detected change: runs `./build` (regenerates `index.html` locally)
- Starts `browser-sync` on `http://localhost:3000` which auto-reloads when `index.html` changes
- Cleans up background processes on exit (Ctrl+C)
- Deploy manually with `./build --deploy` when ready to publish

## New dependencies

```bash
brew install fswatch
npm install -g browser-sync
```

## Test plan

- [x] Run `LANG=en_US.UTF-8 ./dev` — initial build should complete, browser should open at `localhost:3000`
- [x] Edit a song file in `content/songs/` — rebuild + browser reload should trigger automatically
- [ ] Edit a CSS file in `style/` — same
- [ ] Press Ctrl+C — browser-sync process should be cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)