### PR TITLE
Add bright/day theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <style>#bottom-left-controls {
   position: fixed;
   bottom: 2.5em;
-  left: 1em;
+  left: 2em;
   z-index: 100;
   display: flex;
   align-items: center;
@@ -93,8 +93,8 @@ section#TOC::-webkit-scrollbar-thumb {
 
 a#go-to-toc {
   position: fixed;
-  top: 2.5em;
-  left: 1em;
+  top: 2em;
+  left: 1.5em;
   z-index: 100;
   opacity: 0.75;
   text-decoration: none;
@@ -107,8 +107,8 @@ a#go-to-toc::before {
 
 a#toggle-theme {
   position: fixed;
-  top: 2.5em;
-  right: 1em;
+  top: 2em;
+  right: 1.5em;
   z-index: 100;
   opacity: 0.75;
   text-decoration: none;
@@ -116,7 +116,7 @@ a#toggle-theme {
 
 a#toggle-theme::before {
   font-size: 3em;
-  content: '🌞';
+  content: '🌙';
 }
 
 .reveal section strong {
@@ -245,6 +245,63 @@ a#toggle-theme::before {
   max-width: 100%;
   height: auto;
 }
+
+/* Bright theme overrides */
+
+body.theme-bright a#toggle-theme::before {
+  content: '🌞';
+}
+
+body.theme-bright .reveal section h1,
+body.theme-bright h2,
+body.theme-bright em {
+  color: unset !important;
+}
+
+body.theme-bright .reveal section code.x {
+  border: 1px solid #999;
+  color: #777;
+}
+
+body.theme-bright .reveal section pre code {
+  background-color: #ffe29a;
+}
+
+body.theme-bright {
+  --thumbBG: #8b6914;
+  --r-background-color: #fffad5;
+  --r-background: #fffad5;
+  --r-main-color: #222;
+  --r-heading-color: #333;
+  --r-link-color: #9a6f00;
+  --r-link-color-hover: #7a5500;
+}
+
+body.theme-bright .reveal section strong {
+  color: #38920b;
+}
+
+body.theme-bright .modal-box {
+  background: #f4f4f4;
+  border-color: #ccc;
+  color: #333;
+}
+
+body.theme-bright .modal-box input[type="password"] {
+  background: #fff;
+  border-color: #bbb;
+  color: #333;
+}
+
+body.theme-bright .modal-box button {
+  background: #ddd;
+  border-color: #bbb;
+  color: #333;
+}
+
+body.theme-bright .modal-box button:hover {
+  background: #ccc;
+}
 .reveal section h1 {
   font-size: 3em;
 }
@@ -316,14 +373,29 @@ a#toggle-theme::before {
   <button id="show-qr"></button>
   <button id="master-mode"></button>
 </div>
+<a href="#" id="toggle-theme"></a>
+<a href="#/1" id="go-to-toc"></a>
 <script>
   document.getElementById('toggle-chords-visibility').addEventListener('click', function() {
     document.body.classList.toggle('chords-hidden');
     this.blur();
   });
+
+  (function() {
+    function applyTheme(bright) {
+      document.body.classList.toggle('theme-bright', bright);
+    }
+
+    applyTheme(localStorage.getItem('theme') === 'bright');
+
+    document.getElementById('toggle-theme').addEventListener('click', function(e) {
+      e.preventDefault();
+      var bright = !document.body.classList.contains('theme-bright');
+      applyTheme(bright);
+      localStorage.setItem('theme', bright ? 'bright' : 'dark');
+    });
+  })();
 </script>
-<a href="#" id="toggle-theme" onclick="document.getElementById('theme').setAttribute('href','revealjs/style/theme/serif.css'); return false;"></a>
-<a href="#/1" id="go-to-toc"></a>
 
 <div id="master-modal" class="overlay-modal">
   <div class="modal-box">

--- a/style/body-controls.html
+++ b/style/body-controls.html
@@ -3,14 +3,29 @@
   <button id="show-qr"></button>
   <button id="master-mode"></button>
 </div>
+<a href="#" id="toggle-theme"></a>
+<a href="#/1" id="go-to-toc"></a>
 <script>
   document.getElementById('toggle-chords-visibility').addEventListener('click', function() {
     document.body.classList.toggle('chords-hidden');
     this.blur();
   });
+
+  (function() {
+    function applyTheme(bright) {
+      document.body.classList.toggle('theme-bright', bright);
+    }
+
+    applyTheme(localStorage.getItem('theme') === 'bright');
+
+    document.getElementById('toggle-theme').addEventListener('click', function(e) {
+      e.preventDefault();
+      var bright = !document.body.classList.contains('theme-bright');
+      applyTheme(bright);
+      localStorage.setItem('theme', bright ? 'bright' : 'dark');
+    });
+  })();
 </script>
-<a href="#" id="toggle-theme" onclick="document.getElementById('theme').setAttribute('href','revealjs/style/theme/serif.css'); return false;"></a>
-<a href="#/1" id="go-to-toc"></a>
 
 <div id="master-modal" class="overlay-modal">
   <div class="modal-box">

--- a/style/night.css
+++ b/style/night.css
@@ -1,7 +1,7 @@
 #bottom-left-controls {
   position: fixed;
   bottom: 2.5em;
-  left: 1em;
+  left: 2em;
   z-index: 100;
   display: flex;
   align-items: center;
@@ -81,8 +81,8 @@ section#TOC::-webkit-scrollbar-thumb {
 
 a#go-to-toc {
   position: fixed;
-  top: 2.5em;
-  left: 1em;
+  top: 2em;
+  left: 1.5em;
   z-index: 100;
   opacity: 0.75;
   text-decoration: none;
@@ -95,8 +95,8 @@ a#go-to-toc::before {
 
 a#toggle-theme {
   position: fixed;
-  top: 2.5em;
-  right: 1em;
+  top: 2em;
+  right: 1.5em;
   z-index: 100;
   opacity: 0.75;
   text-decoration: none;
@@ -104,7 +104,7 @@ a#toggle-theme {
 
 a#toggle-theme::before {
   font-size: 3em;
-  content: '🌞';
+  content: '🌙';
 }
 
 .reveal section strong {
@@ -232,4 +232,61 @@ a#toggle-theme::before {
 #qr-canvas img {
   max-width: 100%;
   height: auto;
+}
+
+/* Bright theme overrides */
+
+body.theme-bright a#toggle-theme::before {
+  content: '🌞';
+}
+
+body.theme-bright .reveal section h1,
+body.theme-bright h2,
+body.theme-bright em {
+  color: unset !important;
+}
+
+body.theme-bright .reveal section code.x {
+  border: 1px solid #999;
+  color: #777;
+}
+
+body.theme-bright .reveal section pre code {
+  background-color: #ffe29a;
+}
+
+body.theme-bright {
+  --thumbBG: #8b6914;
+  --r-background-color: #fffad5;
+  --r-background: #fffad5;
+  --r-main-color: #222;
+  --r-heading-color: #333;
+  --r-link-color: #9a6f00;
+  --r-link-color-hover: #7a5500;
+}
+
+body.theme-bright .reveal section strong {
+  color: #38920b;
+}
+
+body.theme-bright .modal-box {
+  background: #f4f4f4;
+  border-color: #ccc;
+  color: #333;
+}
+
+body.theme-bright .modal-box input[type="password"] {
+  background: #fff;
+  border-color: #bbb;
+  color: #333;
+}
+
+body.theme-bright .modal-box button {
+  background: #ddd;
+  border-color: #bbb;
+  color: #333;
+}
+
+body.theme-bright .modal-box button:hover {
+  background: #ccc;
 }


### PR DESCRIPTION
## Summary

- Replaces the broken one-way theme toggle (was switching to `serif.css` with no way back) with a proper toggle
- Uses a CSS-variable-only approach: `body.theme-bright` overrides the Reveal.js night theme's CSS custom properties (`--r-background-color`, `--r-main-color`, `--r-heading-color`, etc.) — no second stylesheet loaded
- Mellow yellow background (`#fffad5`), warm amber code blocks (`#ffe29a`), dark text
- Theme preference persisted in `localStorage`
- Toggle button shows 🌙 (dark mode) / 🌞 (bright mode)

## Test plan

- [ ] Click 🌙 → switches to bright yellow theme, button becomes 🌞
- [ ] Click 🌞 → switches back to dark theme, button becomes 🌙
- [ ] Reload page → theme preference is restored from localStorage
- [ ] Chord colours, strong/del, pre code blocks all look correct in both themes
- [ ] Master mode modal is readable in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)