### PR TITLE
Use Pandoc hard_line_breaks; strip trailing spaces from songs

### DIFF
--- a/all-songs.md
+++ b/all-songs.md
@@ -38,10 +38,11 @@ G |3 2 0 0 0 3|      Gm |3 x 0 3 3 3|      G7 |3 2 3 0 0 1|
 
 Variations:
 
-  |E A D G B e|
-  |-----------|
-F |0 0 3 2 1 1| Easier, no barre
-G |3 x 0 0 0 1| Easier, A string muted
+   |E A D G B e|
+   |-----------|
+F  |0 0 3 2 1 1| Easier, no barre
+G  |3 x 0 0 0 1| Easier, A string muted
+Gm |3 x 0 0 1 1| Easier, A string muted
 
 Feeling bored of major chords (A, D, E...)?
   => Try playing a seventh chord instead (A7, D7, E7...)!

--- a/all-songs.md
+++ b/all-songs.md
@@ -7,7 +7,7 @@ author: 😊 Josua & Monika ❤️
 
 ## Welcome
 
-This is a collection of my favourite guitar songs.  
+This is a collection of my favourite guitar songs.
 🎤😍🎸🔥 Find it on [songs.josh.ch](https://songs.josh.ch).
 
 - Use arrow keys or swipe gestures to navigate
@@ -52,174 +52,174 @@ Feeling bored of major chords (A, D, E...)?
 
 ## Chorus
 
-Immer wenn es `Em`{.e} regnet  
-muss ich an Dich `D`{.d} denken  
-Wie wir uns be`Am`{.a}gegneten  
-kann mich nicht ablenken  
-Nass bis auf die `Em`{.e} Haut  
-so stand sie `D`{.d} da  
+Immer wenn es `Em`{.e} regnet
+muss ich an Dich `D`{.d} denken
+Wie wir uns be`Am`{.a}gegneten
+kann mich nicht ablenken
+Nass bis auf die `Em`{.e} Haut
+so stand sie `D`{.d} da
 
-_(1st time:)_ Um uns war es `Am`{.a}  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es `Am`{.a}
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-`Am`{.a}A
 
 ## Verse 1
 
-`C`{.c} Pitsch, patsch nass, floh ich unter das  
-Vor`D`{.d}dach des Fachgeschäftes  
-Vom Himmel goss ein Bach. `Em`{.e}  
-Ich schätz' es war halb acht  
-Doch ich war hellwach  
+`C`{.c} Pitsch, patsch nass, floh ich unter das
+Vor`D`{.d}dach des Fachgeschäftes
+Vom Himmel goss ein Bach. `Em`{.e}
+Ich schätz' es war halb acht
+Doch ich war hellwach
 als mich Anna ansah, anlachte
 
 ---
 
-`C`{.c} Ich dachte: "Sprich sie an"  
-denn sie sprach mich an  
-Die `D`{.d} Kleidung ganz durchnässt  
-klebte an ihr fest  
-Die `Em`{.e} Tasche in der Hand  
-stand sie an der Wand  
-Die dunkeln Augen funkelten  
+`C`{.c} Ich dachte: "Sprich sie an"
+denn sie sprach mich an
+Die `D`{.d} Kleidung ganz durchnässt
+klebte an ihr fest
+Die `Em`{.e} Tasche in der Hand
+stand sie an der Wand
+Die dunkeln Augen funkelten
 wie 'ne Nacht in Asien
 
 ---
 
-`C`{.c} Strähnen im Gesicht  
-nehmen ihr die Sicht  
-Mein `D`{.d} Herz das klopft  
-die Nase tropft  
-Ich schäme mich  
-benehme mich `Em`{.e} dämlich  
-Bin nämlich eher schüchtern  
-"Mein Name ist Anna"  
+`C`{.c} Strähnen im Gesicht
+nehmen ihr die Sicht
+Mein `D`{.d} Herz das klopft
+die Nase tropft
+Ich schäme mich
+benehme mich `Em`{.e} dämlich
+Bin nämlich eher schüchtern
+"Mein Name ist Anna"
 sagte sie sehr nüchtern
 
 ---
 
-Ich fing an zu flüstern:  
-`C`{.c} "Ich bin Max aus dem  
-Schosse der Kolchose"  
-Doch `D`{.d} so 'ne Katastrophe  
-das ging mächtig in die Hose  
-Mach' mich `Em`{.e} lächerlich  
-Doch sie lächelte  
-Ehrlich wahr man! Sieh da  
+Ich fing an zu flüstern:
+`C`{.c} "Ich bin Max aus dem
+Schosse der Kolchose"
+Doch `D`{.d} so 'ne Katastrophe
+das ging mächtig in die Hose
+Mach' mich `Em`{.e} lächerlich
+Doch sie lächelte
+Ehrlich wahr man! Sieh da
 Anna war ein Hip Hop – Fan
 
 ## Chorus
 
-Immer wenn es `Em`{.e} regnet  
-muss ich an Dich `D`{.d} denken  
-Wie wir uns be`Am`{.a}gegneten  
-kann mich nicht ablenken  
-Nass bis auf die `Em`{.e} Haut  
-so stand sie `D`{.d} da  
+Immer wenn es `Em`{.e} regnet
+muss ich an Dich `D`{.d} denken
+Wie wir uns be`Am`{.a}gegneten
+kann mich nicht ablenken
+Nass bis auf die `Em`{.e} Haut
+so stand sie `D`{.d} da
 
-_(1st time:)_ Um uns war es `Am`{.a}  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es `Am`{.a}
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-`Am`{.a}A
 
 ## Verse 2
 
-`C`{.c} Plitsch, platsch fiel  
-ein Regen wie die Sintflut  
-Das `D`{.d} Vordach, die Insel  
-Wir waren wie Strandgut  
-Ich `Em`{.e} fand Mut  
-Bin selber überrascht  
-Über das Selbstverständnis  
+`C`{.c} Plitsch, platsch fiel
+ein Regen wie die Sintflut
+Das `D`{.d} Vordach, die Insel
+Wir waren wie Strandgut
+Ich `Em`{.e} fand Mut
+Bin selber überrascht
+Über das Selbstverständnis
 meines Geständnis'
 
 ---
 
-"Anna, ich `C`{.c} fänd' es schön  
-mit Dir auszugehn  
-Könnt' mich `D`{.d} dran gewöhn'  
-Dich öfters zu sehn"  
-`Em`{.e} Anna zog mich an sich  
-An sich mach' ich das nicht  
-Spüre ihre süssen Küsse  
+"Anna, ich `C`{.c} fänd' es schön
+mit Dir auszugehn
+Könnt' mich `D`{.d} dran gewöhn'
+Dich öfters zu sehn"
+`Em`{.e} Anna zog mich an sich
+An sich mach' ich das nicht
+Spüre ihre süssen Küsse
 wie sie mein Gesicht lieb`C`{.c}kost
 
 ---
 
-Was geschieht bloss?  
-Lass mich nicht los, Anna  
-Ich `D`{.d} lieb bloss noch Dich  
-andere sind lieblos  
-Du bist wie `Em`{.e} Vinyl für meinen DJ  
-die Dialektik für Hegel  
-Pinsel für Picasso  
+Was geschieht bloss?
+Lass mich nicht los, Anna
+Ich `D`{.d} lieb bloss noch Dich
+andere sind lieblos
+Du bist wie `Em`{.e} Vinyl für meinen DJ
+die Dialektik für Hegel
+Pinsel für Picasso
 für Philip der Schlagzeugschlegel
 
 ---
 
-`C`{.c} Anna, wie war das da bei Dada?  
+`C`{.c} Anna, wie war das da bei Dada?
 
-Du bist von `D`{.d} hinten  
-wie von vorne: A-N-N-A  
+Du bist von `D`{.d} hinten
+wie von vorne: A-N-N-A
 
-Du bist von `Em`{.e} hinten  
+Du bist von `Em`{.e} hinten
 wie von vorne: A-N-N-A _(x2)_
 
 ## Chorus
 
-Immer wenn es `Em`{.e} regnet  
-muss ich an Dich `D`{.d} denken  
-Wie wir uns be`Am`{.a}gegneten  
-kann mich nicht ablenken  
-Nass bis auf die `Em`{.e} Haut  
-so stand sie `D`{.d} da  
+Immer wenn es `Em`{.e} regnet
+muss ich an Dich `D`{.d} denken
+Wie wir uns be`Am`{.a}gegneten
+kann mich nicht ablenken
+Nass bis auf die `Em`{.e} Haut
+so stand sie `D`{.d} da
 
-_(1st time:)_ Um uns war es `Am`{.a}  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es `Am`{.a}
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-`Am`{.a}A
 
 ## Verse 3
 
-Sie `C`{.c} gab mir 'nen Abschiedskuss  
-denn dann kam der Bus  
-Sie sagte: `D`{.d} "Max, ich muss!"  
-die Türe schloss  
-Was ist jetzt Schluss?  
+Sie `C`{.c} gab mir 'nen Abschiedskuss
+denn dann kam der Bus
+Sie sagte: `D`{.d} "Max, ich muss!"
+die Türe schloss
+Was ist jetzt Schluss?
 
-Es goss. Ich `Em`{.e} ging zu Fuss  
-Bin konfus, fast gerannt  
-Anna nahm mein' Verstand  
+Es goss. Ich `Em`{.e} ging zu Fuss
+Bin konfus, fast gerannt
+Anna nahm mein' Verstand
 Ich fand an Anna allerhand
 
 ---
 
-Manchmal `C`{.c} lach' ich drüber  
-doch dann merk' ich wieder  
-wie 's mich trifft  
-`D`{.d} Komik ist Tragik in Spiegelschrift:  
-A-N-N-A  
-`Em`{.e} Von hinten, wie von vorne  
-Dein Name sei gesegnet  
+Manchmal `C`{.c} lach' ich drüber
+doch dann merk' ich wieder
+wie 's mich trifft
+`D`{.d} Komik ist Tragik in Spiegelschrift:
+A-N-N-A
+`Em`{.e} Von hinten, wie von vorne
+Dein Name sei gesegnet
 Ich denk' an Dich, immer wenn es...
 
 ## Chorus
 
-Immer wenn es `Em`{.e} regnet  
-muss ich an Dich `D`{.d} denken  
-Wie wir uns be`Am`{.a}gegneten  
-kann mich nicht ablenken  
-Nass bis auf die `Em`{.e} Haut  
-so stand sie `D`{.d} da  
+Immer wenn es `Em`{.e} regnet
+muss ich an Dich `D`{.d} denken
+Wie wir uns be`Am`{.a}gegneten
+kann mich nicht ablenken
+Nass bis auf die `Em`{.e} Haut
+so stand sie `D`{.d} da
 
-_(1st time:)_ Um uns war es `Am`{.a}  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es `Am`{.a}
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-`Am`{.a}A
 
 ## Outro
 
 `Em`{.e} `D`{.d} `Am`{.a} `Em`{.e} `D`{.d}
 
-(Lass mich nicht im Regen stehn  
-Ich will dich wiedersehn  
-A-N-N-A...  
+(Lass mich nicht im Regen stehn
+Ich will dich wiedersehn
+A-N-N-A...
 Yeah...)
 
 ## Resources
@@ -245,58 +245,58 @@ F#m    |2=4=4=2=2=2|
 
 ## Verse 1
 
-`D`{.d} Words are flowing out `Bm`{.b}  
-like endless `F#m`{.f} rain into a paper cup  
-They `Em7`{.e} slither wildly as they slip away  
+`D`{.d} Words are flowing out `Bm`{.b}
+like endless `F#m`{.f} rain into a paper cup
+They `Em7`{.e} slither wildly as they slip away
 a`A`{.a}cross the `A7`{.a} universe
 
-`D`{.d} Pools of sorrow, `Bm`{.b} waves of joy  
-are `F#m`{.f} drifting through my opened mind  
+`D`{.d} Pools of sorrow, `Bm`{.b} waves of joy
+are `F#m`{.f} drifting through my opened mind
 Poss`Em7`{.e}essing and car`Gm`{.g}essing me
 
 ## Chorus
 
 `D`{.d} Jai guru deva om `A7sus4`{.a}
 
-`A`{.a} Nothing's gonna change my world `A7`{.a}  
+`A`{.a} Nothing's gonna change my world `A7`{.a}
 `G`{.g} Nothing's gonna change my world `D`{.d} _(x2)_
 
 ## Verse 2
 
-`D`{.d} Images of `Bm`{.b} broken light which  
-`F#m`{.f} dance before me like a million `Em7`{.e} eyes  
-They call me on and on  
+`D`{.d} Images of `Bm`{.b} broken light which
+`F#m`{.f} dance before me like a million `Em7`{.e} eyes
+They call me on and on
 a`A`{.a}cross the `A7`{.a} universe
 
-`D`{.d} Thoughts meander `Bm`{.b} like a restless  
-`F#m`{.f} wind inside a letterbox  
-They `Em7`{.e} tumble blindly  
-as they make their `A`{.a} way  
+`D`{.d} Thoughts meander `Bm`{.b} like a restless
+`F#m`{.f} wind inside a letterbox
+They `Em7`{.e} tumble blindly
+as they make their `A`{.a} way
 across the `A7`{.a} universe
 
 ## Chorus
 
 `D`{.d} Jai guru deva om `A7sus4`{.a}
 
-`A`{.a} Nothing's gonna change my world `A7`{.a}  
+`A`{.a} Nothing's gonna change my world `A7`{.a}
 `G`{.g} Nothing's gonna change my world `D`{.d} _(x2)_
 
 ## Verse 3
 
-`D`{.d} Sounds of laughter, `Bm`{.b} shades of life  
-are `F#m`{.f} ringing through my opened ears  
-In`Em7`{.e}citing and in`Gm`{.g}viting me  
+`D`{.d} Sounds of laughter, `Bm`{.b} shades of life
+are `F#m`{.f} ringing through my opened ears
+In`Em7`{.e}citing and in`Gm`{.g}viting me
 
-`D`{.d} Limitless, un`Bm`{.b}dying love  
-which `F#m`{.f}shines around me like  
-a million `Em7`{.e} suns and calls me on and on   
+`D`{.d} Limitless, un`Bm`{.b}dying love
+which `F#m`{.f}shines around me like
+a million `Em7`{.e} suns and calls me on and on
 a`A`{.a}cross the universe `A7`{.a}
 
 ## Chorus
 
 `D`{.d} Jai guru deva om `A7sus4`{.a}
 
-`A`{.a} Nothing's gonna change my world `A7`{.a}  
+`A`{.a} Nothing's gonna change my world `A7`{.a}
 `G`{.g} Nothing's gonna change my world `D`{.d} _(x2)_
 
 ## Outro
@@ -314,45 +314,45 @@ a`A`{.a}cross the universe `A7`{.a}
 
 ## Intro
 
-`C`{.c} `G`{.g} `Em`{.e} `D`{.d}  
+`C`{.c} `G`{.g} `Em`{.e} `D`{.d}
 As long as you love me
 
 _(Repeat)_
 
 ## Verse 1
 
-Although `Em`{.e} loneliness has always been  
-a `C`{.c} friend of mine  
-I'm `D`{.d} leavin' my life in your hands `G`{.g} `D`{.d}  
-`Em`{.e} People say I'm crazy and that `C`{.c} I am blind  
+Although `Em`{.e} loneliness has always been
+a `C`{.c} friend of mine
+I'm `D`{.d} leavin' my life in your hands `G`{.g} `D`{.d}
+`Em`{.e} People say I'm crazy and that `C`{.c} I am blind
 `D`{.d} Risking it all in a glance `G`{.g} `D`{.d}
 
-And `Em`{.e} how you got me blind is still a `C`{.c} mystery  
-I `D`{.d} can't get you out of my head `G`{.g} `D`{.d}  
-`Em`{.e} Don't care what is written in your `C`{.c} history  
+And `Em`{.e} how you got me blind is still a `C`{.c} mystery
+I `D`{.d} can't get you out of my head `G`{.g} `D`{.d}
+`Em`{.e} Don't care what is written in your `C`{.c} history
 As `D`{.d} long as you're here with me `G`{.g}
 
 ## Chorus
 
-I don't care who `C`{.c} you are  
-Where `G`{.g} you're from  
-What `Em`{.e} you did  
+I don't care who `C`{.c} you are
+Where `G`{.g} you're from
+What `Em`{.e} you did
 As long `D`{.d} as you love me
 
 _(Repeat)_
 
 ## Verse 2
 
-`Em`{.e} Every little thing that you have `C`{.c} said and done  
-Feels `D`{.d} like it's deep within me `G`{.g} `D`{.d}  
-`Em`{.e} Doesn't really matter if you're `C`{.c} on the run  
+`Em`{.e} Every little thing that you have `C`{.c} said and done
+Feels `D`{.d} like it's deep within me `G`{.g} `D`{.d}
+`Em`{.e} Doesn't really matter if you're `C`{.c} on the run
 It `D`{.d} seems like we're `G`{.g} meant to be `D`{.d}
 
 ## Chorus
 
-I don't care who `C`{.c} you are  
-Where `G`{.g} you're from  
-What `Em`{.e} you did  
+I don't care who `C`{.c} you are
+Where `G`{.g} you're from
+What `Em`{.e} you did
 As long `D`{.d} as you love me (yeah)
 
 _(Repeat)_
@@ -361,19 +361,19 @@ _(Repeat)_
 
 ## Bridge
 
-`Em`{.e} I've tried to hide it so that `G`{.g} no one knows  
-But I `C`{.c} guess it shows  
-When you `C`{.c} look into my eyes `D`{.d}  
+`Em`{.e} I've tried to hide it so that `G`{.g} no one knows
+But I `C`{.c} guess it shows
+When you `C`{.c} look into my eyes `D`{.d}
 
-`Em`{.e} What you did and where you're `G`{.g} comin from  
-I don't `D`{.d} care, `C`{.c} as long `D`{.d} as you `C`{.c} love me, baby  
+`Em`{.e} What you did and where you're `G`{.g} comin from
+I don't `D`{.d} care, `C`{.c} as long `D`{.d} as you `C`{.c} love me, baby
 `G`{.g} `D`{.d} `Em`{.e} `C`{.c} `D`{.d}
 
 ## Chorus
 
-I don't care who `C`{.c} you are  
-Where `G`{.g} you're from  
-What `Em`{.e} you did  
+I don't care who `C`{.c} you are
+Where `G`{.g} you're from
+What `Em`{.e} you did
 As long `D`{.d} as you love me
 
 _(Repeat and fade)_
@@ -388,76 +388,76 @@ _(Repeat and fade)_
 ## Intro
 
 `Am`{.a} Oh baby, baby _(x2)_
- 
+
 ## Verse 1
 
-`Am`{.a} Oh baby, baby  
-How `E`{.e} was I supposed to know `C`{.c}  
+`Am`{.a} Oh baby, baby
+How `E`{.e} was I supposed to know `C`{.c}
 That `Dm`{.d} something wasn't `E`{.e} right here
 
-`Am`{.a} Oh baby baby  
-I `E`{.e} shouldn't have let you go `C`{.c}  
+`Am`{.a} Oh baby baby
+I `E`{.e} shouldn't have let you go `C`{.c}
 And `Dm`{.d} now you're out of `E`{.e} sight, yeah
- 
+
 ## Pre-Chorus
 
-`Am`{.a} Show me, how you want it `E`{.e} to be  
-Tell me `C`{.c} baby  
+`Am`{.a} Show me, how you want it `E`{.e} to be
+Tell me `C`{.c} baby
 'Cause I need to `Dm`{.d} know now what we've got `E`{.e}
 
 ## Chorus
 
-`Am`{.a} My loneliness is `E`{.e} killing me  
+`Am`{.a} My loneliness is `E`{.e} killing me
 `C`{.c} I must confess  I `Dm`{.d} still believe
 `E`{.e} (still believe)
 
-`Am`{.a} When I'm not with you I lose `E`{.e} my mind  
-`G`{.g} Give me a sign `C`{.c}  
+`Am`{.a} When I'm not with you I lose `E`{.e} my mind
+`G`{.g} Give me a sign `C`{.c}
 `Dm`{.d} Hit me baby `E`{.e} one more time
 
 ## Verse 2
 
-`Am`{.a} Oh baby, baby  
-The `E`{.e} reason I breathe is you `C`{.c}  
+`Am`{.a} Oh baby, baby
+The `E`{.e} reason I breathe is you `C`{.c}
 `Dm`{.d} Boy you've got me `E`{.e} flying
 
-`Am`{.a} Oh pretty baby  
-There's `E`{.e} nothing that I woul`C`{.c}dn't do  
+`Am`{.a} Oh pretty baby
+There's `E`{.e} nothing that I woul`C`{.c}dn't do
 It's `Dm`{.d} not the way I `E`{.e} planned it
 
 ## Pre-Chorus
 
-`Am`{.a} Show me, how you want it `E`{.e} to be  
-Tell me `C`{.c} baby  
+`Am`{.a} Show me, how you want it `E`{.e} to be
+Tell me `C`{.c} baby
 'Cause I need to `Dm`{.d} know now what we've got `E`{.e}
 
 ## Chorus
 
-`Am`{.a} My loneliness is `E`{.e} killing me (and I)  
+`Am`{.a} My loneliness is `E`{.e} killing me (and I)
 `C`{.c} I must confess  I `Dm`{.d} still believe
 `E`{.e} (still believe)
 
-`Am`{.a} When I'm not with you I lose `E`{.e} my mind  
-`G`{.g} Give me a sign `C`{.c}  
+`Am`{.a} When I'm not with you I lose `E`{.e} my mind
+`G`{.g} Give me a sign `C`{.c}
 `Dm`{.d} Hit me baby `E`{.e} one more time
 
 ## Interlude
 
 `Am`{.a} Oh baby, baby _(x2)_
- 
-`Am`{.a} Oh baby, baby  
-How `E`{.e} was I supposed to know `C`{.c}  
+
+`Am`{.a} Oh baby, baby
+How `E`{.e} was I supposed to know `C`{.c}
 `Dm`{.d} `E`{.e}
 
-`F`{.f} Oh pretty baby  
+`F`{.f} Oh pretty baby
 I `G`{.g} shouldn't have let you go `Dm`{.d} `F`{.f} `G`{.g}
 
 ## Bridge
 
-I must confess `Am`{.a} that my loneliness `E`{.e}  
-Is killing me now `C`{.c}  
-don't you `Dm`{.d} know I `E`{.e} still believe `F`{.f}  
-That you will be here `G`{.g}  
+I must confess `Am`{.a} that my loneliness `E`{.e}
+Is killing me now `C`{.c}
+don't you `Dm`{.d} know I `E`{.e} still believe `F`{.f}
+That you will be here `G`{.g}
 Now give me a sign `F`{.f}
 
 `Dm`{.d} Hit me baby
@@ -465,16 +465,16 @@ Now give me a sign `F`{.f}
 
 ## Chorus
 
-`Am`{.a} My loneliness is `E`{.e} killing me (and I)  
+`Am`{.a} My loneliness is `E`{.e} killing me (and I)
 `C`{.c} I must confess  I `Dm`{.d} still believe
 `E`{.e} (still believe)
 
-`Am`{.a} When I'm not with you I lose `E`{.e} my mind  
-`G`{.g} Give me a sign `C`{.c}  
+`Am`{.a} When I'm not with you I lose `E`{.e} my mind
+`G`{.g} Give me a sign `C`{.c}
 `Dm`{.d} Hit me baby `E`{.e} ~~one more time~~ **I must confess...**
 
-_(Repeat and add 2nd voice)_ **...that my loneliness  
-is killing me now, don't you know I still believe  
+_(Repeat and add 2nd voice)_ **...that my loneliness
+is killing me now, don't you know I still believe
 that you would be here and give me a sign**
 
 _(Together)_ Hit me baby one more time! `Am`{.a}
@@ -491,60 +491,60 @@ _(Together)_ Hit me baby one more time! `Am`{.a}
 
 Una mat`Am`{.a}tina mi son svegliato
 
-O bella, ciao! Bella, ciao!  
+O bella, ciao! Bella, ciao!
 Bella, `Am7`{.a} ciao, ciao, ciao!
 
-Una mat`Dm`{.d}tina mi son sveg`Am`{.a}liato  
+Una mat`Dm`{.d}tina mi son sveg`Am`{.a}liato
 e ho tro`E7`{.e}vato l'inva`Am`{.a}sor
 
 ## Verse 2
 
 O parti`Am`{.a}giano, portami via
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, `Am7`{.a} ciao, ciao, ciao!
 
-O parti`Dm`{.d}giano, portami Am via  
+O parti`Dm`{.d}giano, portami Am via
 ché mi `E7`{.e} sento di mo`Am`{.a}rir
 
 ## Verse 3
 
 E se io `Am`{.a} muoio da partigiano
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, `Am7`{.a} ciao, ciao, ciao!
 
-E se io `Dm`{.d} muoio da parti`Am`{.a}giano  
+E se io `Dm`{.d} muoio da parti`Am`{.a}giano
 tu mi `E7`{.e} devi seppel`Am`{.a}lir
 
 ## Verse 4
 
 E seppel`Am`{.a}lire lassù in montagna
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, `Am7`{.a} ciao, ciao, ciao!
 
-E seppel`Dm`{.d}lire lassù in mon`Am`{.a}tagna  
+E seppel`Dm`{.d}lire lassù in mon`Am`{.a}tagna
 Sotto `E7`{.e} l'ombra di un bel `Am`{.a} fior
 
 ## Verse 5
 
 Tutte le `Am`{.a} genti che passeranno
 
-O bella, ciao! Bella, ciao!  
+O bella, ciao! Bella, ciao!
 Bella, `Am7`{.a} ciao, ciao, ciao!
 
-Tutte le `Dm`{.d} genti che passe`Am`{.a}ranno  
+Tutte le `Dm`{.d} genti che passe`Am`{.a}ranno
 Ti di`E7`{.e}ranno "Che bel `Am`{.a} fior!"
 
 ## Verse 6
 
 "È questo il `Am`{.a} fiore del partigiano"
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, `Am7`{.a} ciao, ciao, ciao!
 
-"È questo il `Dm`{.d} fiore del parti`Am`{.a}giano  
+"È questo il `Dm`{.d} fiore del parti`Am`{.a}giano
 morto `E7`{.e} per la liber`Am`{.a}tà!" _(Repeat and fade)_
 
 ## Resources
@@ -563,14 +563,14 @@ _(Instrumental)_
 
 ## Verse 1
 
-`G`{.g} Here's a little song I wrote  
-You `Am`{.a} might want to sing it note for note   
+`G`{.g} Here's a little song I wrote
+You `Am`{.a} might want to sing it note for note
 Don't `C`{.c} worry, be `G`{.g} happy
 
-In `G`{.g} every life we have some trouble  
-`Am`{.a} When you worry you make it double  
-Don't `C`{.c} worry, be `G`{.g} happy 
- 
+In `G`{.g} every life we have some trouble
+`Am`{.a} When you worry you make it double
+Don't `C`{.c} worry, be `G`{.g} happy
+
 ## Chorus
 
 (Whistle)
@@ -579,12 +579,12 @@ Don't `C`{.c} worry, be `G`{.g} happy
 
 ## Verse 2
 
-`G`{.g} Ain't got no place to lay your head  
-`Am`{.a} Somebody came and took your bed  
-Don't `C`{.c} worry, be `G`{.g} happy  
+`G`{.g} Ain't got no place to lay your head
+`Am`{.a} Somebody came and took your bed
+Don't `C`{.c} worry, be `G`{.g} happy
 
-The `G`{.g} landlord say your rent is late  
-`Am`{.a} He may have to litigate  
+The `G`{.g} landlord say your rent is late
+`Am`{.a} He may have to litigate
 Don't `C`{.c} worry, be `G`{.g} happy
 
 ## Chorus
@@ -595,12 +595,12 @@ Don't `C`{.c} worry, be `G`{.g} happy
 
 ## Verse 3
 
-`G`{.g} Ain't got no cash, ain't got no style  
-`Am`{.a} Ain't got no girl to make you smile  
+`G`{.g} Ain't got no cash, ain't got no style
+`Am`{.a} Ain't got no girl to make you smile
 **But** don't `C`{.c} worry, be `G`{.g} happy
 
-Cause `G`{.g} when you worry, your face will frown  
-`Am`{.a} And that will bring everybody down  
+Cause `G`{.g} when you worry, your face will frown
+`Am`{.a} And that will bring everybody down
 **So** don't `C`{.c} worry, be `G`{.g} happy
 
 ## Chorus
@@ -611,14 +611,14 @@ Cause `G`{.g} when you worry, your face will frown
 
 ## Verse 4
 
-`G`{.g} There is this little song I wrote  
-`Am`{.a} I hope you learn it note for note  
+`G`{.g} There is this little song I wrote
+`Am`{.a} I hope you learn it note for note
 Don't `C`{.c} worry, be `G`{.g} happy
 
 (Listen to what I say!)
 
-`G`{.g} In your life expect some trouble 
-`Am`{.a} But when you worry, you make it double 
+`G`{.g} In your life expect some trouble
+`Am`{.a} But when you worry, you make it double
 Don't `C`{.c} worry, be `G`{.g} happy
 
 ## Chorus
@@ -639,41 +639,41 @@ _(Repeat and fade)_
 
 ## Verse 1
 
-`Am`{.a} Kenned ihr das Gschichtli scho  
-`E`{.e} Vu dem arme `Am`{.a} Eskimo  
-`Em`{.e} Wo in `Am`{.a} Grönland `Em`{.e} einisch `Am`{.a} so  
+`Am`{.a} Kenned ihr das Gschichtli scho
+`E`{.e} Vu dem arme `Am`{.a} Eskimo
+`Em`{.e} Wo in `Am`{.a} Grönland `Em`{.e} einisch `Am`{.a} so
 `Em`{.e} Truurig `Am`{.a} isch ums `Em`{.e} Lebe `Am`{.a} cho.
- 
+
 ## Verse 2
 
-`Am`{.a} Er hät dank em Radio  
-`E`{.e} Freud ar Musig `Am`{.a} übercho  
-`Em`{.e} Und het `Am`{.a} denkt das `Em`{.e} chan i `Am`{.a} o  
+`Am`{.a} Er hät dank em Radio
+`E`{.e} Freud ar Musig `Am`{.a} übercho
+`Em`{.e} Und het `Am`{.a} denkt das `Em`{.e} chan i `Am`{.a} o
 `Em`{.e} So isch `Am`{.a} er is `Em`{.e} unglück `Am`{.a} cho.
- 
+
 ## Verse 3
 
-`Am`{.a} Nämlich hät er sich für zwo  
-`E`{.e} Fläsche Leber`Am`{.a}tran es no  
-`Em`{.e} Guet er`Am`{.a}haltnigs `Em`{.e} Cemba`Am`{.a}lo  
+`Am`{.a} Nämlich hät er sich für zwo
+`E`{.e} Fläsche Leber`Am`{.a}tran es no
+`Em`{.e} Guet er`Am`{.a}haltnigs `Em`{.e} Cemba`Am`{.a}lo
 `Em`{.e} Kouft und `Am`{.a} hets i d `Em`{.e} Höhli `Am`{.a} gno.
- 
+
 ## Verse 4
 
-`Am`{.a} Doch won er fortissimo  
-`E`{.e} Gspilt het uf sim `Am`{.a} Cembalo  
-`Em`{.e} Isch en `Am`{.a} Iisbär `Em`{.e} ine `Em`{.e} cho und  
+`Am`{.a} Doch won er fortissimo
+`E`{.e} Gspilt het uf sim `Am`{.a} Cembalo
+`Em`{.e} Isch en `Am`{.a} Iisbär `Em`{.e} ine `Em`{.e} cho und
 `Am`{.a} Hetne `Am`{.a} zwüsche d'`Em`{.e}Chralle `Am`{.a} gno.
- 
+
 ## Verse 5
 
-`Am`{.a} D'Kunst isch geng es Risiko  
-`E`{.e} So isch er ums `Am`{.a} Lebe cho  
-`Em`{.e} Und ihr `Am`{.a} gsänd d'Mo`Em`{.e}ral der`Am`{.a}vo  
-`Em`{.e} Choufed `Am`{.a} nie es `Em`{.e} Cemba`Am`{.a}lo  
-`Em`{.e} Süscht geits `Am`{.a} euch grad `Em`{.e} äbe`Am`{.a}so  
-`Em`{.e} Wie dem `Am`{.a} arme `Em`{.e} Eski`Am`{.a}mo  
-`Em`{.e} Wo in `Am`{.a} Grönland `Em`{.e} einisch `Am`{.a} so  
+`Am`{.a} D'Kunst isch geng es Risiko
+`E`{.e} So isch er ums `Am`{.a} Lebe cho
+`Em`{.e} Und ihr `Am`{.a} gsänd d'Mo`Em`{.e}ral der`Am`{.a}vo
+`Em`{.e} Choufed `Am`{.a} nie es `Em`{.e} Cemba`Am`{.a}lo
+`Em`{.e} Süscht geits `Am`{.a} euch grad `Em`{.e} äbe`Am`{.a}so
+`Em`{.e} Wie dem `Am`{.a} arme `Em`{.e} Eski`Am`{.a}mo
+`Em`{.e} Wo in `Am`{.a} Grönland `Em`{.e} einisch `Am`{.a} so
 `Em`{.e} Truurig `Am`{.a} isch ums `Em`{.e} Lebe `Am`{.a} cho.
 
 ## Resources
@@ -684,43 +684,43 @@ _(Repeat and fade)_
 
 ## Verse 1
 
-Dr `Am`{.a} Sidi Abdel Assar vo El Hama  
-Het `Am`{.a} mal am Morge früe no im Pijama  
-Ir `Dm`{.d} Strass vor dr Moschee  
-Zwöi `Am`{.a} schöni Ouge gseh  
+Dr `Am`{.a} Sidi Abdel Assar vo El Hama
+Het `Am`{.a} mal am Morge früe no im Pijama
+Ir `Dm`{.d} Strass vor dr Moschee
+Zwöi `Am`{.a} schöni Ouge gseh
 Das `E`{.e} isch dr Afang worde vo sim `Am`{.a} Drama
 
 ## Verse 2
 
-S isch `Am`{.a} Tochter gsy vom Mohamed Mustafa  
-Dr `Am`{.a} Abdel Assar het nümm choenne schlafa  
-Bis `Dm`{.d} er bim Mohamed  
-Um `Am`{.a} d'Hand aghalte hed  
+S isch `Am`{.a} Tochter gsy vom Mohamed Mustafa
+Dr `Am`{.a} Abdel Assar het nümm choenne schlafa
+Bis `Dm`{.d} er bim Mohamed
+Um `Am`{.a} d'Hand aghalte hed
 Und `E`{.e} gseit: I biete hundertfüfzig `Am`{.a} Schaf a
 
 ## Verse 3
 
-Dr `Am`{.a} Mohamed het gantwortet: Bi Allah  
-Es `Am`{.a} froeit mi, dass mi Tochter dir het gfalla  
-Doch `Dm`{.d} wärt isch si, mi Seel  
-Zwöi`Am`{.a}hundertzwänzg Kamel  
+Dr `Am`{.a} Mohamed het gantwortet: Bi Allah
+Es `Am`{.a} froeit mi, dass mi Tochter dir het gfalla
+Doch `Dm`{.d} wärt isch si, mi Seel
+Zwöi`Am`{.a}hundertzwänzg Kamel
 Und `E`{.e} drunder chan i dir sen uf ke `Am`{.a} Fall la
 
 ## Verse 4
 
-Da `Am`{.a} het dr Abdel Assar gseit: O Sidi  
-Uf `Am`{.a} sone türe Handel gang i nid y  
-Isch `Dm`{.d} furt, het gly druf scho  
-E `Am`{.a} billigeri gno  
+Da `Am`{.a} het dr Abdel Assar gseit: O Sidi
+Uf `Am`{.a} sone türe Handel gang i nid y
+Isch `Dm`{.d} furt, het gly druf scho
+E `Am`{.a} billigeri gno
 Wo `E`{.e} nid so schoen isch gsy, defuer e `Am`{.a} gschydi
 
 ## Verse 5
 
 _(Langsam)_
 
-Doch `Am`{.a} wenn es Nacht wird ueber der Sahara  
-Luegt `Am`{.a} er dr Mond am Himmel hell und klar a  
-Und `Dm`{.d} truret hie und da  
+Doch `Am`{.a} wenn es Nacht wird ueber der Sahara
+Luegt `Am`{.a} er dr Mond am Himmel hell und klar a
+Und `Dm`{.d} truret hie und da
 De `Am`{.a} schoene Ouge na -
 
 _(Schnell)_
@@ -736,87 +736,87 @@ Und `E`{.e} daenkt: Haett i doch frueecher afa `Am`{.a} spara!
 
 ## Verse 1
 
-Si `C`{.c} hei der Willhelm Täll ufgfüehrt  
-Im `G7`{.g} Löie z'Nottis`C`{.c}wil  
-Da `C`{.c} bruchts viel Volk, gwüss z'halbe Dorf  
+Si `C`{.c} hei der Willhelm Täll ufgfüehrt
+Im `G7`{.g} Löie z'Nottis`C`{.c}wil
+Da `C`{.c} bruchts viel Volk, gwüss z'halbe Dorf
 Hett `G7`{.g} mitgmacht i däm `C`{.c} Schpil
 
-Die `E7`{.e} andri Hälfti `Am`{.a} isch im Saal gsy  
-`G7`{.g} Bim'ne grosse `C`{.c} Bier  
-Als `F`{.f} publikum, het `C`{.c} zuegluegt  
+Die `E7`{.e} andri Hälfti `Am`{.a} isch im Saal gsy
+`G7`{.g} Bim'ne grosse `C`{.c} Bier
+Als `F`{.f} publikum, het `C`{.c} zuegluegt
 Und isch `G7`{.g} gschpannt gsy, was pas`C`{.c}sier
 
 ## Verse 2
 
-Am `C`{.c} Aafang isch es schön gsy  
-Do het `G7`{.g} als Schtouffache`C`{.c}rin  
-D'Frou `C`{.c} Pfarrer mit dem Schnyder gret  
+Am `C`{.c} Aafang isch es schön gsy
+Do het `G7`{.g} als Schtouffache`C`{.c}rin
+D'Frou `C`{.c} Pfarrer mit dem Schnyder gret
 I `G7`{.g} Wort vo tiefem `C`{.c} Sinn
 
-Und `E7`{.e} alls isch grüert gsy, `Am`{.a} sy het dasmal  
-`G7`{.g} Nid gseit, s'Chleid sig z'`C`{.c}tüür  
-Und `F`{.f} är het guet uf`C`{.c}passt  
+Und `E7`{.e} alls isch grüert gsy, `Am`{.a} sy het dasmal
+`G7`{.g} Nid gseit, s'Chleid sig z'`C`{.c}tüür
+Und `F`{.f} är het guet uf`C`{.c}passt
 Das är der `G7`{.g} Fade nid ver`C`{.c}lüür
 
 ## Verse 3
 
-Uf `C`{.c} z'Mal, churz vor em Öpfelschuss  
-Dr `G7`{.g} Lehrer chunnt als `C`{.c} Täll  
-Sy `C`{.c} Sohn, dä fragt'ne dis und äis  
+Uf `C`{.c} z'Mal, churz vor em Öpfelschuss
+Dr `G7`{.g} Lehrer chunnt als `C`{.c} Täll
+Sy `C`{.c} Sohn, dä fragt'ne dis und äis
 Do `G7`{.g} rüeft dert eine `C`{.c} schnäll
 
-Wo `E7`{.e} und'rem Huet als `Am`{.a} Wach isch gschtande  
-`G7`{.g} So dass' jede `C`{.c} ghört  
-Wi`F`{.f}so fragt dä so `C`{.c} dumm  
+Wo `E7`{.e} und'rem Huet als `Am`{.a} Wach isch gschtande
+`G7`{.g} So dass' jede `C`{.c} ghört
+Wi`F`{.f}so fragt dä so `C`{.c} dumm
 Het dä ir `G7`{.g} Schuel de nüt rächts `C`{.c} glehrt
 
 ## Verse 4
 
-E `C`{.c} Fründ vom Täll, e Maa us Altdorf  
-`G7`{.g} Zwickt em eis uf ds `C`{.c} Muul  
-Und `C`{.c} dise wo dr Huet bewacht  
+E `C`{.c} Fründ vom Täll, e Maa us Altdorf
+`G7`{.g} Zwickt em eis uf ds `C`{.c} Muul
+Und `C`{.c} dise wo dr Huet bewacht
 Git `G7`{.g} ume, gar nid `C`{.c} fuul
 
-Und `E7`{.e} stosst ihm mit syr `Am`{.a} Helebarde  
-`G7`{.g} Eine z'Mitzt i `C`{.c} Buuch  
-Da `F`{.f} chunnt scho s'Volk vo `C`{.c} Uri z'springe  
+Und `E7`{.e} stosst ihm mit syr `Am`{.a} Helebarde
+`G7`{.g} Eine z'Mitzt i `C`{.c} Buuch
+Da `F`{.f} chunnt scho s'Volk vo `C`{.c} Uri z'springe
 `G7`{.g} Donner jetzt geits `C`{.c} ruuch
 
 ## Verse 5
 
-Die `C`{.c} einte, die vo Öschterrich  
-`G7`{.g} Die näh für d'Wach Par`C`{.c}tei  
-Die `C`{.c} andre, die vo Altdorf  
+Die `C`{.c} einte, die vo Öschterrich
+`G7`{.g} Die näh für d'Wach Par`C`{.c}tei
+Die `C`{.c} andre, die vo Altdorf
 Füre `G7`{.g} Täll - ei Schläge`C`{.c}rei
 
-Mit `E7`{.e} Helebarde, `Am`{.a} Kartonschwärt  
-`G7`{.g} Kulisse schlöh sy `C`{.c} dry  
-`F`{.f} Der Täll liit und'rem `C`{.c} Gessler scho  
+Mit `E7`{.e} Helebarde, `Am`{.a} Kartonschwärt
+`G7`{.g} Kulisse schlöh sy `C`{.c} dry
+`F`{.f} Der Täll liit und'rem `C`{.c} Gessler scho
 Da `G7`{.g} mischt der Saal sech `C`{.c} y
 
 ## Verse 6
 
-Jitz `C`{.c} chöme Gläser z'flüge  
-Jede `G7`{.g} stillt sy gheimi Wuet `C`{.c}  
-Es `C`{.c} chrose Tisch, u bänk und's Bier  
+Jitz `C`{.c} chöme Gläser z'flüge
+Jede `G7`{.g} stillt sy gheimi Wuet `C`{.c}
+Es `C`{.c} chrose Tisch, u bänk und's Bier
 Ver`G7`{.g}mischt sech mit em `C`{.c} Bluet
 
-Dr `E7`{.e} Wirt rouft sech sys `Am`{.a} Haar  
-D'Frou schinet `G7`{.g} brochni glider y `C`{.c}  
-Zwo `F`{.f} Stund lang het das duu`C`{.c}ret  
+Dr `E7`{.e} Wirt rouft sech sys `Am`{.a} Haar
+D'Frou schinet `G7`{.g} brochni glider y `C`{.c}
+Zwo `F`{.f} Stund lang het das duu`C`{.c}ret
 Do isch `G7`{.g} Öschtrich gschlage `C`{.c} gsy
 
 ## Verse 7
 
-Si `C`{.c} hei der Willhelm Täll ufgfüehrt  
-Im `G7`{.g} Löie z'Nottis`C`{.c}wil  
-Und `C`{.c} gwüss no niene i  
+Si `C`{.c} hei der Willhelm Täll ufgfüehrt
+Im `G7`{.g} Löie z'Nottis`C`{.c}wil
+Und `C`{.c} gwüss no niene i
 natura`G7`{.g}listischerem `C`{.c} Stil
 
-D'Ver`E7`{.e}sicherig het `Am`{.a} zahlt  
+D'Ver`E7`{.e}sicherig het `Am`{.a} zahlt
 Hingäge `G7`{.g} eis weiss ig sit`C`{.c}här:
 
-Sy `F`{.f} würde d'Freiheit `C`{.c} gwinne  
+Sy `F`{.f} würde d'Freiheit `C`{.c} gwinne
 Wenn sy `G7`{.g} dä Wäg z'gwinne `C`{.c} wär _(x2)_
 
 ## Resources
@@ -828,59 +828,59 @@ Wenn sy `G7`{.g} dä Wäg z'gwinne `C`{.c} wär _(x2)_
 
 ## Verse 1
 
-`Am`{.a} Einisch ir Nacht won i spät no bi `E7`{.e} gloffe  
-`Am`{.a} D'Bundesterrasse z'düruf gäge `G`{.g} hei  
-`Am`{.a} Han i e bärtige Kärli a`E7`{.e}troffe  
-`Am`{.a} Und gseh grad, dass dä sech dert, jemers nei `G7`{.g}  
-`C`{.c} Dass dä sech dert zu nachtschlafener `E`{.e} Zyt  
+`Am`{.a} Einisch ir Nacht won i spät no bi `E7`{.e} gloffe
+`Am`{.a} D'Bundesterrasse z'düruf gäge `G`{.g} hei
+`Am`{.a} Han i e bärtige Kärli a`E7`{.e}troffe
+`Am`{.a} Und gseh grad, dass dä sech dert, jemers nei `G7`{.g}
+`C`{.c} Dass dä sech dert zu nachtschlafener `E`{.e} Zyt
 `Am`{.a} Am Bundeshus z'schaffe macht `E7`{.e} mit Dyna`Am`{.a}mit
 
 ## Verse 2
 
-`Am`{.a} I bi erchlüpft und ha zuen ihm gseit: `E7`{.e} Säget  
-`Am`{.a} Exgüse, aber es gseht fasch so `G`{.g} us  
-`Am`{.a} Wi dass dir da jitze würklech er`E7`{.e}wäget  
-`Am`{.a} Das grad id Luft welle z'spränge das `G7`{.g} Hus  
-`C`{.c} Ja, seit dä Ma mir mit Füür, es mues `E`{.e} sy  
+`Am`{.a} I bi erchlüpft und ha zuen ihm gseit: `E7`{.e} Säget
+`Am`{.a} Exgüse, aber es gseht fasch so `G`{.g} us
+`Am`{.a} Wi dass dir da jitze würklech er`E7`{.e}wäget
+`Am`{.a} Das grad id Luft welle z'spränge das `G7`{.g} Hus
+`C`{.c} Ja, seit dä Ma mir mit Füür, es mues `E`{.e} sy
 `Am`{.a} Furt mit däm Ghütt, i bi `E7`{.e} für d'Anar`Am`{.a}chie
 
 ## Verse 3
 
-`Am`{.a} Was isch als Bürger mir da übrig`E7`{.e}blybe  
-`Am`{.a} Als ihm's probiere uszrede, i `G`{.g} ha  
-`Am`{.a} Ihm afa d'Vorteile alli be`E7`{.e}schrybe  
-`Am`{.a} Vo üsem Staat, eso guet dass i `G7`{.g} cha  
-`C`{.c} Ds Rütli und d'Freiheit und d'Demokra`E`{.e}tie  
+`Am`{.a} Was isch als Bürger mir da übrig`E7`{.e}blybe
+`Am`{.a} Als ihm's probiere uszrede, i `G`{.g} ha
+`Am`{.a} Ihm afa d'Vorteile alli be`E7`{.e}schrybe
+`Am`{.a} Vo üsem Staat, eso guet dass i `G7`{.g} cha
+`C`{.c} Ds Rütli und d'Freiheit und d'Demokra`E`{.e}tie
 `Am`{.a} Han i beschworen, är `E7`{.e} sölls doch la `Am`{.a} sy
 
 ## Verse 4
 
-`Am`{.a} D'Angscht het mys Rednertalänt la ent`E7`{.e}falte  
-`Am`{.a} Chüel het dr Wind um üs gwäit i dr `G`{.g} Nacht  
-`Am`{.a} Während ig ihm en Ouguschtred ha `E7`{.e} ghalte  
-`Am`{.a} Dass es es Ross patriotisch hätt `G7`{.g} gmacht  
-`C`{.c} Z'letscht hei dä Ma mini Wort so be`E`{.e}rückt  
+`Am`{.a} D'Angscht het mys Rednertalänt la ent`E7`{.e}falte
+`Am`{.a} Chüel het dr Wind um üs gwäit i dr `G`{.g} Nacht
+`Am`{.a} Während ig ihm en Ouguschtred ha `E7`{.e} ghalte
+`Am`{.a} Dass es es Ross patriotisch hätt `G7`{.g} gmacht
+`C`{.c} Z'letscht hei dä Ma mini Wort so be`E`{.e}rückt
 `Am`{.a} Dass är e Träne im `E7`{.e} Oug het ver`Am`{.a}drückt
 
 ## Verse 5
 
-`Am`{.a} So han i schliesslech dr Staat chönne `E7`{.e} rette  
-`Am`{.a} Är isch mit sym Dynamit wieder `G`{.g} hei  
-`Am`{.a} Und i ha mir a däm Abe im `E7`{.e} Bett en  
-`Am`{.a} Orde zuegsproche für my ganz al`G7`{.g}lei  
-`C`{.c} Glunge isch nume, dass zmonderischt^_*_^ `E`{.e} scho  
+`Am`{.a} So han i schliesslech dr Staat chönne `E7`{.e} rette
+`Am`{.a} Är isch mit sym Dynamit wieder `G`{.g} hei
+`Am`{.a} Und i ha mir a däm Abe im `E7`{.e} Bett en
+`Am`{.a} Orde zuegsproche für my ganz al`G7`{.g}lei
+`C`{.c} Glunge isch nume, dass zmonderischt^_*_^ `E`{.e} scho
 `Am`{.a} Über mi Red mir du `E7`{.e} Zwyfel si `Am`{.a} cho
 
-_^*^ Zmonderischt: Ein Tag, welcher nach einem schon  
+_^*^ Zmonderischt: Ein Tag, welcher nach einem schon
 vergangenen Tag gekommen ist. ([Quelle](https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi))_
 
 ## Verse 6
 
-`Am`{.a} Han ig ihm d'Schwyz o mit Rächt eso `E7`{.e} prise?  
-`Am`{.a} Fragen i mi no bis hüt hinde`G`{.g}dry  
-`Am`{.a} Und no uf eis het dä Ma mi hi`E7`{.e}gwise  
-`Am`{.a} Louf i am Bundeshus sider ver`G7`{.g}by  
-`C`{.c} Mues i gäng dänke, s'steit numen uf `E`{.e} Zyt  
+`Am`{.a} Han ig ihm d'Schwyz o mit Rächt eso `E7`{.e} prise?
+`Am`{.a} Fragen i mi no bis hüt hinde`G`{.g}dry
+`Am`{.a} Und no uf eis het dä Ma mi hi`E7`{.e}gwise
+`Am`{.a} Louf i am Bundeshus sider ver`G7`{.g}by
+`C`{.c} Mues i gäng dänke, s'steit numen uf `E`{.e} Zyt
 `Am`{.a} S'länge fürs z'Spränge paar `E7`{.e} Seck Dyna`Am`{.a}mit!
 
 `E7`{.e} `Am`{.a}
@@ -912,43 +912,43 @@ E |3--3-3-3-3-------|
 ## Intro
 
 _(Riff x4)_
- 
+
 ## Verse 1 - Father
 
-It's not `G`{.g} time to make a change `D/F#`{.d}  
-just relax `C`{.c} and take it ea`Am7`{.a}sy  
-You're still `G`{.g} young, that's your fault `Em`{.e}  
+It's not `G`{.g} time to make a change `D/F#`{.d}
+just relax `C`{.c} and take it ea`Am7`{.a}sy
+You're still `G`{.g} young, that's your fault `Em`{.e}
 there's so `Am`{.a} much you have to know `D`{.d}
 
-Find a `G`{.g} girl, settle down `D/F#`{.d}  
-if you want `C`{.c}, you can mar`Am7`{.a}ry  
-Look at me `G`{.g}, I am old `Em`{.e}  
+Find a `G`{.g} girl, settle down `D/F#`{.d}
+if you want `C`{.c}, you can mar`Am7`{.a}ry
+Look at me `G`{.g}, I am old `Em`{.e}
 but I'm `Am`{.a} happy `D`{.d}
 
 ---
 
-I was `G`{.g} once like you are now `D`{.d}  
-and I know `C`{.c} that it's not ea`Am7`{.a}sy  
-To be `G`{.g} calm when you've found `Em`{.e}  
+I was `G`{.g} once like you are now `D`{.d}
+and I know `C`{.c} that it's not ea`Am7`{.a}sy
+To be `G`{.g} calm when you've found `Em`{.e}
 something `Am`{.a} going on `D`{.d}
 
-But take your time `G`{.g}, think a lot `D`{.d}  
-why think of ev`C`{.c}erything you've got `Am7`{.a}  
-For you will `G`{.g} still be here tomorrow `Em`{.e}  
+But take your time `G`{.g}, think a lot `D`{.d}
+why think of ev`C`{.c}erything you've got `Am7`{.a}
+For you will `G`{.g} still be here tomorrow `Em`{.e}
 but your `Am`{.a} dreams `D`{.d} may `G`{.g} not
 
 _(Riff x2)_
 
 ## Verse 2 - Son
 
-How can I `G`{.g} try to explain? `Bm`{.b}  
-'cause when I `C`{.c} do he turns a`Am7`{.a}way again  
-It's al`G`{.g}ways been the same `Em`{.e}  
+How can I `G`{.g} try to explain? `Bm`{.b}
+'cause when I `C`{.c} do he turns a`Am7`{.a}way again
+It's al`G`{.g}ways been the same `Em`{.e}
 same old `Am`{.a} story `D`{.d}
 
-From the mo`G`{.g}ment I could talk `Bm`{.b}  
-I was or`C`{.c}dered to lis`Am7`{.a}ten  
-Now there's a way `G`{.g}, and I know `Em`{.e} that I `D`{.d} have to go away `G`{.g}  
+From the mo`G`{.g}ment I could talk `Bm`{.b}
+I was or`C`{.c}dered to lis`Am7`{.a}ten
+Now there's a way `G`{.g}, and I know `Em`{.e} that I `D`{.d} have to go away `G`{.g}
 I `D`{.d} know I `C`{.c} have to `G`{.g} go
 
 _(Riff x2)_
@@ -957,34 +957,34 @@ _(Riff x2)_
 
 _(Instrumental)_
 
-`G`{.g} `D`{.d} `C`{.c} `Am7`{.a}  
-`G`{.g} `Em`{.e} `Am`{.a} `C`{.c} `D`{.d}  
-`G`{.g} `D`{.d} `C`{.c} `Am7`{.a}  
-`G`{.g} `Em`{.e} `D`{.d} `G`{.g}  
+`G`{.g} `D`{.d} `C`{.c} `Am7`{.a}
+`G`{.g} `Em`{.e} `Am`{.a} `C`{.c} `D`{.d}
+`G`{.g} `D`{.d} `C`{.c} `Am7`{.a}
+`G`{.g} `Em`{.e} `D`{.d} `G`{.g}
 `D`{.d} `C`{.c} `G`{.g}
 
 ## Verse 3 - Father
 
-It's not `G`{.g} time to make a change `D/F#`{.d}  
-just ~~relax~~ **sit down** `C`{.c} and take it ~~easy~~ **slow`Am7`{.a}ly**  
-You're still `G`{.g} young, that's your fault `Em`{.e}  
+It's not `G`{.g} time to make a change `D/F#`{.d}
+just ~~relax~~ **sit down** `C`{.c} and take it ~~easy~~ **slow`Am7`{.a}ly**
+You're still `G`{.g} young, that's your fault `Em`{.e}
 there's so `Am`{.a} much you have to ~~know~~ **go through** `D`{.d}
 
-Find a `G`{.g} girl, settle down `D/F#`{.d}  
-if you want `C`{.c}, you can mar`Am7`{.a}ry  
-Look at me `G`{.g}, I am old `Em`{.e}  
+Find a `G`{.g} girl, settle down `D/F#`{.d}
+if you want `C`{.c}, you can mar`Am7`{.a}ry
+Look at me `G`{.g}, I am old `Em`{.e}
 but I'm `Am`{.a} happy `D`{.d}
 
 ## Verse 4 - Son
 
-All the times `G`{.g} that I've cried `Bm`{.b}  
-keeping all `C`{.c} the things I knew `Am7`{.a} inside  
+All the times `G`{.g} that I've cried `Bm`{.b}
+keeping all `C`{.c} the things I knew `Am7`{.a} inside
 It's hard `G`{.g}
 but it's har`Em`{.e}der to ig`Am`{.a}nore it `D`{.d}
 
-If they were right `G`{.g}, I'd agree `Bm`{.b} _(I love this one!)_  
+If they were right `G`{.g}, I'd agree `Bm`{.b} _(I love this one!)_
 but it's them `C`{.c} they know, not me `Am7`{.a}
-Now there's a way `G`{.g}, and I know `Em`{.e}  
+Now there's a way `G`{.g}, and I know `Em`{.e}
 that I `D`{.d} have to go away `G`{.g}
 
 I `D`{.d} know I `C`{.c} have to `G`{.g} go
@@ -1003,52 +1003,52 @@ I `D`{.d} know I `C`{.c} have to `G`{.g} go
 
 ## Verse 1
 
-Come on and hold my `Dm`{.d} hand  
-`Am`{.a} I wanna contact the living `A`{.a} `A7`{.a}  
-Not sure I under`Gm`{.g}stand  
+Come on and hold my `Dm`{.d} hand
+`Am`{.a} I wanna contact the living `A`{.a} `A7`{.a}
+Not sure I under`Gm`{.g}stand
 `Dm`{.d} This role I've been gi`A`{.a}ven `A7`{.a}
 
 ---
 
-I sit and talk to `Dm`{.d} God  
-`Am`{.a} and he just laughs at my `A`{.a} plans `A7`{.a}  
-My head speaks a `Gm`{.g} language  
+I sit and talk to `Dm`{.d} God
+`Am`{.a} and he just laughs at my `A`{.a} plans `A7`{.a}
+My head speaks a `Gm`{.g} language
 `Dm`{.d} I don't understand `A`{.a} `A7`{.a}
 
 ## Chorus 1
 
-I just wanna `Bb`{.b} feel real lo`F`{.f}ve  
-Fill the home that I li`C`{.c}ve in  
-Cause I got too much li`Bb`{.b}fe  
-Running through my ve`F`{.f}igns  
+I just wanna `Bb`{.b} feel real lo`F`{.f}ve
+Fill the home that I li`C`{.c}ve in
+Cause I got too much li`Bb`{.b}fe
+Running through my ve`F`{.f}igns
 Going to waste `C`{.c}
 
 ## Verse 2
 
-I dont wanna `Dm`{.d} die  
-`Am`{.a} But I ain't keen on living ei`A`{.a}ther `A7`{.a}  
-Before I fall in `Gm`{.g} love  
+I dont wanna `Dm`{.d} die
+`Am`{.a} But I ain't keen on living ei`A`{.a}ther `A7`{.a}
+Before I fall in `Gm`{.g} love
 `Dm`{.d} I'm preparing to le`A`{.a}ave her `A7`{.a}
 
 ---
 
-I scare myself to de`Dm`{.d}ath  
-`Am`{.a} That's why I keep on run`A`{.a}ning `A7`{.a}  
-Before I've ar`Gm`{.g}rived  
+I scare myself to de`Dm`{.d}ath
+`Am`{.a} That's why I keep on run`A`{.a}ning `A7`{.a}
+Before I've ar`Gm`{.g}rived
 `Dm`{.d} I can see myself co`A`{.a}ming `A7`{.a}
 
 ## Chorus 2
 
-I just wanna `Bb`{.b} feel real lo`F`{.f}ve  
-Fill the home that I li`C`{.c}ve in  
-Cause I got too much li`Bb`{.b}fe  
-Running through my ve`F`{.f}igns  
+I just wanna `Bb`{.b} feel real lo`F`{.f}ve
+Fill the home that I li`C`{.c}ve in
+Cause I got too much li`Bb`{.b}fe
+Running through my ve`F`{.f}igns
 Going to waste `C`{.c}
 
 ---
 
-I just wanna feel `Bb`{.b} real lo`F`{.f}ve  
-And the life ever af`C`{.c}ter  
+I just wanna feel `Bb`{.b} real lo`F`{.f}ve
+And the life ever af`C`{.c}ter
 I cannot get enough
 
 `Dm`{.d} `Am`{.a} `Dm`{.d} `Am`{.a} _(3x)_
@@ -1057,27 +1057,27 @@ I cannot get enough
 
 ## Chorus 2
 
-I just wanna `Bb`{.b} feel real lo`F`{.f}ve  
-Fill the home that I li`C`{.c}ve in  
-Cause I got too much li`Bb`{.b}fe  
-Running through my ve`F`{.f}igns  
+I just wanna `Bb`{.b} feel real lo`F`{.f}ve
+Fill the home that I li`C`{.c}ve in
+Cause I got too much li`Bb`{.b}fe
+Running through my ve`F`{.f}igns
 Going to `C`{.c} waste
 
 ---
 
-I just wanna feel `Bb`{.b} real lo`F`{.f}ve  
-And the life ever af`C`{.c}ter  
-There's a hole in my soul `Bb`{.b}  
-you can see it in my face `F`{.f}  
+I just wanna feel `Bb`{.b} real lo`F`{.f}ve
+And the life ever af`C`{.c}ter
+There's a hole in my soul `Bb`{.b}
+you can see it in my face `F`{.f}
 it's a real big place `C`{.c}
 
 ## Bridge
 
 `Dm`{.d} `Am`{.a} _(2x)_
 
-Come on and hold my `Dm`{.d} hand  
-`Am`{.a} I wanna contact the li`Dm`{.d}ving  
-`Am`{.a} Not sure I under`Dm`{.d}stand  
+Come on and hold my `Dm`{.d} hand
+`Am`{.a} I wanna contact the li`Dm`{.d}ving
+`Am`{.a} Not sure I under`Dm`{.d}stand
 `Am`{.a} This role I've been gi`Dm`{.d}ven
 
 `Am`{.a} Not sure I under`Dm`{.d}stand _(4x)_
@@ -1096,37 +1096,37 @@ Come on and hold my `Dm`{.d} hand
 
 ## Verse 1
 
-Where the road is `Am`{.a} dark  
-And the seed is `C`{.c} sowed  
-Where the gun is `Am`{.a} cocked  
+Where the road is `Am`{.a} dark
+And the seed is `C`{.c} sowed
+Where the gun is `Am`{.a} cocked
 As the bullet's `C`{.c} cold
 
-Where the miles are `Am`{.a} marked  
-`G`{.g} In the blood and the `Am`{.a} gold  
+Where the miles are `Am`{.a} marked
+`G`{.g} In the blood and the `Am`{.a} gold
 `G`{.g} I'll `F`{.f} meet you further `G`{.g} on up the road `Am`{.a}
 
 ## Verse 2
 
-Got on my dead man `Am`{.a} suit  
-And my smilin' skull `C`{.c} ring  
-My lucky graveyard `Am`{.a} boots  
+Got on my dead man `Am`{.a} suit
+And my smilin' skull `C`{.c} ring
+My lucky graveyard `Am`{.a} boots
 And a song to `C`{.c} sing
 
-I got a song to `Am`{.a} sing  
-`G`{.g} That keeps me out of the `Am`{.a} cold  
-`G`{.g} And I'll `F`{.f} meet you  
+I got a song to `Am`{.a} sing
+`G`{.g} That keeps me out of the `Am`{.a} cold
+`G`{.g} And I'll `F`{.f} meet you
 further `G`{.g} on up the `Am`{.a} road
 
 ## Chorus 1
 
-Further on up the `C`{.c} road  
-Further on up the `Am`{.a} road  
-Where the way is `C`{.c} dark  
+Further on up the `C`{.c} road
+Further on up the `Am`{.a} road
+Where the way is `C`{.c} dark
 And the night is `E7`{.e} cold
 
-One sunny `Am`{.a} mornin'  
-`G`{.g} We'll rise I `Am`{.a} know  
-`G`{.g} And I'll `F`{.f} meet you  
+One sunny `Am`{.a} mornin'
+`G`{.g} We'll rise I `Am`{.a} know
+`G`{.g} And I'll `F`{.f} meet you
 further `G`{.g} on up the `Am`{.a} road
 
 ## Instrumental
@@ -1135,32 +1135,32 @@ further `G`{.g} on up the `Am`{.a} road
 
 ## Verse 3
 
-Now I've been out in the `Am`{.a} desert  
-Just don't my `C`{.c} time  
-Searchin' through the `Am`{.a} dust  
+Now I've been out in the `Am`{.a} desert
+Just don't my `C`{.c} time
+Searchin' through the `Am`{.a} dust
 Lookin' for a `C`{.c} sign
 
-If there's a light up a`G`{.g}head  
-Well, brother I don't `Am`{.a} know  
-`G`{.g} But I've `F`{.f} got  
+If there's a light up a`G`{.g}head
+Well, brother I don't `Am`{.a} know
+`G`{.g} But I've `F`{.f} got
 this fever `G`{.g} burnin' in my soul `Am`{.a}
 
 ## Chours 2
 
-Further on up the `C`{.c} road  
-Further on up the `Am`{.a} road  
-Further on up the `C`{.c} road  
+Further on up the `C`{.c} road
+Further on up the `Am`{.a} road
+Further on up the `C`{.c} road
 Further on up the `E7`{.e} road
 
 ---
 
-One sunny `Am`{.a} mornin' `G`{.g}  
+One sunny `Am`{.a} mornin' `G`{.g}
 We'll rise I `Am`{.a} know `G`{.g}
 
-And I'll `F`{.f} meet you  
+And I'll `F`{.f} meet you
 further `G`{.g} on up the `Am`{.a} road `G`{.g} _(2x)_
 
-And I'll `F`{.f} meet you  
+And I'll `F`{.f} meet you
 further `G`{.g} on up the `Am`{.a} road
 
 ## Resources
@@ -1177,79 +1177,79 @@ further `G`{.g} on up the `Am`{.a} road
 
 ## Verse 1
 
-Es war schon `Am`{.a} dunkel, als ich durch  
-Vorstadtstrassen `F`{.f} heim`G`{.g}wärts `C`{.c} ging  
-Da war ein Wirtshaus, aus dem das  
+Es war schon `Am`{.a} dunkel, als ich durch
+Vorstadtstrassen `F`{.f} heim`G`{.g}wärts `C`{.c} ging
+Da war ein Wirtshaus, aus dem das
 Licht noch auf den Geh`F`{.f}steig `G`{.g} schien
 
-Ich hatte `Am`{.a} Zeit und mir war `E`{.e} kalt  
+Ich hatte `Am`{.a} Zeit und mir war `E`{.e} kalt
 drum trat ich `Am`{.a} ein
 
 ---
 
-Da sassen `Am`{.a} Männer mit braunen Augen  
-und mit `F`{.f} schwar`G`{.g}zem `C`{.c} Haar  
-Und aus der Jukebox erklang Musik  
+Da sassen `Am`{.a} Männer mit braunen Augen
+und mit `F`{.f} schwar`G`{.g}zem `C`{.c} Haar
+Und aus der Jukebox erklang Musik
 die fremd und süd`F`{.f}lich `G`{.g} war
 
-Als man mich sah `Am`{.a}, stand einer auf `E`{.e}  
+Als man mich sah `Am`{.a}, stand einer auf `E`{.e}
 und lud mich ein `Am`{.a}
 
 ## Chorus 1
 
-`F`{.f} Griechischer Wein ist so wie das Blut der Erde  
-`C`{.c} Komm schenk dir ein  
-Und wenn ich dann traurig werde, `G`{.g} liegt es daran  
+`F`{.f} Griechischer Wein ist so wie das Blut der Erde
+`C`{.c} Komm schenk dir ein
+Und wenn ich dann traurig werde, `G`{.g} liegt es daran
 Dass ich immer träume von da`C`{.c}heim
 
 Du musst ver`E`{.e}zeihen!
 
 ---
 
-`F`{.f} Griechischer Wein und die alt vertrauten Lieder  
-`C`{.c} Schenk nochmal ein  
-Denn ich fühl die Sehnsucht wieder  
+`F`{.f} Griechischer Wein und die alt vertrauten Lieder
+`C`{.c} Schenk nochmal ein
+Denn ich fühl die Sehnsucht wieder
 
-`G`{.g} In dieser Stadt  
-werd' ich immer nur ein Fremder `Am`{.a} sein  
+`G`{.g} In dieser Stadt
+werd' ich immer nur ein Fremder `Am`{.a} sein
 `E`{.e} und al`Am`{.a}lein
 
 ## Verse 2
 
-Und dann er`Am`{.a}zählten sie mir von grünen Hügeln  
-`F`{.f} Meer `G`{.g} und `C`{.c} Wind  
+Und dann er`Am`{.a}zählten sie mir von grünen Hügeln
+`F`{.f} Meer `G`{.g} und `C`{.c} Wind
 Von alten Häusern und jungen Frauen, die allei`F`{.f}ne `G`{.g} sind
 
-Und von dem `Am`{.a} Kind  
+Und von dem `Am`{.a} Kind
 das seinen `E`{.e} Vater noch nie `Am`{.a} sah
 
 ---
 
-Sie sagten `Am`{.a} sich immer wieder  
-irgendwann geht `F`{.f} es `G`{.g} zu`C`{.c}rück  
-Und das Ersparte genügt zu Hause  
+Sie sagten `Am`{.a} sich immer wieder
+irgendwann geht `F`{.f} es `G`{.g} zu`C`{.c}rück
+Und das Ersparte genügt zu Hause
 für ein klei`F`{.f}nes `G`{.g} Glück
 
-Und bald denkt `Am`{.a} keiner mehr da`E`{.e}ran  
+Und bald denkt `Am`{.a} keiner mehr da`E`{.e}ran
 wie es hier `Am`{.a} war
 
 ## Chorus 2
 
-`F`{.f} Griechischer Wein ist so wie das Blut der Erde  
-`C`{.c} Komm schenk dir ein  
-Und wenn ich dann traurig werde, `G`{.g} liegt es daran  
+`F`{.f} Griechischer Wein ist so wie das Blut der Erde
+`C`{.c} Komm schenk dir ein
+Und wenn ich dann traurig werde, `G`{.g} liegt es daran
 Dass ich immer träume von da`C`{.c}heim
 
 Du musst ver`E`{.e}zeihen!
 
 ---
 
-`F`{.f} Griechischer Wein und die alt vertrauten Lieder  
-`C`{.c} Schenk nochmal ein  
+`F`{.f} Griechischer Wein und die alt vertrauten Lieder
+`C`{.c} Schenk nochmal ein
 Denn ich fühl die Sehnsucht wieder
 
-`G`{.g} in dieser Stadt  
-Werd' ich immer nur ein Fremder `Am`{.a} sein  
+`G`{.g} in dieser Stadt
+Werd' ich immer nur ein Fremder `Am`{.a} sein
 `E`{.e} und al`Am`{.a}lein
 
 ## Outro
@@ -1270,107 +1270,107 @@ Werd' ich immer nur ein Fremder `Am`{.a} sein
 
 ## Verse 1
 
-Now I've `C`{.c} heard there was a `Am`{.a} secret chord  
-That `C`{.c} David played, and it `Am`{.a} pleased the Lord  
+Now I've `C`{.c} heard there was a `Am`{.a} secret chord
+That `C`{.c} David played, and it `Am`{.a} pleased the Lord
 But `F`{.f} you don't really `G`{.g} care for music, `C`{.c} do you? `G`{.g}
 
-It `C`{.c} goes like this, the `F`{.f} fourth, the `G`{.g} fifth  
-The `Am`{.a} minor fall, the `F`{.f} major lift  
+It `C`{.c} goes like this, the `F`{.f} fourth, the `G`{.g} fifth
+The `Am`{.a} minor fall, the `F`{.f} major lift
 The `G`{.g} baffled king `E`{.e} composing, halle`Am`{.a}lujah
 
 ## Chorus
 
-Halle`F`{.f}lujah, halle`Am`{.a}lujah  
+Halle`F`{.f}lujah, halle`Am`{.a}lujah
 Galle`F`{.f}lujah, halle`C`{.c}lu`G`{.g}jah `C`{.c} `G`{.g}
 
 ## Verse 2
 
-Your `C`{.c} faith was strong, but you `Am`{.a} needed proof  
-You `C`{.c} saw her bathing `Am`{.a} on the roof  
+Your `C`{.c} faith was strong, but you `Am`{.a} needed proof
+You `C`{.c} saw her bathing `Am`{.a} on the roof
 Her `F`{.f} beauty and the `G`{.g} moonlight over`C`{.c}threw ya `G`{.g}
 
-She `C`{.c} tied you to a `F`{.f} kitchen `G`{.g} chair  
-She `Am`{.a} broke your throne, and she `F`{.f} cut your hair  
+She `C`{.c} tied you to a `F`{.f} kitchen `G`{.g} chair
+She `Am`{.a} broke your throne, and she `F`{.f} cut your hair
 And `G`{.g} from your lips she `E`{.e} drew the `Am`{.a} hallelujah
 
 ## Chorus
 
-Halle`F`{.f}lujah, halle`Am`{.a}lujah  
+Halle`F`{.f}lujah, halle`Am`{.a}lujah
 Galle`F`{.f}lujah, halle`C`{.c}lu`G`{.g}jah `C`{.c} `G`{.g}
 
 ## Verse 3
 
 `C`{.c} Baby, I've been `Am`{.a} here before
-I `C`{.c} know this room, I've `Am`{.a} walked this floor  
+I `C`{.c} know this room, I've `Am`{.a} walked this floor
 I `F`{.f}used to live a`G`{.g}lone before I `C`{.c} knew you `G`{.g}
 
-I've `C`{.c} seen your flag on the `F`{.f} marble `G`{.g} arch  
-`Am`{.a}Love is not a `F`{.f} victory march  
+I've `C`{.c} seen your flag on the `F`{.f} marble `G`{.g} arch
+`Am`{.a}Love is not a `F`{.f} victory march
 It's a `G`{.g} cold, and it's a `E`{.e} broken halle`Am`{.a}lujah
 
 ## Chorus
 
-Halle`F`{.f}lujah, halle`Am`{.a}lujah  
+Halle`F`{.f}lujah, halle`Am`{.a}lujah
 Galle`F`{.f}lujah, halle`C`{.c}lu`G`{.g}jah `C`{.c} `G`{.g}
 
 ## Verse 4
 
-There `C`{.c} was a time when you `Am`{.a} let me know  
-What's `C`{.c} really going `Am`{.a} on below  
+There `C`{.c} was a time when you `Am`{.a} let me know
+What's `C`{.c} really going `Am`{.a} on below
 But `F`{.f} now you never `G`{.g} show it to me, `C`{.c} do you? `G`{.g}
 
-And re`C`{.c}member when I `F`{.f} moved in `G`{.g} you  
-The `Am`{.a} holy dove was `F`{.f} moving too  
+And re`C`{.c}member when I `F`{.f} moved in `G`{.g} you
+The `Am`{.a} holy dove was `F`{.f} moving too
 And `G`{.g} every breath we `E`{.e} drew was halle`Am`{.a}lujah
 
 ## Chorus
 
-Halle`F`{.f}lujah, halle`Am`{.a}lujah  
+Halle`F`{.f}lujah, halle`Am`{.a}lujah
 Galle`F`{.f}lujah, halle`C`{.c}lu`G`{.g}jah `C`{.c} `G`{.g}
 
 ## Verse 5
 
-`C`{.c} Maybe there's a `Am`{.a} God above  
-And `C`{.c} all I ever `Am`{.a} learned from love  
+`C`{.c} Maybe there's a `Am`{.a} God above
+And `C`{.c} all I ever `Am`{.a} learned from love
 Was `F`{.f} how to shoot at `G`{.g} someone who out`C`{.c}drew you `G`{.g}
 
-It's `C`{.c} not a cry you can `F`{.f} hear at `G`{.g} night  
-It's `Am`{.a} not somebody who has `F`{.f} seen the light  
+It's `C`{.c} not a cry you can `F`{.f} hear at `G`{.g} night
+It's `Am`{.a} not somebody who has `F`{.f} seen the light
 It's a `G`{.g} cold, and it's a `E`{.e} broken halle`Am`{.a}lujah
 
 ## Chorus
 
-Halle`F`{.f}lujah, halle`Am`{.a}lujah  
+Halle`F`{.f}lujah, halle`Am`{.a}lujah
 Galle`F`{.f}lujah, halle`C`{.c}lu`G`{.g}jah `C`{.c} `G`{.g}
 
 ## Verse 6
 
-You `C`{.c} say I took the `Am`{.a} name in vain  
-Though `C`{.c} I don't even `Am`{.a} know the name  
+You `C`{.c} say I took the `Am`{.a} name in vain
+Though `C`{.c} I don't even `Am`{.a} know the name
 But `F`{.f} if I did, well `G`{.g} really, what's it `C`{.c} to ya? `G`{.g}
 
-There's a `C`{.c} blaze of light in `F`{.f} every `G`{.g} word  
-It `Am`{.a} doesn't matter `F`{.f} which you heard  
+There's a `C`{.c} blaze of light in `F`{.f} every `G`{.g} word
+It `Am`{.a} doesn't matter `F`{.f} which you heard
 The `G`{.g} holy or the `E`{.e} broken halle`Am`{.a}lujah
 
 ## Chorus
 
-Halle`F`{.f}lujah, halle`Am`{.a}lujah  
+Halle`F`{.f}lujah, halle`Am`{.a}lujah
 Galle`F`{.f}lujah, halle`C`{.c}lu`G`{.g}jah `C`{.c} `G`{.g}
 
 ## Verse 7
 
-I `C`{.c} did my best, it `Am`{.a} wasn't much  
-I `C`{.c} couldn't feel, so I `Am`{.a} tried to touch  
+I `C`{.c} did my best, it `Am`{.a} wasn't much
+I `C`{.c} couldn't feel, so I `Am`{.a} tried to touch
 I've `F`{.f} told the truth, I `G`{.g} didn't come to `C`{.c} fool ya `G`{.g}
 
-And `C`{.c} even though it `F`{.f} all went `G`{.g} wrong  
-I'll `Am`{.a} stand before the `F`{.f} Lord of Song  
+And `C`{.c} even though it `F`{.f} all went `G`{.g} wrong
+I'll `Am`{.a} stand before the `F`{.f} Lord of Song
 With `G`{.g} nothing on my `E`{.e} tongue but halle`Am`{.a}lujah
 
 ## Chorus
 
-Halle`F`{.f}lujah, halle`Am`{.a}lujah  
+Halle`F`{.f}lujah, halle`Am`{.a}lujah
 Galle`F`{.f}lujah, halle`C`{.c}lu`G`{.g}jah `C`{.c} `G`{.g}
 
 _(4x)_
@@ -1386,30 +1386,30 @@ _(4x)_
 
 ## Verse 1
 
-S'git `Am`{.a} Lüt, die würden alletwäge `Dm`{.d} nie  
-Es `G`{.g} Lied vorsinge, so win ig jitz `C`{.c} hie  
-Eis singe `C`{.c} - um kei Pris, nei bhüetis `E7`{.e} nei!  
+S'git `Am`{.a} Lüt, die würden alletwäge `Dm`{.d} nie
+Es `G`{.g} Lied vorsinge, so win ig jitz `C`{.c} hie
+Eis singe `C`{.c} - um kei Pris, nei bhüetis `E7`{.e} nei!
 Will si `Am`{.a} hemmige `E7`{.e} hei
 
 ## Verse 2
 
 Si `Am`{.a} wäre vilicht gärn im Grund gno `Dm`{.d} fräch
-Und `G`{.g} dänke, das syg ires grosse `C`{.c} Päch  
-Und `C`{.c} s'laschtet uf ne wine schwäre `E7`{.e} Stei  
+Und `G`{.g} dänke, das syg ires grosse `C`{.c} Päch
+Und `C`{.c} s'laschtet uf ne wine schwäre `E7`{.e} Stei
 dass si `Am`{.a} Hemmige `E7`{.e} hei
 
 ## Verse 3
 
-I `Am`{.a} weis, das macht eim heiss, verschlat eim `Dm`{.d} d'Stimm  
-Doch `G`{.g} dünkt eim mängisch o s'syg nüt so `C`{.c} schlimm  
-S'isch `C`{.c} glych es Glück, o we mirs gar nid `E7`{.e} wei  
+I `Am`{.a} weis, das macht eim heiss, verschlat eim `Dm`{.d} d'Stimm
+Doch `G`{.g} dünkt eim mängisch o s'syg nüt so `C`{.c} schlimm
+S'isch `C`{.c} glych es Glück, o we mirs gar nid `E7`{.e} wei
 Dass mir `Am`{.a} Hemmige `E7`{.e} hei
 
 ## Verse 4
 
-Was `Am`{.a} unterscheidet d'Mönsche vom schim`Dm`{.d}pans?  
-S'isch `G`{.g} nid die glatti Huut, dr fählend `C`{.c} Schwanz^_(*)_^  
-Nid `C`{.c} dass mir schlächter d'Böim ufchöme, `E7`{.e} nei  
+Was `Am`{.a} unterscheidet d'Mönsche vom schim`Dm`{.d}pans?
+S'isch `G`{.g} nid die glatti Huut, dr fählend `C`{.c} Schwanz^_(*)_^
+Nid `C`{.c} dass mir schlächter d'Böim ufchöme, `E7`{.e} nei
 Dass mir `Am`{.a} Hemmige `E7`{.e} hei
 
 _(^*^ Fun Fact: Schimpanse haben gar keinen Schwanz!)_
@@ -1418,16 +1418,16 @@ _(^*^ Fun Fact: Schimpanse haben gar keinen Schwanz!)_
 
 _(Interlude in Stephan Eicher's Version)_
 
-Me `Am`{.a} stell sech d'Manne vor, wenns anders `Dm`{.d} wär  
-Und `G`{.g} s'chäm es hübsches Meiteli der`C`{.c}här  
-Jitz `C`{.c} luege mir doch höchstens chly uf d'`E7`{.e}Bei  
+Me `Am`{.a} stell sech d'Manne vor, wenns anders `Dm`{.d} wär
+Und `G`{.g} s'chäm es hübsches Meiteli der`C`{.c}här
+Jitz `C`{.c} luege mir doch höchstens chly uf d'`E7`{.e}Bei
 Will mir `Am`{.a} Hemmige `E7`{.e} hei
 
 ## Verse 6
 
 Und `Am`{.a} we me gseht, was hütt dr Mönschheit `Dm`{.d} droht
-So `G`{.g} gseht me würklech schwarz, nid nume `C`{.c} rot  
-Und `C`{.c} was me no cha hoffen isch a`E7`{.e}lei  
+So `G`{.g} gseht me würklech schwarz, nid nume `C`{.c} rot
+Und `C`{.c} was me no cha hoffen isch a`E7`{.e}lei
 Dass si `Am`{.a} Hemm`E7`{.e}ige `Am`{.a} hei
 
 ## Resources
@@ -1454,74 +1454,74 @@ Just keep pinky on 3rd fret of e string
 
 ## Intro
 
-`Am`{.a}  
-`C`{.c} `D`{.d} `Am`{.a}  
+`Am`{.a}
 `C`{.c} `D`{.d} `Am`{.a}
- 
+`C`{.c} `D`{.d} `Am`{.a}
+
 ## Verse 1
 
-I `C`{.c} hurt myself `D`{.d} today `Am`{.a}  
-to see `C`{.c} if I `D`{.d} still feel `Am`{.a}  
-I `C`{.c} focus `D`{.d} on the pain `Am`{.a}  
+I `C`{.c} hurt myself `D`{.d} today `Am`{.a}
+to see `C`{.c} if I `D`{.d} still feel `Am`{.a}
+I `C`{.c} focus `D`{.d} on the pain `Am`{.a}
 the `C`{.c} only thing `D`{.d} that's real `Am`{.a}
 
-The `C`{.c} needle `D`{.d} tears a hole `Am`{.a}  
-the `C`{.c} old fa`D`{.d}miliar sting `Am`{.a}  
-Try to `C`{.c} kill it `D`{.d} all away `Am`{.a}  
+The `C`{.c} needle `D`{.d} tears a hole `Am`{.a}
+the `C`{.c} old fa`D`{.d}miliar sting `Am`{.a}
+Try to `C`{.c} kill it `D`{.d} all away `Am`{.a}
 but I re`C`{.c}member `D`{.d} everything `G`{.g}
- 
+
 ## Chorus 1
 
-`Am7`{.a} What have I become? `Fadd9`{.f}  
-`C/E`{.c} My sweetest friend `G`{.g}  
-`Am7`{.a} Everyone I know `Fadd9`{.f}  
+`Am7`{.a} What have I become? `Fadd9`{.f}
+`C/E`{.c} My sweetest friend `G`{.g}
+`Am7`{.a} Everyone I know `Fadd9`{.f}
 goes away `C/E`{.c} in the end `G`{.g}
 
-And `Am7`{.a} you could have it all `Fadd9`{.f}  
-`C/E`{.c} My empire of dirt `G`{.g}  
-`Am7`{.a} I will let you down `Fadd9`{.f}  
+And `Am7`{.a} you could have it all `Fadd9`{.f}
+`C/E`{.c} My empire of dirt `G`{.g}
+`Am7`{.a} I will let you down `Fadd9`{.f}
 `G`{.g} I will make you hurt `Am`{.a}
 
 ## Transition
 
-`C`{.c} `D`{.d} `Am`{.a}  
+`C`{.c} `D`{.d} `Am`{.a}
 `C`{.c} `D`{.d} `Am`{.a}
 
 ## Verse 2
 
-I `C`{.c} wear this crown `D`{.d} of thorns `Am`{.a}  
-u`C`{.c}pon my li`D`{.d}ar's chair `Am`{.a}  
-`C`{.c} Full of bro`D`{.d}ken thoughts `Am`{.a}  
+I `C`{.c} wear this crown `D`{.d} of thorns `Am`{.a}
+u`C`{.c}pon my li`D`{.d}ar's chair `Am`{.a}
+`C`{.c} Full of bro`D`{.d}ken thoughts `Am`{.a}
 `C`{.c}I cannot `D`{.d} re`Am`{.a}pair
 
-Be`C`{.c}neath the stains `D`{.d} of `Am`{.a} time  
-the `C`{.c} feelings `D`{.d} disappear `Am`{.a}  
-`C`{.c} You are some`D`{.d}one else `Am`{.a}  
+Be`C`{.c}neath the stains `D`{.d} of `Am`{.a} time
+the `C`{.c} feelings `D`{.d} disappear `Am`{.a}
+`C`{.c} You are some`D`{.d}one else `Am`{.a}
 `C`{.c} I am still `D`{.d} right `G`{.g} here
 
 _(x2)_
 
 ## Chorus 2
 
-`Am7`{.a} What have I become? `Fadd9`{.f}  
-`C/E`{.c} My sweetest friend `G`{.g}  
-`Am7`{.a} Everyone I know `Fadd9`{.f}  
+`Am7`{.a} What have I become? `Fadd9`{.f}
+`C/E`{.c} My sweetest friend `G`{.g}
+`Am7`{.a} Everyone I know `Fadd9`{.f}
 goes away `C/E`{.c} in the end `G`{.g}
 
-And `Am7`{.a} you could have it all `Fadd9`{.f}  
-`C/E`{.c} My empire of dirt `G`{.g}  
-`Am7`{.a} I will let you down `Fadd9`{.f}  
+And `Am7`{.a} you could have it all `Fadd9`{.f}
+`C/E`{.c} My empire of dirt `G`{.g}
+`Am7`{.a} I will let you down `Fadd9`{.f}
 `G`{.g} I will make you hurt `G`{.g} _(remain on G)_
 
 ---
 
-If I `Am7`{.a} could start again `Fadd9`{.f}  
-a `C/E`{.c} million miles a`G`{.g}way  
-`Am7`{.a} I would keep myself `Fadd9`{.f}  
+If I `Am7`{.a} could start again `Fadd9`{.f}
+a `C/E`{.c} million miles a`G`{.g}way
+`Am7`{.a} I would keep myself `Fadd9`{.f}
 `G`{.g} I would find a way
 
-`Am`{.a}  
-`C`{.c} `D`{.d} `Am`{.a}  
+`Am`{.a}
+`C`{.c} `D`{.d} `Am`{.a}
 `C`{.c} `D`{.d} `Am`{.a}
 
 ## Resources
@@ -1553,41 +1553,41 @@ _(Riff)_
 
 ## Verse 1
 
-I am `G`{.g} sailing, I am `Em`{.e} sailing  
+I am `G`{.g} sailing, I am `Em`{.e} sailing
 home a`C`{.c}gain 'cross the `G`{.g} sea.
 
-I am `Am`{.a} sailing stormy `Em`{.e} waters  
+I am `Am`{.a} sailing stormy `Em`{.e} waters
 to be `Am`{.a} near you, to be `G`{.g} free. `D`{.d}
 
 ## Verse 2
- 
-I am `G`{.g} flying, I am `Em`{.e} flying  
+
+I am `G`{.g} flying, I am `Em`{.e} flying
 like a `C`{.c} bird 'cross the `G`{.g} sea.
 
-I am `Am`{.a} flying passing `Em`{.e} high clouds  
+I am `Am`{.a} flying passing `Em`{.e} high clouds
 to be `Am`{.a} near you, to be `G`{.g} free. `D`{.d}
 
 ## Chorus
 
-Can you `G`{.g} hear me, can you `Em`{.e} hear me  
+Can you `G`{.g} hear me, can you `Em`{.e} hear me
 thru the `C`{.c} dark night far a`G`{.g}way?
 
-I am `Am`{.a} dying, forever `Em`{.e} trying  
+I am `Am`{.a} dying, forever `Em`{.e} trying
 to be `Am`{.a} with you, who can `G`{.g} say? `D`{.d}
- 
+
 _(x2)
- 
+
 `Verse 3`{.v}
 
-We are `G`{.g} sailing, we are `Em`{.e} sailing  
+We are `G`{.g} sailing, we are `Em`{.e} sailing
 home a`C`{.c}gain 'cross the `G`{.g} sea.
 
-We are `Am`{.a} sailing stormy `Em`{.e} waters  
+We are `Am`{.a} sailing stormy `Em`{.e} waters
 to be `Am`{.a} near you, to be `G`{.g} free. `D`{.d} Oh Lord
 
 ## Outro
- 
-To be `Am`{.a} near you, to be `G`{.g} free.  
+
+To be `Am`{.a} near you, to be `G`{.g} free.
 Oh Lord, to be `Am`{.a} near you, to be free. `G`{.g}
 
 ## Resources
@@ -1602,71 +1602,71 @@ Oh Lord, to be `Am`{.a} near you, to be free. `G`{.g}
 ## Intro
 
 `Am`{.a} _(x4)_
- 
+
 ## Chorus
 
-Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene  
-I'm `G`{.g} begging of you  
+Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene
+I'm `G`{.g} begging of you
 please don't take my `Am`{.a} man
 
-Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene  
-`G`{.g} Please don't take him  
+Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene
+`G`{.g} Please don't take him
 `Em`{.e} just because you `Am`{.a} can
- 
+
 ## Verse 1
 
-Your `Am`{.a} beauty is be`C`{.c}yond compare  
-With `G`{.g} flaming locks of `Am`{.a} auburn hair  
-With `G`{.g} ivory skin  
+Your `Am`{.a} beauty is be`C`{.c}yond compare
+With `G`{.g} flaming locks of `Am`{.a} auburn hair
+With `G`{.g} ivory skin
 and `Em`{.e} eyes of emerald `Am`{.a} green
 
-Your `Am`{.a} smile is like a `C`{.c} breath of spring  
-Your `G`{.g} voice is soft like `Am`{.a} summer rain  
-And `G`{.g} I cannot com`Em`{.e}pete with you  
+Your `Am`{.a} smile is like a `C`{.c} breath of spring
+Your `G`{.g} voice is soft like `Am`{.a} summer rain
+And `G`{.g} I cannot com`Em`{.e}pete with you
 `Am`{.a} Jolene
 
 ## Verse 2
 
-He `Am`{.a} talks about you `C`{.c} in his sleep  
-There's `G`{.g} nothing I can `Am`{.a} do to keep  
-From `G`{.g} crying when he `Em`{.e} calls your name  
+He `Am`{.a} talks about you `C`{.c} in his sleep
+There's `G`{.g} nothing I can `Am`{.a} do to keep
+From `G`{.g} crying when he `Em`{.e} calls your name
 Jo`Am`{.a}lene
 
-And `Am`{.a} I can easily `C`{.c} understand  
-How `G`{.g} you could easily `Am`{.a} take my man  
-But you `G`{.g} don't know what he `Em`{.e} means to me  
+And `Am`{.a} I can easily `C`{.c} understand
+How `G`{.g} you could easily `Am`{.a} take my man
+But you `G`{.g} don't know what he `Em`{.e} means to me
 Jo`Am`{.a}lene
 
 ## Chorus
 
-Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene  
-I'm `G`{.g} begging of you  
+Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene
+I'm `G`{.g} begging of you
 please don't take my `Am`{.a} man
 
-Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene  
-`G`{.g} Please don't take him  
+Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene
+`G`{.g} Please don't take him
 `Em`{.e} just because you `Am`{.a} can
 
 ## Verse 3
 
-`Am`{.a} You could have your `C`{.c} choice of men  
-But `G`{.g} I could never `Am`{.a} love again  
-`G`{.g} He's the only `Em`{.e} one for me  
+`Am`{.a} You could have your `C`{.c} choice of men
+But `G`{.g} I could never `Am`{.a} love again
+`G`{.g} He's the only `Em`{.e} one for me
 Jo`Am`{.a}lene
 
-I `Am`{.a} had to have this `C`{.c} talk with you  
-My `G`{.g} happiness de`Am`{.a}pends on you  
-What`G`{.g}ever you de`Em`{.e}cide to do  
+I `Am`{.a} had to have this `C`{.c} talk with you
+My `G`{.g} happiness de`Am`{.a}pends on you
+What`G`{.g}ever you de`Em`{.e}cide to do
 Jo`Am`{.a}lene
- 
+
 ## Chorus
 
-Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene  
-I'm `G`{.g} begging of you  
+Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene
+I'm `G`{.g} begging of you
 please don't take my `Am`{.a} man
 
-Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene  
-`G`{.g} Please don't take him  
+Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene
+`G`{.g} Please don't take him
 `Em`{.e} ~~just because~~ **even though** you `Am`{.a} can
 
 ## Resources
@@ -1686,30 +1686,30 @@ Jo`Am`{.a}lene, Jo`C`{.c}lene, Jo`G`{.g}lene, Jo`Am`{.a}lene
 
 _(Picking)_
 
-`F`{.f} Junge, warum `G`{.g} hast Du  
-nichts gelernt? `Am`{.a}  
-Guck Dir den `F`{.f} Dieter an:  
+`F`{.f} Junge, warum `G`{.g} hast Du
+nichts gelernt? `Am`{.a}
+Guck Dir den `F`{.f} Dieter an:
 `G`{.g} der hat sogar ein `Am`{.a} Auto! `Em`{.e}
 
-Warum `F`{.f} gehst Du nicht zu  
-Onkel Werner in die Werk`G`{.g}statt?  
+Warum `F`{.f} gehst Du nicht zu
+Onkel Werner in die Werk`G`{.g}statt?
 Der gibt Dir ne `Am`{.a} Festanstellung
 wenn Du ihn darum bittest
 
 `F`{.f} Junge... `G`{.g}
- 
+
 ## Chorus 1
 
 _(Strumming)_
 
-...und wie du wieder aus`F`{.f}siehst  
-Löcher in der Ho`Dm`{.d}se  
-und ständig dieser Lärm `Am`{.a}  
+...und wie du wieder aus`F`{.f}siehst
+Löcher in der Ho`Dm`{.d}se
+und ständig dieser Lärm `Am`{.a}
 (Was soll'n die Nach`C`{.c}barn sagen?)
 
-Und dann noch deine Ha`F`{.f}are  
-da fehlen mir die Wor`Dm`{.d}te  
-musst du die denn färb'n? `Am`{.a}  
+Und dann noch deine Ha`F`{.f}are
+da fehlen mir die Wor`Dm`{.d}te
+musst du die denn färb'n? `Am`{.a}
 (Was soll'n die Nach`C`{.c}barn sagen?)
 
 Nie kommst du nach Hau`F`{.f}se
@@ -1719,9 +1719,9 @@ wir wissen nicht mehr wei`Dm`{.d}ter
 
 _(Picking)_
 
-`F`{.f} Junge, `G`{.g} brich deiner  
-Mutter nicht das Herz `Am`{.a}  
-es ist noch `F`{.f} nicht zu spät  
+`F`{.f} Junge, `G`{.g} brich deiner
+Mutter nicht das Herz `Am`{.a}
+es ist noch `F`{.f} nicht zu spät
 `G`{.g} dich an der Uni einzu`Am`{.a}schreiben
 
 du hast dich doch `F`{.f} früher so für Tiere interessiert `G`{.g}
@@ -1734,43 +1734,43 @@ eine eigene Praxis
 
 _(Strumming)_
 
-...und wie du wieder aus`F`{.f}siehst  
-Löcher in der Ho`Dm`{.d}se  
-und ständig dieser Lärm `Am`{.a}  
+...und wie du wieder aus`F`{.f}siehst
+Löcher in der Ho`Dm`{.d}se
+und ständig dieser Lärm `Am`{.a}
 (Was soll'n die Nach`C`{.c}barn sagen?)
 
-Elektrische Gi`F`{.f}tarren  
-und immer diese Tex`Dm`{.d}te  
-das will doch keiner hör'n `Am`{.a}  
+Elektrische Gi`F`{.f}tarren
+und immer diese Tex`Dm`{.d}te
+das will doch keiner hör'n `Am`{.a}
 (Was soll'n die Nach`C`{.c}barn sagen?)
 
 ---
 
-Nie kommst du nach Hau`F`{.f}se  
-so viel schlechter Um`Dm`{.d}gang  
-wir werden dich enterb'n `Am`{.a}  
+Nie kommst du nach Hau`F`{.f}se
+so viel schlechter Um`Dm`{.d}gang
+wir werden dich enterb'n `Am`{.a}
 (was soll das Finanz`C`{.c}amt sagen?)
 
-wo soll das alles en`F`{.f}den?  
+wo soll das alles en`F`{.f}den?
 Wir machen uns doch Sor`Dm`{.d}gen
- 
+
 ## Bridge
 
 _(Very fast strumming)_
 
-`F`{.f} und du warst `Dm`{.d} so ein süßes `Am`{.a} Kind  
-und du warst `C`{.c} so ein süßes `F`{.f} Kind  
-und du warst `Dm`{.d} so ein süßes `Am`{.a} Kind  
-du warst so `C`{.c} süss 
- 
+`F`{.f} und du warst `Dm`{.d} so ein süßes `Am`{.a} Kind
+und du warst `C`{.c} so ein süßes `F`{.f} Kind
+und du warst `Dm`{.d} so ein süßes `Am`{.a} Kind
+du warst so `C`{.c} süss
+
 ## Chorus
 
-Und immer deine Freun`F`{.f}de  
-ihr nehmt doch alle Dro`Dm`{.d}gen  
-und ständig dieser Lärm `Am`{.a}  
+Und immer deine Freun`F`{.f}de
+ihr nehmt doch alle Dro`Dm`{.d}gen
+und ständig dieser Lärm `Am`{.a}
 (Was soll'n die Nach`C`{.c}barn sagen?)
 
-denk' an deine Zu`F`{.f}kunft  
+denk' an deine Zu`F`{.f}kunft
 denk' an deine El`Dm`{.d}tern...
 
 ...willst du, dass wir `Am`{.a} sterb'n?
@@ -1787,69 +1787,69 @@ denk' an deine El`Dm`{.d}tern...
 
 _(Instrumental)_
 
-`C`{.c} `F`{.f} `C`{.c}  
-`C`{.c} `G`{.g}  
-`G7`{.g} `C`{.c}  
+`C`{.c} `F`{.f} `C`{.c}
+`C`{.c} `G`{.g}
+`G7`{.g} `C`{.c}
 `G`{.g} `C`{.c}
 
 ## Verse 1
 
-There's a `C`{.c} dark and a `F`{.f} troubled side of `C`{.c} life  
-There's a `C`{.c} bright, there's a sunny side `G`{.g} too  
-Tho' we `G7`{.g} meet with the darkness and `C`{.c} strife  
+There's a `C`{.c} dark and a `F`{.f} troubled side of `C`{.c} life
+There's a `C`{.c} bright, there's a sunny side `G`{.g} too
+Tho' we `G7`{.g} meet with the darkness and `C`{.c} strife
 The `G`{.g} sunny side we also may `C`{.c} view
 
 ## Chorus
 
-`C`{.c} Keep on the sunny side `F`{.f} always on the `C`{.c} sunny side  
-Keep on the sunny side of `G`{.g} life  
-`C`{.c} It will help us every day  
-It will `F`{.f} brighten all the `C`{.c} way  
+`C`{.c} Keep on the sunny side `F`{.f} always on the `C`{.c} sunny side
+Keep on the sunny side of `G`{.g} life
+`C`{.c} It will help us every day
+It will `F`{.f} brighten all the `C`{.c} way
 If we'll `C`{.c} keep on the `G`{.g} sunny side of `C`{.c} life
- 
+
 ## Verse 2
 
-Well the `C`{.c} storm and its `F`{.f} fury broke to`C`{.c}day  
-Crushing `C`{.c} hopes that we cherish so `G`{.g} dear  
-Clouds and `G7`{.g} storms will, in time, pass a`C`{.c}way  
+Well the `C`{.c} storm and its `F`{.f} fury broke to`C`{.c}day
+Crushing `C`{.c} hopes that we cherish so `G`{.g} dear
+Clouds and `G7`{.g} storms will, in time, pass a`C`{.c}way
 The `G7`{.g} sun again will shine bright and `C`{.c} clear
 
 ## Chorus
 
-`C`{.c} Keep on the sunny side `F`{.f} always on the `C`{.c} sunny side  
-Keep on the sunny side of `G`{.g} life  
-`C`{.c} It will help us every day  
-It will `F`{.f} brighten all the `C`{.c} way  
+`C`{.c} Keep on the sunny side `F`{.f} always on the `C`{.c} sunny side
+Keep on the sunny side of `G`{.g} life
+`C`{.c} It will help us every day
+It will `F`{.f} brighten all the `C`{.c} way
 If we'll `C`{.c} keep on the `G`{.g} sunny side of `C`{.c} life
 
 ## Interlude
 
 _(Instrumental)_
 
-`C`{.c} `F`{.f} `C`{.c}  
-`C`{.c} `G`{.g}  
-`G7`{.g} `C`{.c}  
+`C`{.c} `F`{.f} `C`{.c}
+`C`{.c} `G`{.g}
+`G7`{.g} `C`{.c}
 `G`{.g} `C`{.c}
 
 ## Verse 3
 
-Let us `C`{.c} greet with a `F`{.f} song of hope each `C`{.c} day  
-Thou the `C`{.c} moment be cloudy or `G`{.g} fair  
-Let us `G7`{.g} trust in our Saviour al`C`{.c}ways  
+Let us `C`{.c} greet with a `F`{.f} song of hope each `C`{.c} day
+Thou the `C`{.c} moment be cloudy or `G`{.g} fair
+Let us `G7`{.g} trust in our Saviour al`C`{.c}ways
 Who `G7`{.g} keepeth everyone in His `C`{.c} care
 
 ## Chorus
 
-`C`{.c} Keep on the sunny side `F`{.f} always on the `C`{.c} sunny side  
-Keep on the sunny side of `G`{.g} life  
-`C`{.c} It will help us every day  
-It will `F`{.f} brighten all the `C`{.c} way  
+`C`{.c} Keep on the sunny side `F`{.f} always on the `C`{.c} sunny side
+Keep on the sunny side of `G`{.g} life
+`C`{.c} It will help us every day
+It will `F`{.f} brighten all the `C`{.c} way
 If we'll `C`{.c} keep on the `G`{.g} sunny side of `C`{.c} life
 
 _(Repeat)_
 
-`C`{.c} It will help us every day  
-It will `F`{.f} brighten all the `C`{.c} way  
+`C`{.c} It will help us every day
+It will `F`{.f} brighten all the `C`{.c} way
 If we'll `C`{.c} keep on the `G`{.g} sunny side of `C`{.c} life
 
 _(Fade out_
@@ -1888,91 +1888,91 @@ Cadd9 |x 3 2 0 3 1|
 
 _(Barre chords)_
 
-`Em`{.e} `Bm`{.b} `Em`{.e} `Bm`{.b}  
+`Em`{.e} `Bm`{.b} `Em`{.e} `Bm`{.b}
 `Bbm`{.b} `Am`{.a} `Bm`{.b} `Em`{.e}
- 
+
 ## Verse 1
 
 _(Barre chords)_
 
-I'm `Em`{.e} sitting here in a `Bm`{.b} boring room  
-It's `Em`{.e} just another rainy sunday `Bm`{.b} afternoon  
-I'm `Em`{.e} wasting my time I got `Bm`{.b} nothing to do  
-I'm `Em`{.e} hanging around I'm `Bm`{.b} waiting for you  
+I'm `Em`{.e} sitting here in a `Bm`{.b} boring room
+It's `Em`{.e} just another rainy sunday `Bm`{.b} afternoon
+I'm `Em`{.e} wasting my time I got `Bm`{.b} nothing to do
+I'm `Em`{.e} hanging around I'm `Bm`{.b} waiting for you
 `Bbm`{.b} But `Am`{.a} nothing ever happens `Bm`{.b} - and I won`Em`{.e}der
 
 ## Verse 2
 
 _(Barre chords)_
 
-I'm `Em`{.e} driving around `Bm`{.b} in my car  
-I'm `Em`{.e} driving too fast I'm `Bm`{.b} driving too far  
-I'd `Em`{.e} like to change my `Bm`{.b} point of view  
-I `Em`{.e} feel so lonely I'm `Bm`{.b} waiting for you  
+I'm `Em`{.e} driving around `Bm`{.b} in my car
+I'm `Em`{.e} driving too fast I'm `Bm`{.b} driving too far
+I'd `Em`{.e} like to change my `Bm`{.b} point of view
+I `Em`{.e} feel so lonely I'm `Bm`{.b} waiting for you
 `Bbm`{.b} But `Am`{.a} nothing ever happens `Bm`{.b} - and I won`Em`{.e}der
 
 ## Chorus
 
 _(Open chords)_
 
-I `G`{.g} wonder how I `D`{.d} wonder why  
-`Em`{.e} Yesterday you told me 'bout the `Bm`{.b} blue blue sky  
-And all `C/G`{.c} that I can see `D`{.d}  
+I `G`{.g} wonder how I `D`{.d} wonder why
+`Em`{.e} Yesterday you told me 'bout the `Bm`{.b} blue blue sky
+And all `C/G`{.c} that I can see `D`{.d}
 Is just a yellow `G`{.g} lemon tree `D`{.d}
-                   
-I'm `G`{.g} turning my head `D`{.d} up and down  
-I'm `Em`{.e} turning turning turning turning `Bm`{.b} turning around  
+
+I'm `G`{.g} turning my head `D`{.d} up and down
+I'm `Em`{.e} turning turning turning turning `Bm`{.b} turning around
 And `C/G`{.c} all that I can `A7`{.a} see is just a yellow `D`{.d} lemon tree
 
 ## Bridge 1
 
 _(Barre chords)_
 
-`Em`{.e} `Bm`{.b} `Em`{.e} `Bm`{.b}  
-`Bbm`{.b} `Am`{.a} `Bm`{.b} `Em`{.e}  
+`Em`{.e} `Bm`{.b} `Em`{.e} `Bm`{.b}
+`Bbm`{.b} `Am`{.a} `Bm`{.b} `Em`{.e}
 Da da da...
 
 ## Verse 3
 
 _(Barre chords)_
 
-I'm `Em`{.e} sitting here I `Bm`{.b} miss the power  
-I'd `Em`{.e} like to go out `Bm`{.b} taking a shower  
-But `Em`{.e} there's a heavy cloud in`Bm`{.b}side my head  
-I `Em`{.e} feel so tired put my`Bm`{.b}self into bed  
+I'm `Em`{.e} sitting here I `Bm`{.b} miss the power
+I'd `Em`{.e} like to go out `Bm`{.b} taking a shower
+But `Em`{.e} there's a heavy cloud in`Bm`{.b}side my head
+I `Em`{.e} feel so tired put my`Bm`{.b}self into bed
 `Bbm`{.b} Where `Am`{.a} nothing ever happens `Bm`{.b} - and I won`Em`{.e}der
 
 ## Bridge 2
 
 _(Barre chords)_
-           
-`B7`{.b} Isolation `Em`{.e} is not good for me  
+
+`B7`{.b} Isolation `Em`{.e} is not good for me
 `D7`{.d} Isolation - `G`{.g} I don't want to `B7`{.b} sit on a lemon tree
-                                                   
+
 ## Verse 4
 
-I'm `Em`{.e} steppin' around in a `Bm`{.b} desert of joy  
-`Em`{.e} Baby anyhow I'll get an`Bm`{.b}other toy  
+I'm `Em`{.e} steppin' around in a `Bm`{.b} desert of joy
+`Em`{.e} Baby anyhow I'll get an`Bm`{.b}other toy
 And `Am`{.a} everything will happen - `Bm`{.b} and you'll won`Em`{.e}der
 
 ## Chorus
 
 _(Open chords)_
 
-I `G`{.g} wonder how I `D`{.d} wonder why  
-`Em`{.e} Yesterday you told me 'bout the `Bm`{.b} blue blue sky  
-And all `C/G`{.c} that I can see `D`{.d}  
+I `G`{.g} wonder how I `D`{.d} wonder why
+`Em`{.e} Yesterday you told me 'bout the `Bm`{.b} blue blue sky
+And all `C/G`{.c} that I can see `D`{.d}
 Is just a yellow `G`{.g} lemon tree `D`{.d}
-                   
-I'm `G`{.g} turning my head `D`{.d} up and down  
-I'm `Em`{.e} turning turning turning turning `Bm`{.b} turning around  
+
+I'm `G`{.g} turning my head `D`{.d} up and down
+I'm `Em`{.e} turning turning turning turning `Bm`{.b} turning around
 And `C/G`{.c} all that I can `A7`{.a} see is just a yellow `D`{.d} lemon tree
 And I wonder I wonder
 
 ---
-              
-I `G`{.g} wonder how I `D`{.d} wonder why  
-`Em`{.e} Yesterday you told me 'bout the `Bm`{.b} blue blue sky  
+
+I `G`{.g} wonder how I `D`{.d} wonder why
+`Em`{.e} Yesterday you told me 'bout the `Bm`{.b} blue blue sky
 And all `C/G`{.c} that I can see `D`{.d} _(x3)_
 Is `Cadd9`{.c} just a yellow `G7`{.g} lemon tree `G`{.g}
 
@@ -1998,77 +1998,77 @@ G7sus4 |x x 0 0 1 1|
 
 ## Intro
 
-`D`{.d} `G`{.g} `A`{.a} `F#`{.f} `Bm`{.b}  
+`D`{.d} `G`{.g} `A`{.a} `F#`{.f} `Bm`{.b}
 `G7`{.g} `C`{.c} `F`{.f} `C`{.c}
 
 ## Verse 1
 
-Morning has `C`{.c}brok`Dm`{.d}en  
-`G`{.g} like the first `F`{.f} morn`C`{.c}ing  
-`C`{.c} Blackbird has `Em`{.e} spok`Am`{.a}en  
+Morning has `C`{.c}brok`Dm`{.d}en
+`G`{.g} like the first `F`{.f} morn`C`{.c}ing
+`C`{.c} Blackbird has `Em`{.e} spok`Am`{.a}en
 `D7sus4`{.d} like the first `G`{.g} bird
 
-`C`{.c} Praise for the `F`{.f} singing  
-`C`{.c} praise for the `Am`{.a} morn`D`{.d}ing  
-`G`{.g} Praise for them `C`{.c} spring`F`{.f}ing  
+`C`{.c} Praise for the `F`{.f} singing
+`C`{.c} praise for the `Am`{.a} morn`D`{.d}ing
+`G`{.g} Praise for them `C`{.c} spring`F`{.f}ing
 `G7`{.g} fresh from the `C`{.c} world
 
 ## Instrumental
 
-`F`{.f} `G`{.g} `E`{.e} `Am`{.a}  
+`F`{.f} `G`{.g} `E`{.e} `Am`{.a}
 `G7`{.g} `C`{.c} `G7sus4`{.g}
 
 ## Verse 2
 
-Sweet the rain's `C`{.c} new `Dm`{.d} fall  
-`G`{.g} sunlit from `F`{.f} heav`C`{.c}en  
-`C`{.c} Like the first `Em`{.e} dew `Am`{.a} fall  
+Sweet the rain's `C`{.c} new `Dm`{.d} fall
+`G`{.g} sunlit from `F`{.f} heav`C`{.c}en
+`C`{.c} Like the first `Em`{.e} dew `Am`{.a} fall
 `D7sus4`{.d} on the first `G`{.g} grass
 
-`C`{.c} Praise for the `F`{.f} sweetness  
-`C`{.c} of the wet `Am`{.a} gard`D`{.d}en  
-`G`{.g} Sprung in comp`C`{.c}lete`F`{.f}ness  
+`C`{.c} Praise for the `F`{.f} sweetness
+`C`{.c} of the wet `Am`{.a} gard`D`{.d}en
+`G`{.g} Sprung in comp`C`{.c}lete`F`{.f}ness
 `G7`{.g} where his feet `C`{.c} pass
 
 ## Instrumental
 
-`F`{.f} `G`{.g} `E`{.e} `Am`{.a}  
-`F#`{.f} `Bm`{.b} `G`{.g} `D`{.d}  
+`F`{.f} `G`{.g} `E`{.e} `Am`{.a}
+`F#`{.f} `Bm`{.b} `G`{.g} `D`{.d}
 `A7/D`{.a} `D`{.d}
 
 ## Verse 3
 
-Mine is the `D`{.d} sun`Em`{.e}light  
-`A`{.a} mine is the `G`{.g} morn`D`{.d}ing  
-Born of the `F#m`{.f} one `Bm`{.b} light  
+Mine is the `D`{.d} sun`Em`{.e}light
+`A`{.a} mine is the `G`{.g} morn`D`{.d}ing
+Born of the `F#m`{.f} one `Bm`{.b} light
 `E7`{.e} Eden saw `A`{.a} play `A7`{.a}
 
-`D`{.d} Praise with el`G`{.g}ation  
-`D`{.d} praise every `Bm`{.b} morn`E`{.e}ing  
-`A`{.a} God's recre`D`{.d}a`G`{.g}tion  
+`D`{.d} Praise with el`G`{.g}ation
+`D`{.d} praise every `Bm`{.b} morn`E`{.e}ing
+`A`{.a} God's recre`D`{.d}a`G`{.g}tion
 `A7`{.a} of the new `D`{.d} day
 
 ## Instrumental
 
-`G`{.g} `A`{.a} `F#`{.f} `Bm`{.b}  
+`G`{.g} `A`{.a} `F#`{.f} `Bm`{.b}
 `G7`{.g} `C`{.c} `F`{.f} `C`{.c}
 
 ## Verse 1
 
-Morning has `C`{.c}brok`Dm`{.d}en  
-`G`{.g} like the first `F`{.f} morn`C`{.c}ing  
-`C`{.c} Blackbird has `Em`{.e} spok`Am`{.a}en  
+Morning has `C`{.c}brok`Dm`{.d}en
+`G`{.g} like the first `F`{.f} morn`C`{.c}ing
+`C`{.c} Blackbird has `Em`{.e} spok`Am`{.a}en
 `D7sus4`{.d} like the first `G`{.g} bird
 
-`C`{.c} Praise for the `F`{.f} singing  
-`C`{.c} praise for the `Am`{.a} morn`D`{.d}ing  
-`G`{.g} Praise for them `C`{.c} spring`F`{.f}ing  
+`C`{.c} Praise for the `F`{.f} singing
+`C`{.c} praise for the `Am`{.a} morn`D`{.d}ing
+`G`{.g} Praise for them `C`{.c} spring`F`{.f}ing
 `G7`{.g} fresh from the `C`{.c} world
 
 ## Outro
 
-`F`{.f} `G`{.g} `E`{.e} `Am`{.a}  
-`F#`{.f} `Bm`{.b} `G`{.g} `D`{.d}  
+`F`{.f} `G`{.g} `E`{.e} `Am`{.a}
+`F#`{.f} `Bm`{.b} `G`{.g} `D`{.d}
 `A7/D`{.a} `D`{.d}
 
 ## Resources
@@ -2081,66 +2081,66 @@ Morning has `C`{.c}brok`Dm`{.d}en
 
 ## Verse 1
 
-Hal`G`{.g}lo, mein Schatz, ich liebe Dich,  
-Du `Em`{.e} bist die einzige für mich.  
-Die `C`{.c} andern find' ich alle doof,  
+Hal`G`{.g}lo, mein Schatz, ich liebe Dich,
+Du `Em`{.e} bist die einzige für mich.
+Die `C`{.c} andern find' ich alle doof,
 Des`D`{.d}wegen mach ich Dir den Hof.
 
-Du `G`{.g} bist so anders, ganz speziell,  
-Ich `Em`{.e} merke sowas immer schnell.  
-Jetzt `C`{.c} zieh Dich aus und leg Dich hin,  
+Du `G`{.g} bist so anders, ganz speziell,
+Ich `Em`{.e} merke sowas immer schnell.
+Jetzt `C`{.c} zieh Dich aus und leg Dich hin,
 Weil `D`{.d} ich so verliebt in Dich bin.
 
 ## Bridge 1
 
-`C`{.c} Gleich wird es dunkel, `Bm`{.b} bald ist es Nacht,  
+`C`{.c} Gleich wird es dunkel, `Bm`{.b} bald ist es Nacht,
 Da `C`{.c} ist ein Wort der Warnung angebracht! `D`{.d}
 
 ## Chorus 1
 
-Männer sind `G`{.g} Schweine!  
-Traue ihnen `Em`{.e} nicht, mein Kind!  
-Sie wollen `Am`{.a} alle das eine!  
+Männer sind `G`{.g} Schweine!
+Traue ihnen `Em`{.e} nicht, mein Kind!
+Sie wollen `Am`{.a} alle das eine!
 Weil `C`{.c} Männer nun mal so `D`{.d} sind.
 
 ## Verse 2
 
-Ein `G`{.g} Mann fühlt sich erst dann als Mann,  
-Wenn `Em`{.e} er es Dir besorgen kann.  
-Er `C`{.c} lügt, dass sich die Balken biegen.  
+Ein `G`{.g} Mann fühlt sich erst dann als Mann,
+Wenn `Em`{.e} er es Dir besorgen kann.
+Er `C`{.c} lügt, dass sich die Balken biegen.
 `D`{.d} Nur, um Dich ins Bett zu kriegen.
 
-Und `G`{.g} dann am nächsten Morgen weiss er  
-`Em`{.e} Nicht einmal mehr, wie Du heisst.  
-`C`{.c} Rücksichtslos und ungehemmt,  
+Und `G`{.g} dann am nächsten Morgen weiss er
+`Em`{.e} Nicht einmal mehr, wie Du heisst.
+`C`{.c} Rücksichtslos und ungehemmt,
 Ge`D`{.d}fühle sind ihm völlig fremd.
 
 ## Bridge 2
 
-`C`{.c} Für ihn ist Liebe gleich `Bm`{.b} Samenverlust,  
+`C`{.c} Für ihn ist Liebe gleich `Bm`{.b} Samenverlust,
 `C`{.c} Mädchen, sei Dir dessen stets bewusst! `D`{.d}
 
 ## Chorus 2
 
-Männer sind `G`{.g} Schweine!  
-Frage nicht nach `Em`{.e} Sonnenschein.  
-Ausnahmen `Am`{.a} gibt's leider keine!  
+Männer sind `G`{.g} Schweine!
+Frage nicht nach `Em`{.e} Sonnenschein.
+Ausnahmen `Am`{.a} gibt's leider keine!
 In jedem `C`{.c} Mann steckt auch immer ein `D`{.d} Schwein!
 
-Männer sind `G`{.g} Säue!  
-Glaube ihnen `Em`{.e} nicht ein Wort!  
-Sie schwör'n Dir `Am`{.a} ewige Treue  
+Männer sind `G`{.g} Säue!
+Glaube ihnen `Em`{.e} nicht ein Wort!
+Sie schwör'n Dir `Am`{.a} ewige Treue
 Und dann am `C`{.c} nächsten Morgen sind sie fort. `D`{.d}
 
 ## Verse 3
 
-Und `G`{.g} falls Du doch den Fehler machst  
-Und `Em`{.e} Dir 'nen Ehemann anlachst.  
+Und `G`{.g} falls Du doch den Fehler machst
+Und `Em`{.e} Dir 'nen Ehemann anlachst.
 Mu`C`{.c}tiert dein Rosenkavalier
 Bald `D`{.d} nach der Hochzeit auch zum Tier.
 
-Da `G`{.g} zeigt er dann sein wahres Ich,  
-Ganz `Em`{.e} unrasiert und widerlich.  
+Da `G`{.g} zeigt er dann sein wahres Ich,
+Ganz `Em`{.e} unrasiert und widerlich.
 Trinkt `C`{.c} Bier, sieht fern und wird schnell fett.
 Und `D`{.d} rülpst und furzt im Ehebett.
 
@@ -2151,26 +2151,26 @@ Drum `C`{.c} sag' ich Dir - denk bitte stets daran: `D`{.d}
 
 ## Chorus 3
 
-Männer sind `G`{.g} Schweine!  
-Traue ihnen `Em`{.e} nicht, mein Kind!  
-Sie wollen `Am`{.a} alle das eine!  
+Männer sind `G`{.g} Schweine!
+Traue ihnen `Em`{.e} nicht, mein Kind!
+Sie wollen `Am`{.a} alle das eine!
 Für wahre `C`{.c} Liebe sind sie blind `D`{.d}.
 
-Männer sind `G`{.g} Ratten  
-Begegne ihnen `Em`{.e} nur mit List  
-Sie wollen `Am`{.a} alles begatten  
+Männer sind `G`{.g} Ratten
+Begegne ihnen `Em`{.e} nur mit List
+Sie wollen `Am`{.a} alles begatten
 Was nicht bei `C`{.c} drei auf den Bäumen ist `D`{.d}
 
 ---
 
-Männer sind `G`{.g} Schweine!  
-Frage nicht nach `Em`{.e} Sonnenschein.  
-Ausnahmen `Am`{.a} gibt's leider keine!  
+Männer sind `G`{.g} Schweine!
+Frage nicht nach `Em`{.e} Sonnenschein.
+Ausnahmen `Am`{.a} gibt's leider keine!
 In jedem `C`{.c} Mann steckt auch immer ein `D`{.d} Schwein!
 
-Männer sind `G`{.g} Autos  
-Nur ohne Re`Em`{.e}serverad  
-Yeah, yeah, yeah, yeaääääää `Am`{.a}  
+Männer sind `G`{.g} Autos
+Nur ohne Re`Em`{.e}serverad
+Yeah, yeah, yeah, yeaääääää `Am`{.a}
 `C`{.c} Uh-hu, uh-hu `D`{.d}
 
 ## Resources
@@ -2181,98 +2181,98 @@ Yeah, yeah, yeah, yeaääääää `Am`{.a}
 # No woman no cry (Bob Marley)
 
 ## Intro
- 
+
 _(Instrumental)_
- 
-`C`{.c} `G/B`{.g} `Am`{.a} `F`{.f}  
+
+`C`{.c} `G/B`{.g} `Am`{.a} `F`{.f}
 `C`{.c} `F`{.f} `C`{.c} `G`{.g}
- 
+
 ## Chorus
 
-`C`{.c} No `G/B`{.g} woman no cry `Am`{.a} `F`{.f}  
+`C`{.c} No `G/B`{.g} woman no cry `Am`{.a} `F`{.f}
 `C`{.c} No `F`{.f} woman no cry `C`{.c} `G`{.g}
 
 _(Repeat)_
 
 ## Verse 1
 
-Said said  
-`C`{.c} said I re`G/B`{.g}member  
-`Am`{.a} when we used to sit `F`{.f}  
-`C`{.c} In the govern`G/B`{.g}ment yard  
+Said said
+`C`{.c} said I re`G/B`{.g}member
+`Am`{.a} when we used to sit `F`{.f}
+`C`{.c} In the govern`G/B`{.g}ment yard
 in `Am`{.a} trenchtown `F`{.f}
 
-`C`{.c} Oba-oba`G/B`{.g}serving the `Am`{.a} hypo`F`{.f}crites  
-As they would `C`{.c} mingle  
+`C`{.c} Oba-oba`G/B`{.g}serving the `Am`{.a} hypo`F`{.f}crites
+As they would `C`{.c} mingle
 with the good `G/B`{.g} people we meet `Am`{.a} `F`{.f}
 
 ---
 
-`C`{.c} good friends `G/B`{.g} we had oh  
-`Am`{.a} good friend we lost `F`{.f}  
+`C`{.c} good friends `G/B`{.g} we had oh
+`Am`{.a} good friend we lost `F`{.f}
 `C`{.c} along `G/B`{.g} the way `Am`{.a} `F`{.f}
 
-`C`{.c} In this bright `G/B`{.g} future  
-you `Am`{.a} cant forget your past `F`{.f}  
+`C`{.c} In this bright `G/B`{.g} future
+you `Am`{.a} cant forget your past `F`{.f}
 `C`{.c} So dry your tears `G/B`{.g} I say `Am`{.a} `F`{.f}
 
 ## Chorus
 
-`C`{.c} No `G/B`{.g} woman no cry `Am`{.a} `F`{.f}  
+`C`{.c} No `G/B`{.g} woman no cry `Am`{.a} `F`{.f}
 `C`{.c} No `F`{.f} woman no cry `C`{.c} `G`{.g}
 
-~~No woman no cry~~  
-**`C`{.c} Here `G/B`{.g} little darlin'**  
-**`Am`{.a} don't shed no `F`{.f} tears**  
+~~No woman no cry~~
+**`C`{.c} Here `G/B`{.g} little darlin'**
+**`Am`{.a} don't shed no `F`{.f} tears**
 `C`{.c} No `F`{.f} woman no cry `C`{.c} `G`{.g}
 
 ## Verse 1
 
-Said said  
-`C`{.c} said I re`G/B`{.g}member  
-`Am`{.a} when we used to sit `F`{.f}  
-`C`{.c} In the govern`G/B`{.g}ment yard  
+Said said
+`C`{.c} said I re`G/B`{.g}member
+`Am`{.a} when we used to sit `F`{.f}
+`C`{.c} In the govern`G/B`{.g}ment yard
 in `Am`{.a} trenchtown `F`{.f}
 
-`C`{.c} And then `G/B`{.g} Georgie  
-would `Am`{.a} make a fire light `F`{.f}  
-as it was `C`{.c} log wood `G/B`{.g} burnin  
+`C`{.c} And then `G/B`{.g} Georgie
+would `Am`{.a} make a fire light `F`{.f}
+as it was `C`{.c} log wood `G/B`{.g} burnin
 through the nights `Am`{.a} `F`{.f}
 
 ---
 
-`C`{.c} Then we `G/B`{.g} would cook  
-corn `Am`{.a} meal porridge `F`{.f}  
-`C`{.c} of which I'll `G/B`{.g} share  
+`C`{.c} Then we `G/B`{.g} would cook
+corn `Am`{.a} meal porridge `F`{.f}
+`C`{.c} of which I'll `G/B`{.g} share
 with you `Am`{.a} yeah `F`{.f}
 
-`C`{.c} My feet `G/B`{.g} is my `Am`{.a} only carriage `F`{.f}  
-`C`{.c} and so I've got `G/B`{.g} to  
-push on through `Am`{.a}  
+`C`{.c} My feet `G/B`{.g} is my `Am`{.a} only carriage `F`{.f}
+`C`{.c} and so I've got `G/B`{.g} to
+push on through `Am`{.a}
 But while I'm `F`{.f} gone
 
 ## Bridge
 
-`C`{.c} Everything's gonna `G/B`{.g} be alright  
+`C`{.c} Everything's gonna `G/B`{.g} be alright
 `Am`{.a} Everything's gonna `F`{.f} be alright
 
 _(x4)_
 
 ## Chorus
 
-`C`{.c} No `G/B`{.g} woman no cry `Am`{.a} `F`{.f}  
+`C`{.c} No `G/B`{.g} woman no cry `Am`{.a} `F`{.f}
 `C`{.c} No `F`{.f} woman no cry `C`{.c} `G`{.g}
 
-~~No woman no cry~~  
-**`C`{.c} Here `G/B`{.g} little darlin'**  
-**`Am`{.a} don't shed no `F`{.f} tears**  
+~~No woman no cry~~
+**`C`{.c} Here `G/B`{.g} little darlin'**
+**`Am`{.a} don't shed no `F`{.f} tears**
 `C`{.c} No `F`{.f} woman no cry `C`{.c} `G`{.g}
 
 ## Outro
 
 _(Instrumental)_
 
-`C`{.c} `G/B`{.g} `Am`{.a} `F`{.f}  
+`C`{.c} `G/B`{.g} `Am`{.a} `F`{.f}
 `C`{.c} `F`{.f} `C`{.c} `G`{.g}
 
 _(Repeat and fade)_
@@ -2288,91 +2288,91 @@ _(Repeat and fade)_
 ## Intro
 
 `Am`{.a} `Dsus2`{.d} `FM7`{.f} `G`{.g} _(x4)_
- 
+
 ## Verse 1
 
-`Am`{.a} Is it getting `Dsus2`{.d} better?  
-`FM7`{.f} Or do you feel the `G`{.g} same?  
-`Am`{.a} Will it make it `Dsus2`{.d} easier on you?  
+`Am`{.a} Is it getting `Dsus2`{.d} better?
+`FM7`{.f} Or do you feel the `G`{.g} same?
+`Am`{.a} Will it make it `Dsus2`{.d} easier on you?
 Now `FM7`{.f} you got someone to `G`{.g} blame
 
 You say
 
 ## Chorus 1
 
-`C`{.c} One love `Am`{.a} One life  
-`FM7`{.f} When it's one need `C`{.c} in the night  
-`C`{.c}One love `Am`{.a} We got to share it  
-`FM7`{.f} It leaves you baby  
+`C`{.c} One love `Am`{.a} One life
+`FM7`{.f} When it's one need `C`{.c} in the night
+`C`{.c}One love `Am`{.a} We got to share it
+`FM7`{.f} It leaves you baby
 if you `C`{.c} don't care for it
 
 `Am`{.a} `Dsus2`{.d} `FM7`{.f} `G`{.g}
 
 ## Verse 2
 
-`Am`{.a} Did I disap`Dsus2`{.d}point you?  
-`FM7`{.f} Or leave a bad taste in your `G`{.g} mouth?  
-`Am`{.a} You act like you never `Dsus2`{.d} had love  
+`Am`{.a} Did I disap`Dsus2`{.d}point you?
+`FM7`{.f} Or leave a bad taste in your `G`{.g} mouth?
+`Am`{.a} You act like you never `Dsus2`{.d} had love
 `FM7`{.f} And you want me to go with`G`{.g}out
 
 Well it's
- 
+
 ## Bridge 1
 
-`C`{.c} Too late `Am`{.a} Tonight  
-`FM7`{.f} To drag the past out in`C`{.c}to the light  
-`C`{.c} We're one, but we're `Am`{.a} not the same  
-We got to `FM7`{.f} carry each other  
+`C`{.c} Too late `Am`{.a} Tonight
+`FM7`{.f} To drag the past out in`C`{.c}to the light
+`C`{.c} We're one, but we're `Am`{.a} not the same
+We got to `FM7`{.f} carry each other
 `C`{.c} carry each other
 
 `Am`{.a} `Dsus2`{.d} `FM7`{.f} `G`{.g}
 
 ## Verse 3
 
-`Am`{.a} Have you come here for for`Dsus2`{.d}giveness?  
-`FM7`{.f} Have you come to raise `G`{.g} the dead?  
-`Am`{.a} Have you come here to play `Dsus2`{.d} Jesus  
+`Am`{.a} Have you come here for for`Dsus2`{.d}giveness?
+`FM7`{.f} Have you come to raise `G`{.g} the dead?
+`Am`{.a} Have you come here to play `Dsus2`{.d} Jesus
 `FM7`{.f} To the lepers in your `G`{.g} head?
 
 ## Bridge 2
 
-`C`{.c} Did I ask too much? `Am`{.a} More than a lot?  
-`FM7`{.f} You gave me nothing, now it's `C`{.c} all I got  
-`C`{.c} We're one, but we're `Am`{.a} not the same  
-Well we `FM7`{.f} hurt each other  
+`C`{.c} Did I ask too much? `Am`{.a} More than a lot?
+`FM7`{.f} You gave me nothing, now it's `C`{.c} all I got
+`C`{.c} We're one, but we're `Am`{.a} not the same
+Well we `FM7`{.f} hurt each other
 then we `C`{.c} do it again
 
 You say
 
 ## Interlude
 
-`C`{.c} Love is a temple `Am`{.a} Love's a higher law  
-`C`{.c} Love is a temple `Am`{.a} Love's the higher law  
-You `C`{.c} ask me to enter  
+`C`{.c} Love is a temple `Am`{.a} Love's a higher law
+`C`{.c} Love is a temple `Am`{.a} Love's the higher law
+You `C`{.c} ask me to enter
 but `G`{.g} then you make me crawl
-                      
-And `G`{.g} I can't be holding on `FM7`{.f}  
-To what you got `FM7`{.f}  
+
+And `G`{.g} I can't be holding on `FM7`{.f}
+To what you got `FM7`{.f}
 When all you got is hurt
 
 ## Chorus 3
 
-`C`{.c} One love `Am`{.a} One ~~life~~ **blood**  
-~~When it's one need in the night~~  
+`C`{.c} One love `Am`{.a} One ~~life~~ **blood**
+~~When it's one need in the night~~
 **`FM7`{.f} One life, You got to `C`{.c} do what you should**
-~~One love, we got to share it~~  
-**`C`{.c} One life `Am`{.a} with each other**  
-~~It leaves you baby~~  
-`FM7`{.f} Sisters  
-~~if you don't care for it~~  
+~~One love, we got to share it~~
+**`C`{.c} One life `Am`{.a} with each other**
+~~It leaves you baby~~
+`FM7`{.f} Sisters
+~~if you don't care for it~~
 **`C`{.c} Brothers**
 
 ## Outro
 
-`C`{.c} One life, but we're `Am`{.a} not the same  
+`C`{.c} One life, but we're `Am`{.a} not the same
 We got to `FM7`{.f} carry each other, car`C`{.c}ry each other
 
-One `C`{.c} `Am`{.a} One `FM7`{.f} `C`{.c}  
+One `C`{.c} `Am`{.a} One `FM7`{.f} `C`{.c}
 _(Repeat several times and fade)_
 
 ## Resources
@@ -2387,24 +2387,24 @@ _(Repeat several times and fade)_
 
 _(Vocals only)_
 
-Mmmh `G`{.g} mmmh `G`{.g} mmmh `D7`{.d} mmmh `G`{.g}  
+Mmmh `G`{.g} mmmh `G`{.g} mmmh `D7`{.d} mmmh `G`{.g}
 Uuuh `G`{.g} uuuh `G`{.g} uuuh `D7`{.d} uuuh `G`{.g}
- 
+
 ## Chorus
 
-By the rivers of `G`{.g} Babylon  
-there we sat down  
-Ye-eah we `D7`{.d} wept  
+By the rivers of `G`{.g} Babylon
+there we sat down
+Ye-eah we `D7`{.d} wept
 when we remembered Zi`G`{.g}on
 
 _(x2)_
- 
+
 ## Verse 1
 
-(When the wicked)  
-`G`{.g} Carried us away in cap`G7`{.g}tivity  
-Re`C`{.c}quired from us a song `G`{.g}  
-Now how shall we sing the lord's song  
+(When the wicked)
+`G`{.g} Carried us away in cap`G7`{.g}tivity
+Re`C`{.c}quired from us a song `G`{.g}
+Now how shall we sing the lord's song
 in a stra`D7`{.d}nge `G`{.g} land
 
 _(x2)_
@@ -2415,17 +2415,17 @@ Mmmh `G`{.g} mmmh `G`{.g} mmmh `D7`{.d} mmmh `G`{.g}
 
 ## Bridge
 
-Let the `G`{.g} words of our `D7`{.d} mouth  
-and the medi`G`{.g}tations of our heart `D7`{.d}  
+Let the `G`{.g} words of our `D7`{.d} mouth
+and the medi`G`{.g}tations of our heart `D7`{.d}
 Be acc`G`{.g}eptable in thy sight `D7`{.d}here to`G`{.g}night
 
 _(x2)_
 
 ## Chorus
 
-By the rivers of `G`{.g} Babylon  
-there we sat down  
-Ye-eah we `D7`{.d} wept  
+By the rivers of `G`{.g} Babylon
+there we sat down
+Ye-eah we `D7`{.d} wept
 when we remembered Zi`G`{.g}on
 
 _(Repeat and fade)_
@@ -2457,62 +2457,62 @@ X Stop playing
 
 ## Verse 1
 
-`Dm`{.d} Save me from drowning in the sea `Dm6`{.d}  
-`Am`{.a} Beat me up on the beach  
-`Dm`{.d}What a lovely holiday `E7(1)`{.e}  
+`Dm`{.d} Save me from drowning in the sea `Dm6`{.d}
+`Am`{.a} Beat me up on the beach
+`Dm`{.d}What a lovely holiday `E7(1)`{.e}
 There's nothing funny left to say `Asus`{.a} `Am`{.a}
 
-`Dm`{.d} This sombre song would drain the sun `Dm6`{.d}  
-`Am`{.a} But it won't shine until it's sung  
-`Dm`{.d} No water running in the stream `E7(2)`{.e}  
+`Dm`{.d} This sombre song would drain the sun `Dm6`{.d}
+`Am`{.a} But it won't shine until it's sung
+`Dm`{.d} No water running in the stream `E7(2)`{.e}
 The saddest place we've ever seen `A7sus4`{.a} `A7`{.a}
 
 ## Bridge 1
 
-`F/A`{.f} Everything I touched was gol`G7`{.g}den  
-Everything I loved got `C`{.c} broken  
+`F/A`{.f} Everything I touched was gol`G7`{.g}den
+Everything I loved got `C`{.c} broken
 On the road to Mandalay
 
-`F`{.f} Every mistake I've ever made `Em`{.e}  
-Has been rehashed and then re`Dm`{.d}played  
+`F`{.f} Every mistake I've ever made `Em`{.e}
+Has been rehashed and then re`Dm`{.d}played
 As I got lost along the way `G`{.g}
 
 ## Chorus
 
-`X`{.x} Bum bum bum `Dm`{.d} ba da dum bum bum `G`{.g}  
+`X`{.x} Bum bum bum `Dm`{.d} ba da dum bum bum `G`{.g}
 Bum bum bum `C`{.c} ba da dum bum bum `Am`{.a}
 
-Bum bum bum `F`{.f} ba da dum, bum bum `G`{.g}  
+Bum bum bum `F`{.f} ba da dum, bum bum `G`{.g}
 Bum ba dum `Am`{.a}
 
 ## Verse 2
 
-`Dm`{.d} There's nothing left for you to give `Dm6`{.d}  
-`Am`{.a} The truth is all that you're left with  
-`Dm`{.d} Twenty paces then at dawn `E7(1)`{.e}  
+`Dm`{.d} There's nothing left for you to give `Dm6`{.d}
+`Am`{.a} The truth is all that you're left with
+`Dm`{.d} Twenty paces then at dawn `E7(1)`{.e}
 We will `E7`{.e} die and be reborn `Asus`{.a} `Am`{.a}
 
-`Dm`{.d} I like to sleep beneath the trees `Dm6`{.d}  
-`Am`{.a} Have the universe at one with me  
-`Dm`{.d} Look down the barrel of a gun `E7(2)`{.e}  
+`Dm`{.d} I like to sleep beneath the trees `Dm6`{.d}
+`Am`{.a} Have the universe at one with me
+`Dm`{.d} Look down the barrel of a gun `E7(2)`{.e}
 And feel the moon replace the sun `A7sus4`{.a} `A7`{.a}
 
 ## Bridge 2
 
-`F/A`{.f} Everything we've ever sto`G7`{.g}len  
-Has been lost returned or `C`{.c} broken  
+`F/A`{.f} Everything we've ever sto`G7`{.g}len
+Has been lost returned or `C`{.c} broken
 No more dragons left to slay
 
-`F`{.f} Every mistake I've ever made `Em`{.e}  
-Has been rehashed and then re`Dm`{.d}played  
+`F`{.f} Every mistake I've ever made `Em`{.e}
+Has been rehashed and then re`Dm`{.d}played
 As I got lost along the way `G`{.g}
 
 ## Chorus
 
-`X`{.x} Bum bum bum `Dm`{.d} ba da dum bum bum `G`{.g}  
+`X`{.x} Bum bum bum `Dm`{.d} ba da dum bum bum `G`{.g}
 Bum bum bum `C`{.c} ba da dum bum bum `Am`{.a}
 
-Bum bum bum `F`{.f} ba da dum, bum bum `G`{.g}  
+Bum bum bum `F`{.f} ba da dum, bum bum `G`{.g}
 Bum ba dum `Am`{.a}
 
 _(x3)_
@@ -2525,9 +2525,9 @@ _(Instrumental)_
 
 ## Outro
 
-`Dm`{.d} Save me from drowning in the sea `Dm6`{.d}  
-`Am`{.a} Beat me up on the beach  
-`Dm`{.d}What a lovely holiday `E7(1)`{.e}  
+`Dm`{.d} Save me from drowning in the sea `Dm6`{.d}
+`Am`{.a} Beat me up on the beach
+`Dm`{.d}What a lovely holiday `E7(1)`{.e}
 There's nothing funny left to say `Am`{.a}
 
 ## Resources
@@ -2542,97 +2542,97 @@ There's nothing funny left to say `Am`{.a}
 _(Instrumental)_
 
 `Em`{.e} `C`{.c} `B`{.b} _(x2)_
- 
+
 ## Verse 1
 
-`Em`{.e} Road trippin with my two  
-`C`{.c} favorite all`B`{.b}ies  
-`Em`{.e} Fully loaded we got  
+`Em`{.e} Road trippin with my two
+`C`{.c} favorite all`B`{.b}ies
+`Em`{.e} Fully loaded we got
 `C`{.c} snacks and supp`B`{.b}lies
 
-`Em`{.e} It's time to leave this town  
-It's `C`{.c} time to steal away `B`{.b}  
-`Em`{.e} Let's go get lost  
+`Em`{.e} It's time to leave this town
+It's `C`{.c} time to steal away `B`{.b}
+`Em`{.e} Let's go get lost
 any`C`{.c}where in the U.S.A. `B`{.b}
 
 ---
 
-`Em`{.e} Let's go get lost  
+`Em`{.e} Let's go get lost
 let's go get `C`{.c} lost `B`{.b}
 
-`Em`{.e} Blue you sit so pretty  
-`C`{.c} West of the one `B`{.b}  
-`Em`{.e} Sparkles light with yellow `C`{.c} icing  
+`Em`{.e} Blue you sit so pretty
+`C`{.c} West of the one `B`{.b}
+`Em`{.e} Sparkles light with yellow `C`{.c} icing
 Just a `B`{.b} mirror for the sun `Em`{.e}
 
 ##  Chorus
 
-`C`{.c} Just a `B`{.b} mirror for the `Em`{.e} sun  
-`C`{.c} Just a `B`{.b} mirror for the  
+`C`{.c} Just a `B`{.b} mirror for the `Em`{.e} sun
+`C`{.c} Just a `B`{.b} mirror for the
 `Am`{.a} Sun `G/B`{.g} `C`{.c} `D`{.d}
 
-`Am`{.a} These smiling `G/B`{.g} eyes  
+`Am`{.a} These smiling `G/B`{.g} eyes
 are just a `C`{.c} mirror for `D`{.d}
- 
+
 ## Verse 2
 
-`Em`{.e} So much has come before  
-those `C`{.c} battles lost and `B`{.b} won  
-`Em`{.e} This life is shining  
+`Em`{.e} So much has come before
+those `C`{.c} battles lost and `B`{.b} won
+`Em`{.e} This life is shining
 more for`C`{.c}ever in the sun `B`{.b}
 
-`Em`{.e} Now let us check our heads  
-And `C`{.c} let us check the surf `B`{.b}  
-`Em`{.e} Staying high and dry's more `C`{.c} trouble  
+`Em`{.e} Now let us check our heads
+And `C`{.c} let us check the surf `B`{.b}
+`Em`{.e} Staying high and dry's more `C`{.c} trouble
 than it's `B`{.b} worth in the sun `Em`{.e}
 
 ##  Chorus
 
-`C`{.c} Just a `B`{.b} mirror for the `Em`{.e} sun  
-`C`{.c} Just a `B`{.b} mirror for the  
+`C`{.c} Just a `B`{.b} mirror for the `Em`{.e} sun
+`C`{.c} Just a `B`{.b} mirror for the
 `Am`{.a} Sun `G/B`{.g} `C`{.c} `D`{.d}
 
-`Am`{.a} These smiling `G/B`{.g} eyes  
+`Am`{.a} These smiling `G/B`{.g} eyes
 are just a `C`{.c} mirror for `D`{.d}
 
 ## Interlude
 
 _(Instrumental)_
- 
+
 `Em`{.e} `A`{.a} `C`{.c} `D`{.d} `Em`{.e} `A`{.a} `C`{.c} `Bdim`{.b} _(x2)_
- 
+
 `Bdim`{.b} _(x4)_
 
 ## Verse 3
 
 
-`Em`{.e} In Big Sur we take some  
-`C`{.c} time to linger on `B`{.b}  
-`Em`{.e} We three hunky dory's got  
+`Em`{.e} In Big Sur we take some
+`C`{.c} time to linger on `B`{.b}
+`Em`{.e} We three hunky dory's got
 `C`{.c} our snake`B`{.b}finger on
 
-`Em`{.e} Now let us drink the stars  
-`C`{.c} It's time to steal away `B`{.b}  
-`Em`{.e} Let's go get lost  
+`Em`{.e} Now let us drink the stars
+`C`{.c} It's time to steal away `B`{.b}
+`Em`{.e} Let's go get lost
 ~~anywhere~~ **right `C`{.c} here** in the U.S.A. `B`{.b}
 
 ---
 
-`Em`{.e} Let's go get lost  
+`Em`{.e} Let's go get lost
 let's go get `C`{.c} lost `B`{.b}
 
-`Em`{.e} Blue you sit so pretty  
-`C`{.c} West of the one `B`{.b}  
-`Em`{.e} Sparkles light with yellow `C`{.c} icing  
+`Em`{.e} Blue you sit so pretty
+`C`{.c} West of the one `B`{.b}
+`Em`{.e} Sparkles light with yellow `C`{.c} icing
 Just a `B`{.b} mirror for the sun `Em`{.e}
 
 ##  Chorus
 
-`C`{.c} Just a `B`{.b} mirror for the `Em`{.e} sun  
-`C`{.c} Just a `B`{.b} mirror for the  
+`C`{.c} Just a `B`{.b} mirror for the `Em`{.e} sun
+`C`{.c} Just a `B`{.b} mirror for the
 `Am`{.a} Sun `G/B`{.g} `C`{.c} `D`{.d}
 
-`Am`{.a} These smiling `G/B`{.g} eyes  
+`Am`{.a} These smiling `G/B`{.g} eyes
 are just a `C`{.c} mirror for `D`{.d} _(x3)_
 
 ## Resources
@@ -2645,74 +2645,74 @@ are just a `C`{.c} mirror for `D`{.d} _(x3)_
 
 ## Verse 1
 
-I han es `C`{.c}Zündhölzli azündet  
-Und das `G7`{.g} het e Flamme gäh  
-Und i `Am`{.a} ha für d'Zigarette  
+I han es `C`{.c}Zündhölzli azündet
+Und das `G7`{.g} het e Flamme gäh
+Und i `Am`{.a} ha für d'Zigarette
 Welle `E`{.e} Füür vom Hölzli näh
 
 Aber ds `F`{.f} Hölzli isch dervogspickt
-Und `C`{.c} uf e Teppich cho  
-Und es `G7`{.g} hätt no fasch  
+Und `C`{.c} uf e Teppich cho
+Und es `G7`{.g} hätt no fasch
 Es Loch i Teppich `C`{.c} gäh dervo
 
 ## Verse 2
 
-Ja me `C`{.c} weiss was cha passiere  
-We me `G7`{.g} nid ufpasst mit Füür  
-Und für d'`Am`{.a}Gluet ar Zigarette  
+Ja me `C`{.c} weiss was cha passiere
+We me `G7`{.g} nid ufpasst mit Füür
+Und für d'`Am`{.a}Gluet ar Zigarette
 Isch e `E`{.e} Teppich doch de z'tüür
 
-Und vom `F`{.f} Teppich hätt - oh Grus  
-Chönne ds `C`{.c} Füür i ds ganze Hus  
-Und wär `G7`{.g} weiss, was da  
+Und vom `F`{.f} Teppich hätt - oh Grus
+Chönne ds `C`{.c} Füür i ds ganze Hus
+Und wär `G7`{.g} weiss, was da
 Nid alles no wär `C`{.c} worde drus
 
 ## Verse 3
 
-S'hätt e `C`{.c} Brand gäh im Quartier  
-Und s'hätti d'`G7`{.g}Füürwehr müesse cho  
-Hätti `Am`{.a} ghornet i de Strasse  
+S'hätt e `C`{.c} Brand gäh im Quartier
+Und s'hätti d'`G7`{.g}Füürwehr müesse cho
+Hätti `Am`{.a} ghornet i de Strasse
 Und dr `E`{.e} Schluuch vom Wage gno
 
-Und sie `F`{.f} hätte Wasser gsprützt  
-Und das `C`{.c} hätt de glych nüt gnützt  
-Und die `G7`{.g} ganzi Stadt hätt brönnt  
+Und sie `F`{.f} hätte Wasser gsprützt
+Und das `C`{.c} hätt de glych nüt gnützt
+Und die `G7`{.g} ganzi Stadt hätt brönnt
 Es hätt se `C`{.c} nüt meh gschützt
 
 ## Verse 4
 
-Und d'Lüt `C`{.c} wären umegsprunge  
-I dr `G7`{.g} Angscht um Hab und Guet  
-Hätte `Am`{.a} gmeint s'heig eine Füür gleit  
+Und d'Lüt `C`{.c} wären umegsprunge
+I dr `G7`{.g} Angscht um Hab und Guet
+Hätte `Am`{.a} gmeint s'heig eine Füür gleit
 Hätte ds `E`{.e} Sturmgwehr gno ir Wuet
 
-Alls hätt `F`{.f} brüelet: Wär isch tschuld?  
-Ds ganze `C`{.c} Land i eim Tumult  
-Dass me `G7`{.g} gschosse hätt  
+Alls hätt `F`{.f} brüelet: Wär isch tschuld?
+Ds ganze `C`{.c} Land i eim Tumult
+Dass me `G7`{.g} gschosse hätt
 Uf d'Bundesrät am `C`{.c} Rednerpult
 
 ## Verse 5
 
-D'UNO `C`{.c} hätt interveniert  
-Und d'UNO-`G7`{.g}Gägner sofort o  
-Für ir `Am`{.a} Schwyz dr Fride z'rette  
+D'UNO `C`{.c} hätt interveniert
+Und d'UNO-`G7`{.g}Gägner sofort o
+Für ir `Am`{.a} Schwyz dr Fride z'rette
 Wäre `E`{.e} beid mit Panzer cho
 
-S'hätt sech `F`{.f} usdehnt nadisna  
-Uf Eu`C`{.c}ropa, Afrika  
-S'hätt e `G7`{.g} Wältchrieg gäh  
+S'hätt sech `F`{.f} usdehnt nadisna
+Uf Eu`C`{.c}ropa, Afrika
+S'hätt e `G7`{.g} Wältchrieg gäh
 Und d'Mönschheit wär jitz `C`{.c} nümme da
 
 ## Verse 6
 
-I han es `C`{.c} Zündhölzli azündet  
-Und das `G7`{.g} het e Flamme gäh  
-Und i `Am`{.a} ha für d'Zigarette  
+I han es `C`{.c} Zündhölzli azündet
+Und das `G7`{.g} het e Flamme gäh
+Und i `Am`{.a} ha für d'Zigarette
 Welle `E`{.e} Füür vom Hölzli näh
 
-Aber ds `F`{.f} Hölzli isch dervogspickt  
+Aber ds `F`{.f} Hölzli isch dervogspickt
 Und `C`{.c} uf e Teppich cho -
-~~Und es hätt no fasch...~~ Gottsei`G7`{.g}dank  
+~~Und es hätt no fasch...~~ Gottsei`G7`{.g}dank
 Dass i's vom Teppich wider `C`{.c} furt ha gno
 
 ## Resources
@@ -2721,48 +2721,48 @@ Dass i's vom Teppich wider `C`{.c} furt ha gno
 - [Source tab](https://tabs.ultimate-guitar.com/tab/1197401)
 
 # Sittin' on the dock of the bay (Otis Redding)
- 
+
 ## Verse 1
 
-`G`{.g} Sittin' in the mornin' sun `B7`{.b}  
-I'll be `C`{.c} sittin' when the evenin' comes `A`{.a}  
-`G`{.g} Watching the ships roll in `B7`{.b}  
+`G`{.g} Sittin' in the mornin' sun `B7`{.b}
+I'll be `C`{.c} sittin' when the evenin' comes `A`{.a}
+`G`{.g} Watching the ships roll in `B7`{.b}
 And then I `C`{.c} watch 'em roll away again `A`{.a} yeah
 
 ## Chorus
 
-I'm `G`{.g} sittin' on the dock of the `E`{.e} bay  
-Watching the `G`{.g} tide roll `E`{.e}away, ooo  
-I'm just `G`{.g} sittin' on the dock of the `A`{.a} bay  
+I'm `G`{.g} sittin' on the dock of the `E`{.e} bay
+Watching the `G`{.g} tide roll `E`{.e}away, ooo
+I'm just `G`{.g} sittin' on the dock of the `A`{.a} bay
 Wastin' `G`{.g} time `E`{.e}
 
 ## Verse 2
 
-I `G`{.g} left my home in `B7`{.b} Georgia  
-`C`{.c} Headed for the 'Frisco Bay `A`{.a}  
-`G`{.g} 'Cause I've had nothing to `B7`{.b} live for  
+I `G`{.g} left my home in `B7`{.b} Georgia
+`C`{.c} Headed for the 'Frisco Bay `A`{.a}
+`G`{.g} 'Cause I've had nothing to `B7`{.b} live for
 And look like `C`{.c} nothin's gonna come my way `A`{.a}
 
 ## Chorus
 
-~~I'm sittin'~~ **So I'm just gonna `G`{.g} sit** on the dock of the `E`{.e} bay  
-Watching the `G`{.g} tide roll `E`{.e}away, ooh  
-~~I'm just~~ **Ooo I'm** `G`{.g} sittin' on the dock of the `A`{.a} bay  
+~~I'm sittin'~~ **So I'm just gonna `G`{.g} sit** on the dock of the `E`{.e} bay
+Watching the `G`{.g} tide roll `E`{.e}away, ooh
+~~I'm just~~ **Ooo I'm** `G`{.g} sittin' on the dock of the `A`{.a} bay
 Wastin' `G`{.g} time `E`{.e}
 
 ## Bridge
 
-                         
-`G`{.g} Looks like `D`{.d} nothing's `C`{.c} gonna change `G`{.g}  
-`G`{.g} Everything `D`{.d} still remains `C`{.c} the same `G`{.g}  
-`G`{.g} I can't `D`{.d} do what `C`{.c} ten people `G`{.g} tell me to do  
+
+`G`{.g} Looks like `D`{.d} nothing's `C`{.c} gonna change `G`{.g}
+`G`{.g} Everything `D`{.d} still remains `C`{.c} the same `G`{.g}
+`G`{.g} I can't `D`{.d} do what `C`{.c} ten people `G`{.g} tell me to do
 So I `F`{.f} guess I'll remain the `D`{.d} same, yes
 
 ## Chorus
 
-**Now** I'm `G`{.g} sitting on the dock of the `E`{.e} bay  
-Watching the `G`{.g} tide roll `E`{.e}away, ooh  
-~~I'm just~~ **Ooo I'm** `G`{.g} sittin' on the dock of the `A`{.a} bay  
+**Now** I'm `G`{.g} sitting on the dock of the `E`{.e} bay
+Watching the `G`{.g} tide roll `E`{.e}away, ooh
+~~I'm just~~ **Ooo I'm** `G`{.g} sittin' on the dock of the `A`{.a} bay
 Wastin' `G`{.g} time `E`{.e}
 
 _(Repeat and whistle, fade)_
@@ -2800,81 +2800,81 @@ D+ |x x 0 3 3 2| To switch from D, point pinky on G string
 
 ## Verse 1
 
-I `G6`{.g} know I stand in line  
-until you think you have the time  
+I `G6`{.g} know I stand in line
+until you think you have the time
 to spend an `Am`{.a} evening with me `D7`{.d} `Am`{.a} `D7`{.d}
 
-And `Am`{.a} if we go some`D7`{.d}place to dance  
-I `Am`{.a} know that there's a chance `D7`{.d}  
+And `Am`{.a} if we go some`D7`{.d}place to dance
+I `Am`{.a} know that there's a chance `D7`{.d}
 you won't be `G6`{.g} leaving with me
 
 ---
 
-Then `G`{.g} afterwards we drop  
-into a `G7`{.g} quiet little place  
+Then `G`{.g} afterwards we drop
+into a `G7`{.g} quiet little place
 and have a `C`{.c} drink or two `Eb`{.e}
 
-And `Am`{.a} then I go and `D7`{.d} spoil it all  
-by `Am`{.a} saying something `D7`{.d} stupid  
+And `Am`{.a} then I go and `D7`{.d} spoil it all
+by `Am`{.a} saying something `D7`{.d} stupid
 like: "I `G6`{.g} love you"
 
 ## Bridge
 
-I can `G`{.g} see it in your eyes  
-that you de`G7`{.g}spise the same old lies  
+I can `G`{.g} see it in your eyes
+that you de`G7`{.g}spise the same old lies
 you heard the `C`{.c} night before
 
-And `A7`{.a} though it's just a line to you  
-For me it's true and  
+And `A7`{.a} though it's just a line to you
+For me it's true and
 never seemed so `D`{.d} right before `D+`{.d}
 
 ## Verse 2
 
-I `G6`{.g} practice every day  
-to find some clever lines to say to make  
+I `G6`{.g} practice every day
+to find some clever lines to say to make
 the `Am`{.a} meaning come through `D7`{.d} `Am`{.a} `D7`{.d}
 
-But `Am`{.a} then I think I'll `D7`{.d} wait until  
-the `Am`{.a} evening gets late `D7`{.d}  
+But `Am`{.a} then I think I'll `D7`{.d} wait until
+the `Am`{.a} evening gets late `D7`{.d}
 and I'm `G6`{.g} alone with you
 
 ---
 
-The `G`{.g} time is right  
-your perfume fills my `G7`{.g} head  
-the stars get red  
+The `G`{.g} time is right
+your perfume fills my `G7`{.g} head
+the stars get red
 and oh the `C`{.c} night's so blue `Eb`{.e}
 
-And `Am`{.a} then I go and `D7`{.d} spoil it all  
-by `Am`{.a} saying something `D7`{.d} stupid  
+And `Am`{.a} then I go and `D7`{.d} spoil it all
+by `Am`{.a} saying something `D7`{.d} stupid
 like: "I `G6`{.g} love you"
 
 ## Bridge
 
 _(Instrumental, maybe add whistling)_
 
-`G`{.g} `G7`{.g} `C`{.c} 
+`G`{.g} `G7`{.g} `C`{.c}
 `A7`{.a} `D`{.d} `D+`{.d}
- 
+
 ## Verse 2
 
-I `G6`{.g} practice every day  
-to find some clever lines to say to make  
+I `G6`{.g} practice every day
+to find some clever lines to say to make
 the `Am`{.a} meaning come through `D7`{.d} `Am`{.a} `D7`{.d}
 
-But `Am`{.a} then I think I'll `D7`{.d} wait until  
-the `Am`{.a} evening gets late `D7`{.d}  
+But `Am`{.a} then I think I'll `D7`{.d} wait until
+the `Am`{.a} evening gets late `D7`{.d}
 and I'm `G6`{.g} alone with you
 
 ---
 
-The `G`{.g} time is right  
-your perfume fills my `G7`{.g} head  
-the stars get red  
+The `G`{.g} time is right
+your perfume fills my `G7`{.g} head
+the stars get red
 and oh the `C`{.c} night's so blue `Eb`{.e}
 
-And `Am`{.a} then I go and `D7`{.d} spoil it all  
-by `Am`{.a} saying something `D7`{.d} stupid  
+And `Am`{.a} then I go and `D7`{.d} spoil it all
+by `Am`{.a} saying something `D7`{.d} stupid
 like: "I `G`{.g} love you" `Eb`{.e}
 
 I `G`{.g} love you `Eb`{.e} _(Repeat and fade)_
@@ -2894,107 +2894,107 @@ _(Instrumental)_
 
 `C`{.c} `G`{.g} `Am`{.a} `F`{.f} _(repeat)_
 
-`C`{.c} Ooo-ooo `Em`{.e} ooo-ooo  
-`F`{.f} ooo-ooo `C`{.c} ooo-ooo  
-`F`{.f} Ooo-ooo `E7`{.e} ooo-ooo  
+`C`{.c} Ooo-ooo `Em`{.e} ooo-ooo
+`F`{.f} ooo-ooo `C`{.c} ooo-ooo
+`F`{.f} Ooo-ooo `E7`{.e} ooo-ooo
 `Am`{.a} ooo-ooo `F`{.f} ooo-ooo
 
 ## Verse 1
 
-`C`{.c} Somewhere `Em`{.e} over the rainbow  
-`F`{.f} way up `C`{.c} high  
-`F`{.f} And the `C`{.c} dreams that you dream of  
+`C`{.c} Somewhere `Em`{.e} over the rainbow
+`F`{.f} way up `C`{.c} high
+`F`{.f} And the `C`{.c} dreams that you dream of
 `G`{.g} once in a lulla`Am`{.a}by `F`{.f}
 
-Oh `C`{.c} somewhere `Em`{.e} over the rainbow  
-`F`{.f} blue birds `C`{.c} fly  
-`F`{.f} And the `C`{.c} dreams that you dream of  
+Oh `C`{.c} somewhere `Em`{.e} over the rainbow
+`F`{.f} blue birds `C`{.c} fly
+`F`{.f} And the `C`{.c} dreams that you dream of
 `G`{.g} dreams really do come `Am`{.a} true `F`{.f}
 
 ## Verse 2
 
-Some`C`{.c}day i'll wish upon a star  
-`G`{.g} To wake up where the clouds are far  
+Some`C`{.c}day i'll wish upon a star
+`G`{.g} To wake up where the clouds are far
 be`Am`{.a}hind `F`{.f} me
 
-Where `C`{.c} trouble melts like lemon drops  
-`G`{.g} High above the chimney tops  
-that's `Am`{.a} where  
+Where `C`{.c} trouble melts like lemon drops
+`G`{.g} High above the chimney tops
+that's `Am`{.a} where
 you'll `F`{.f} find me
 
 ## Interlude 1
 
-Oh `C`{.c} somewhere `Em`{.e} over the rainbow  
-`F`{.f} blue birds `C`{.c} fly  
-`F`{.f} And the `C`{.c} dreams that you dare to oh  
+Oh `C`{.c} somewhere `Em`{.e} over the rainbow
+`F`{.f} blue birds `C`{.c} fly
+`F`{.f} And the `C`{.c} dreams that you dare to oh
 `G`{.g} why oh why can't `Am`{.a} I? `F`{.f}
 
 ## Verse 3
 
-Well I see `C`{.c} trees of `Em`{.e} green and  
-`F`{.f} Red roses `C`{.c} too  
-`F`{.f} I'll watch them `C`{.c} bloom for  
+Well I see `C`{.c} trees of `Em`{.e} green and
+`F`{.f} Red roses `C`{.c} too
+`F`{.f} I'll watch them `C`{.c} bloom for
 `E7`{.e} me and `Am`{.a} you
 
-And I `F`{.f} think to myself  
+And I `F`{.f} think to myself
 `G`{.g} what a wonderful `Am`{.a} world `F`{.f}
 
 ---
 
-Well I see `C`{.c} skies of `Em`{.e} blue and I see  
-`F`{.f} clouds of `C`{.c} white  
-And the `F`{.f} brightness of `C`{.c} day  
+Well I see `C`{.c} skies of `Em`{.e} blue and I see
+`F`{.f} clouds of `C`{.c} white
+And the `F`{.f} brightness of `C`{.c} day
 `E7`{.e} I like the `Am`{.a} dark
 
-And I `F`{.f} think to myself  
+And I `F`{.f} think to myself
 `G`{.g} what a wonderful `C`{.c} world `F`{.f} `C`{.c}
 
 ## Bridge
 
-The `G`{.g} colours of the rainbow  
-so `C`{.c} pretty in the sky  
-Are `G`{.g} also on the faces  
+The `G`{.g} colours of the rainbow
+so `C`{.c} pretty in the sky
+Are `G`{.g} also on the faces
 of `C`{.c} people passing bye
 
-See `F`{.f} friends shaking `C`{.c} hands  
-saying `F`{.f} how do you `C`{.c} do?  
-`F`{.f} They're really `C`{.c} saying  
+See `F`{.f} friends shaking `C`{.c} hands
+saying `F`{.f} how do you `C`{.c} do?
+`F`{.f} They're really `C`{.c} saying
 `Dm7`{.d} I - I love `D`{.d} you
 
 ## Interlude 2
 
-I hear `C`{.c} babies `Em`{.e} cry and I  
-`F`{.f} watch them `C`{.c} grow  
-`F`{.f} They'll learn much `C`{.c} more  
+I hear `C`{.c} babies `Em`{.e} cry and I
+`F`{.f} watch them `C`{.c} grow
+`F`{.f} They'll learn much `C`{.c} more
 `E7`{.e} than we'll `Am`{.a} know
 
-And I `F`{.f} think to myself  
+And I `F`{.f} think to myself
 `G`{.g} what a wonderful `Am`{.a} world `F`{.f} world
 
 ## Verse 2
 
-Some`C`{.c}day i'll wish upon a star  
-`G`{.g} To wake up where the clouds are far  
+Some`C`{.c}day i'll wish upon a star
+`G`{.g} To wake up where the clouds are far
 be`Am`{.a}hind `F`{.f} me
 
-Where `C`{.c} trouble melts like lemon drops  
-`G`{.g} High above the chimney tops  
-that's `Am`{.a} where  
+Where `C`{.c} trouble melts like lemon drops
+`G`{.g} High above the chimney tops
+that's `Am`{.a} where
 you'll `F`{.f} find me
 
 ## Interlude 1
 
-`C`{.c} Oh somewhere `Em`{.e} over the rainbow  
-~~blue birds fly~~  
-**`F`{.f} way up `C`{.c} high**  
-`F`{.f} And the `C`{.c} dreams that you dare to  
+`C`{.c} Oh somewhere `Em`{.e} over the rainbow
+~~blue birds fly~~
+**`F`{.f} way up `C`{.c} high**
+`F`{.f} And the `C`{.c} dreams that you dare to
 `G`{.g} why oh why can't `Am`{.a} I? `F`{.f}
 
 ## Outro
 
-`C`{.c} Ooo-ooo `Em`{.e} ooo-ooo  
-`F`{.f} ooo-ooo `C`{.c} ooo-ooo  
-`F`{.f} ooo-ooo `E7`{.e} ooo-ooo  
+`C`{.c} Ooo-ooo `Em`{.e} ooo-ooo
+`F`{.f} ooo-ooo `C`{.c} ooo-ooo
+`F`{.f} ooo-ooo `E7`{.e} ooo-ooo
 `Am`{.a} ooo-a-eh-a `F`{.f} a-a-a-a-a
 
 ## Resources
@@ -3008,24 +3008,24 @@ you'll `F`{.f} find me
 
 _(Female)_
 
-`Am`{.a} Strawberries, cherries and an  
-`G`{.g} angel's kiss in spring  
-`Am`{.a} My summer wine is really  
+`Am`{.a} Strawberries, cherries and an
+`G`{.g} angel's kiss in spring
+`Am`{.a} My summer wine is really
 `G`{.g} made from all these things
 
 `Am`{.a} (x4)
- 
+
 ## Verse 1
 
 _(Male)_
 
-`Am`{.a} I walked in town on silver  
-`G`{.g} spurs that jingled to  
-`Am`{.a} A song that I had only  
-`G`{.g} sang to just a few  
+`Am`{.a} I walked in town on silver
+`G`{.g} spurs that jingled to
+`Am`{.a} A song that I had only
+`G`{.g} sang to just a few
 
-`Dm`{.d} She saw my silver spurs and  
-`Am`{.a} said let's pass some time  
+`Dm`{.d} She saw my silver spurs and
+`Am`{.a} said let's pass some time
 `Dm`{.d} And I will give to you `Am`{.a} summer wine
 
 `G`{.g}Ohhh`Em`{.e}oh summer wine `Am`{.a}
@@ -3033,14 +3033,14 @@ _(Male)_
 ## Chorus
 
 _(Female)_
- 
-`Am`{.a} Strawberries, cherries and an  
-`G`{.g} angel's kiss in spring  
-`Am`{.a} My summer wine is really  
+
+`Am`{.a} Strawberries, cherries and an
+`G`{.g} angel's kiss in spring
+`Am`{.a} My summer wine is really
 `G`{.g} made from all these things
 
-`Dm`{.d} Take off your silver spurs and  
-`Am`{.a} help me pass the time  
+`Dm`{.d} Take off your silver spurs and
+`Am`{.a} help me pass the time
 `Dm`{.d} And I will give to you `Am`{.a} summer wine
 
 `G`{.g}Ohhh`Em`{.e}oh summer wine `Am`{.a}
@@ -3048,67 +3048,67 @@ _(Female)_
 ## Verse 2
 
 _(Male)_
- 
-                         
-`Am`{.a} My eyes grew heavy and my  
-`G`{.g} lips they could not speak  
-`Am`{.a} I tried to get up but I  
+
+
+`Am`{.a} My eyes grew heavy and my
+`G`{.g} lips they could not speak
+`Am`{.a} I tried to get up but I
 `G`{.g} couldn't find my feet
 
-`Dm`{.d} She reassured me with an  
-`Am`{.a} unfamiliar line  
+`Dm`{.d} She reassured me with an
+`Am`{.a} unfamiliar line
 `Dm`{.d} And then she gave to me `Am`{.a} more summer wine
 
 `G`{.g}Ohhh`Em`{.e}oh summer wine `Am`{.a}
- 
+
 ## Chorus
 
 _(Female)_
- 
-`Am`{.a} Strawberries, cherries and an  
-`G`{.g} angel's kiss in spring  
-`Am`{.a} My summer wine is really  
+
+`Am`{.a} Strawberries, cherries and an
+`G`{.g} angel's kiss in spring
+`Am`{.a} My summer wine is really
 `G`{.g} made from all these things
 
-`Dm`{.d} Take off your silver spurs and  
-`Am`{.a} help me pass the time  
+`Dm`{.d} Take off your silver spurs and
+`Am`{.a} help me pass the time
 `Dm`{.d} And I will give to you `Am`{.a} summer wine
 
 `G`{.g}Ohhh`Em`{.e}oh summer wine `Am`{.a}
- 
+
 ## Verse 2
- 
+
 _(Male)_
-                          
-`Am`{.a} When I woke up the sun was  
-`G`{.g} shining in my eyes  
-`Am`{.a} My silver spurs were gone  
+
+`Am`{.a} When I woke up the sun was
+`G`{.g} shining in my eyes
+`Am`{.a} My silver spurs were gone
 my `G`{.g} head felt twice its size
 
-`Dm`{.d} She took my silver spurs  
-a `Am`{.a} dollar and a dime  
+`Dm`{.d} She took my silver spurs
+a `Am`{.a} dollar and a dime
 `Dm`{.d} And left me cravin' for `Am`{.a} more summer wine
 
-`G`{.g}Ohhh`Em`{.e}oh summer wine `Am`{.a} 
- 
+`G`{.g}Ohhh`Em`{.e}oh summer wine `Am`{.a}
+
 ## Chorus
 
 _(Female)_
- 
-`Am`{.a} Strawberries, cherries and an  
-`G`{.g} angel's kiss in spring  
-`Am`{.a} My summer wine is really  
+
+`Am`{.a} Strawberries, cherries and an
+`G`{.g} angel's kiss in spring
+`Am`{.a} My summer wine is really
 `G`{.g} made from all these things
 
-`Dm`{.d} Take off your silver spurs and  
-`Am`{.a} help me pass the time  
+`Dm`{.d} Take off your silver spurs and
+`Am`{.a} help me pass the time
 `Dm`{.d} And I will give to you `Am`{.a} summer wine
 
 `G`{.g}Ohhh`Em`{.e}oh summer wine `Am`{.a}
 
 ## Outro
- 
-`Am`{.a} `G`{.g} `Am`{.a} `G`{.g}  
+
+`Am`{.a} `G`{.g} `Am`{.a} `G`{.g}
 `Dm`{.d} `Am`{.a} `Dm`{.d} `Am`{.a}
 
 ## Resources
@@ -3122,50 +3122,50 @@ _(Female)_
 
 _(Chords sequence remains the same)_
 
-The `Am`{.a} river is `C`{.c} flowing  
-`G`{.g} flowing in `Am`{.a} growing  
-the river is flowing  
+The `Am`{.a} river is `C`{.c} flowing
+`G`{.g} flowing in `Am`{.a} growing
+the river is flowing
 back to the sea
 
-Mother Earth is caring me  
-her child I will always be  
-Mother Earth is caring me  
+Mother Earth is caring me
+her child I will always be
+Mother Earth is caring me
 back to the sea
- 
+
 ## Verse 2
 
-The `Am`{.a} Moon she `C`{.c} is waiting  
-`G`{.g} waxing and `Am`{.a} waning  
-the Moon she is waiting  
+The `Am`{.a} Moon she `C`{.c} is waiting
+`G`{.g} waxing and `Am`{.a} waning
+the Moon she is waiting
 for us to be free
 
-Sister Moon watch over me  
-a child I will always be  
-Sister Moon watch over me  
+Sister Moon watch over me
+a child I will always be
+Sister Moon watch over me
 until we are free
- 
+
 ## Verse 3
 
-The `Am`{.a} Sun he `C`{.c} is shining  
-`G`{.g} brightly he's `Am`{.a} shining  
-the Sun he is shining  
+The `Am`{.a} Sun he `C`{.c} is shining
+`G`{.g} brightly he's `Am`{.a} shining
+the Sun he is shining
 lightning the way
 
-Father Sun shine over me  
-your child I will always be  
-father Sun shine over me  
-until we can see  
- 
+Father Sun shine over me
+your child I will always be
+father Sun shine over me
+until we can see
+
 ## Verse 4
 
-The `Am`{.a} Fire `C`{.c} is burning  
-`G`{.g} destroying and `Am`{.a} healing  
-the Fire is burning  
+The `Am`{.a} Fire `C`{.c} is burning
+`G`{.g} destroying and `Am`{.a} healing
+the Fire is burning
 for us to get pure
 
-Violet Flame burn over me  
-a child I will always be  
-violet Flame burn over me  
+Violet Flame burn over me
+a child I will always be
+violet Flame burn over me
 until we are pure
 
 ## Resources
@@ -3177,21 +3177,21 @@ until we are pure
 
 ## Verse 1
 
-Ich `Am`{.a} ziehe durch die Straßen bis nach Mitternacht  
-hab das früher auch gern gemacht  
+Ich `Am`{.a} ziehe durch die Straßen bis nach Mitternacht
+hab das früher auch gern gemacht
 dich `G`{.g} brauch ich dafür `Am`{.a} nicht!
 
-Ich `Am`{.a} sitze am Tresen, trinke noch 'n Bier  
-früher war'n wir oft gemeinsam hier  
+Ich `Am`{.a} sitze am Tresen, trinke noch 'n Bier
+früher war'n wir oft gemeinsam hier
 das `G`{.g} macht mir, macht mir `Am`{.a} nichts!
 
 ---
 
-`C`{.c} Gegenüber sitzt 'n Typ wie'n Bär  
-ich `G`{.g} stell' mir vor, wenn das dein Neuer wär'  
+`C`{.c} Gegenüber sitzt 'n Typ wie'n Bär
+ich `G`{.g} stell' mir vor, wenn das dein Neuer wär'
 Das `Am`{.a} juckt mich `G`{.g} überhaupt `Am`{.a} nicht.
 
-Auf `C`{.c} einmal packt's mich, ich geh auf ihn zu  
+Auf `C`{.c} einmal packt's mich, ich geh auf ihn zu
 und `G`{.g} mach ihn an: "Lass meine Frau in Ruh!"
 Er `Am`{.a} fragt nur: `G`{.g} "Hast du'n `Am`{.a} Stich?"
 
@@ -3201,39 +3201,39 @@ Und ich `F`{.f} denke schon wieder nur an `G`{.g} dich...
 
 _(x2: gently first time, then repeat intensively)_
 
-Verdammt, ich `C`{.c} lieb' dich, ich lieb' dich `G`{.g} nicht.  
-Verdammt, ich `Dm`{.d} brauch' dich, brauch' dich `Am`{.a} nicht. `G`{.g}  
-Verdammt, ich `C`{.c} will dich, ich will dich `G`{.g} nicht,  
+Verdammt, ich `C`{.c} lieb' dich, ich lieb' dich `G`{.g} nicht.
+Verdammt, ich `Dm`{.d} brauch' dich, brauch' dich `Am`{.a} nicht. `G`{.g}
+Verdammt, ich `C`{.c} will dich, ich will dich `G`{.g} nicht,
 Ich `F`{.f} will dich nicht verli`Am`{.a}er'n!
 
 ## Verse 2
 
 So `Am`{.a} langsam fällt mir alles wieder ein:
-Ich wollt doch nur'n bisschen freier sein.  
+Ich wollt doch nur'n bisschen freier sein.
 Jetzt `G`{.g} bin ich's - oder `Am`{.a} nicht?
 
 
-Ich `Am`{.a} passte nicht in deine heile Welt  
-doch die und du ist, was mir jetzt so fehlt  
+Ich `Am`{.a} passte nicht in deine heile Welt
+doch die und du ist, was mir jetzt so fehlt
 ich `G`{.g} glaub das einfach `Am`{.a} nicht.
 
 ---
 
-`C`{.c} Gegenüber steht 'n Telefon  
-es `G`{.g} lacht mich ständig an voll Hohn  
+`C`{.c} Gegenüber steht 'n Telefon
+es `G`{.g} lacht mich ständig an voll Hohn
 Es `Am`{.a} klingelt, `G`{.g} klingelt aber `Am`{.a} nicht.
 
-`C`{.c} Sieben Bier, zuviel geraucht  
-das `G`{.g} ist es, was ein Mann so braucht,  
+`C`{.c} Sieben Bier, zuviel geraucht
+das `G`{.g} ist es, was ein Mann so braucht,
 Doch `F`{.f} niemand, `G`{.g} niemand sagt: "Hör auf". `Am`{.a}
 
 Und ich `F`{.f} denke schon wieder nur an `G`{.g} dich...
 
 ## Chorus
 
-Verdammt, ich `C`{.c} lieb' dich, ich lieb' dich `G`{.g} nicht.  
-Verdammt, ich `Dm`{.d} brauch' dich, brauch' dich `Am`{.a} nicht. `G`{.g}  
-Verdammt, ich `C`{.c} will dich, ich will dich `G`{.g} nicht,  
+Verdammt, ich `C`{.c} lieb' dich, ich lieb' dich `G`{.g} nicht.
+Verdammt, ich `Dm`{.d} brauch' dich, brauch' dich `Am`{.a} nicht. `G`{.g}
+Verdammt, ich `C`{.c} will dich, ich will dich `G`{.g} nicht,
 Ich `F`{.f} will dich nicht verli`Am`{.a}er'n! - Ooooh!
 
 _(Repeat and fade)_
@@ -3249,34 +3249,34 @@ _(Repeat and fade)_
 ## Intro
 
 `D`{.d} `Em`{.e} `G`{.g} `D`{.d} _(x2)_
- 
+
 ## Verse 1
 
-`D`{.d} Twenty-five years and my life is still  
-`Em`{.e} Trying to get up that great big hill  
+`D`{.d} Twenty-five years and my life is still
+`Em`{.e} Trying to get up that great big hill
 Of `G`{.g} hope for a destina`D`{.d}tion
 
-I `D`{.d} realized quickly when I knew I should  
-That the world `Em`{.e} was made of this brotherhood  
+I `D`{.d} realized quickly when I knew I should
+That the world `Em`{.e} was made of this brotherhood
 Of man, `G`{.g} for whatever that means `D`{.d}
- 
+
 ## Pre-Chorus
 
-And so I `D`{.d} cry sometimes when I'm lying in bed  
-Just to `Em`{.e} get it all out, what's in my head  
+And so I `D`{.d} cry sometimes when I'm lying in bed
+Just to `Em`{.e} get it all out, what's in my head
 and I `G`{.g} - I am feeling a little pecu`D`{.d}liar
 
-And so I `D`{.d} wake in the morning and I step outside  
-and I `Em`{.e} take a deep breath and I get real high and  
+And so I `D`{.d} wake in the morning and I step outside
+and I `Em`{.e} take a deep breath and I get real high and
 I `G`{.g} scream at the top of my lungs:
 
 "What's going `D`{.d} on?"
 
 ## Chorus
 
-And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"  
-I said "Hey, `G`{.g} what's going on?" `D`{.d}  
-And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"  
+And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"
+I said "Hey, `G`{.g} what's going on?" `D`{.d}
+And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"
 I said "Hey, `G`{.g} what's going on?" `D`{.d}
 
 ## Interlude
@@ -3284,30 +3284,30 @@ I said "Hey, `G`{.g} what's going on?" `D`{.d}
 `D`{.d} Ooh `Em`{.e} Ooh `G`{.g} Ooh `D`{.d} _(x2)_
 
 ## Verse
-                         
-And I try, `D`{.d} oh my Aod do I try `Em`{.e}  
-I try all the time, `G`{.g} in this institu`D`{.d}tion  
+
+And I try, `D`{.d} oh my Aod do I try `Em`{.e}
+I try all the time, `G`{.g} in this institu`D`{.d}tion
 And I pray, `D`{.d} oh my god do I pray `Em`{.e}
-I pray every single day `G`{.g}  
+I pray every single day `G`{.g}
 For a revo`D`{.d}lution
 
 ## Pre-Chorus
 
-And so I `D`{.d} cry sometimes when I'm lying in bed  
-Just to `Em`{.e} get it all out, what's in my head  
+And so I `D`{.d} cry sometimes when I'm lying in bed
+Just to `Em`{.e} get it all out, what's in my head
 and I `G`{.g} - I am feeling a little pecu`D`{.d}liar
 
-And so I `D`{.d} wake in the morning and I step outside  
-and I `Em`{.e} take a deep breath and I get real high and  
+And so I `D`{.d} wake in the morning and I step outside
+and I `Em`{.e} take a deep breath and I get real high and
 I `G`{.g} scream at the top of my lungs:
 
 "What's going `D`{.d} on?"
 
 ## Chorus
 
-And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"  
-I said "Hey, `G`{.g} what's going on?" `D`{.d}  
-And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"  
+And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"
+I said "Hey, `G`{.g} what's going on?" `D`{.d}
+And I said `D`{.d} "Heyeyeyeyey `Em`{.e} Heyeyey"
 I said "Hey, `G`{.g} what's going on?" `D`{.d}
 
 _(Repeat)_
@@ -3318,8 +3318,8 @@ _(Repeat)_
 
 ## Outro
 
-`D`{.d} Twenty-five years and my life is still  
-`Em`{.e} Trying to get up that great big hill  
+`D`{.d} Twenty-five years and my life is still
+`Em`{.e} Trying to get up that great big hill
 Of `G`{.g} hope for a destina`D`{.d}tion
 
 ## Resources
@@ -3350,55 +3350,55 @@ E |------------3|3-3---------3-|
 
 ## Intro
 
-`Am`{.a} `D/F#`{.d} `G`{.g} `C`{.c} `F`{.f} `Dm`{.d} `E`{.e} `Esus4`{.e} `E`{.e}  
+`Am`{.a} `D/F#`{.d} `G`{.g} `C`{.c} `F`{.f} `Dm`{.d} `E`{.e} `Esus4`{.e} `E`{.e}
 La la la...
- 
+
 ## Verse 1
 
-`Am`{.a} Now that I've `D/F#`{.d} lost everything to `G`{.g} you  
-You say you `C`{.c} wanna start something `F`{.f} new  
-And it's `Dm`{.d} breaking my heart you're `E`{.e} leaving  
+`Am`{.a} Now that I've `D/F#`{.d} lost everything to `G`{.g} you
+You say you `C`{.c} wanna start something `F`{.f} new
+And it's `Dm`{.d} breaking my heart you're `E`{.e} leaving
 Baby I'm `Esus4`{.e} griev`E`{.e}ing
 
-But `Am`{.a} if you wanna `D/F#`{.d} leave take good `G`{.g} care  
-Hope you have a `C`{.c} lot of nice things to wear `F`{.f}  
-But then a `Dm`{.d} lot of nice things turn  
+But `Am`{.a} if you wanna `D/F#`{.d} leave take good `G`{.g} care
+Hope you have a `C`{.c} lot of nice things to wear `F`{.f}
+But then a `Dm`{.d} lot of nice things turn
 `E`{.e} bad out`E7`{.e}there `G`{.g} `G7`{.g} `G6`{.g} `G5`{.g}
 
 ## Chorus
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world  
-`C`{.c} _(Riff 1)_  
-`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile  
+`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
+`C`{.c} _(Riff 1)_
+`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile
 `G`{.g} _(Riff 2)_
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world  
-`C`{.c} _(Riff 1)_  
+`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
+`C`{.c} _(Riff 1)_
 `G`{.g} I'll always remember you `F`{.f} like a `C`{.c} child girl
 `Dm`{.d} `E`{.e}
 
 ## Verse 2
 
-`Am`{.a} You know I've seen a `D/F#`{.d} lot of  
-what the world can `G`{.g} do  
-And it's `C`{.c} breaking my heart in `F`{.f} two  
-'cause I `Dm`{.d} never want to see you `E`{.e} sad girl  
+`Am`{.a} You know I've seen a `D/F#`{.d} lot of
+what the world can `G`{.g} do
+And it's `C`{.c} breaking my heart in `F`{.f} two
+'cause I `Dm`{.d} never want to see you `E`{.e} sad girl
 Don't be a `Esus4`{.e} bad `E`{.e} girl
 
-But `Am`{.a} if you wanna `D/F#`{.d} leave take good `G`{.g} care  
-Hope you make a `C`{.c} lot of nice friends out there `F`{.f}  
-But just re`Dm`{.d}member there's a lot of bad  
+But `Am`{.a} if you wanna `D/F#`{.d} leave take good `G`{.g} care
+Hope you make a `C`{.c} lot of nice friends out there `F`{.f}
+But just re`Dm`{.d}member there's a lot of bad
 `E`{.e} and be`E7`{.e}ware `G`{.g} `G7`{.g} `G6`{.g} `G5`{.g}
 
 ## Chorus
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world  
-`C`{.c} _(Riff 1)_  
-`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile  
+`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
+`C`{.c} _(Riff 1)_
+`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile
 `G`{.g} _(Riff 2)_
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world  
-`C`{.c} _(Riff 1)_  
+`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
+`C`{.c} _(Riff 1)_
 `G`{.g} I'll always remember you `F`{.f} like a `C`{.c} child girl
 `Dm`{.d} `E`{.e}
 
@@ -3407,20 +3407,20 @@ But just re`Dm`{.d}member there's a lot of bad
 `Am`{.a} `D/F#`{.d} `G`{.g} `C`{.c} `F`{.f} `Dm`{.d} `E`{.e} `Esus4`{.e} `E`{.e}
 La la la... Baby I love you
 
-But `Am`{.a} if you wanna `D/F#`{.d} leave take good `G`{.g} care  
-Hope you make a `C`{.c} lot of nice friends out there `F`{.f}  
-But just re`Dm`{.d}member there's a lot of bad  
+But `Am`{.a} if you wanna `D/F#`{.d} leave take good `G`{.g} care
+Hope you make a `C`{.c} lot of nice friends out there `F`{.f}
+But just re`Dm`{.d}member there's a lot of bad
 `E`{.e} and be`E7`{.e}ware `G`{.g} `G7`{.g} `G6`{.g} `G5`{.g}
 
 ## Chorus
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world  
-`C`{.c} _(Riff 1)_  
-`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile  
+`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
+`C`{.c} _(Riff 1)_
+`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile
 `G`{.g} _(Riff 2)_
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world  
-`C`{.c} _(Riff 1)_  
+`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
+`C`{.c} _(Riff 1)_
 `G`{.g} I'll always remember you `F`{.f} like a `C`{.c} child girl
 `Dm`{.d} `E`{.e} _(1st time only)_
 
@@ -3438,64 +3438,64 @@ _(Repeat)_
 
 _(Instrumental)_
 
-`G`{.g} `Em`{.e}  
-`G`{.g} `Em`{.e}  
-`G`{.g} `Em`{.e}  
-`A`{.a} `Em`{.e}  
+`G`{.g} `Em`{.e}
+`G`{.g} `Em`{.e}
+`G`{.g} `Em`{.e}
+`A`{.a} `Em`{.e}
 `A`{.a} `G`{.g}
 
 _(Repeat with solo)_
 
 ## Verse 1
 
-`C`{.c} So, so you think you can `D`{.d} tell  
-heaven from `Am`{.a} hell?  
+`C`{.c} So, so you think you can `D`{.d} tell
+heaven from `Am`{.a} hell?
 Blue skies from `G`{.g} pain?
 
-Can you tell a green `D`{.d} field  
-from a cold steel `C`{.c} rail?  
-A smile from a `Am`{.a} veil?  
+Can you tell a green `D`{.d} field
+from a cold steel `C`{.c} rail?
+A smile from a `Am`{.a} veil?
 Do you think you can `G`{.g} tell?
 
 ## Verse 2
 
-Did they get you to `C`{.c} trade  
-your heroes for `D`{.d} ghosts?  
-Hot ashes for `Am`{.a} trees?  
+Did they get you to `C`{.c} trade
+your heroes for `D`{.d} ghosts?
+Hot ashes for `Am`{.a} trees?
 Hot air for a `G`{.g} cool breeze?
 
-Cold comfort for `D`{.d} change?  
-And did you ex`C`{.c}change  
-a walk-on part in the `Am`{.a} war  
+Cold comfort for `D`{.d} change?
+And did you ex`C`{.c}change
+a walk-on part in the `Am`{.a} war
 for a lead role in a `G`{.g} cage?
 
 ## Interlude
 
-`G`{.g} `Em`{.e}  
-`G`{.g} `Em`{.e}  
-`G`{.g} `Em`{.e}  
-`A`{.a} `Em`{.e}  
+`G`{.g} `Em`{.e}
+`G`{.g} `Em`{.e}
+`G`{.g} `Em`{.e}
+`A`{.a} `Em`{.e}
 `A`{.a} `G`{.g}
 
 ## Chorus
 
-`C`{.c} How I wish  
-how I wish you were `D`{.d} here  
-We're just `Am`{.a} two lost souls  
-swimming in a fishbowl  
+`C`{.c} How I wish
+how I wish you were `D`{.d} here
+We're just `Am`{.a} two lost souls
+swimming in a fishbowl
 `G`{.g} year after year
 
-`D`{.d} Running over the same old ground  
-`C`{.c} what have we found?  
-The same old `Am`{.a} fears  
+`D`{.d} Running over the same old ground
+`C`{.c} what have we found?
+The same old `Am`{.a} fears
 Wish you were `G`{.g} here
 
 ## Outro
 
-`G`{.g} `Em`{.e}  
-`G`{.g} `Em`{.e}  
-`G`{.g} `Em`{.e}  
-`A`{.a} `Em`{.e}  
+`G`{.g} `Em`{.e}
+`G`{.g} `Em`{.e}
+`G`{.g} `Em`{.e}
+`A`{.a} `Em`{.e}
 `A`{.a} `G`{.g}
 
 _(Fade out slowly)_

--- a/build
+++ b/build
@@ -6,6 +6,7 @@ require 'json'
 require 'net/http'
 
 ENV['LANG'] = 'en_US.UTF-8'
+Encoding.default_external = Encoding::UTF_8
 
 Dir.chdir(__dir__)
 
@@ -31,7 +32,7 @@ def step(emoji, label)
 end
 
 def pandoc(output:, theme:)
-  result = `pandoc -t revealjs -s -o #{output} all-songs.md --slide-level=2 --syntax-highlighting=none --toc --toc-depth=1 -V theme=#{theme} -V progress=false -V revealjs-url=./style/revealjs 2>&1`
+  result = `pandoc -f markdown+hard_line_breaks -t revealjs -s -o #{output} all-songs.md --slide-level=2 --syntax-highlighting=none --toc --toc-depth=1 -V theme=#{theme} -V progress=false -V revealjs-url=./style/revealjs 2>&1`
   print result unless result.strip.empty?
 end
 
@@ -42,6 +43,7 @@ song_files = Dir["content/songs/*.md"].sort
 puts "🎵 Songs (#{song_files.size}):"
 song_files.each { |f| puts "   🎶 #{File.basename(f, ".md")}" }
 puts
+
 
 songs_md = song_files.map do |file|
   File.read(file).gsub(/\[([A-Z][^\]]*)\]([^\(])/) { "`#{$1}`{.#{$1[0].downcase}}#{$2}" }

--- a/content/Introduction.md
+++ b/content/Introduction.md
@@ -2,7 +2,7 @@
 
 ## Welcome
 
-This is a collection of my favourite guitar songs.  
+This is a collection of my favourite guitar songs.
 🎤😍🎸🔥 Find it on [songs.josh.ch](https://songs.josh.ch).
 
 - Use arrow keys or swipe gestures to navigate

--- a/content/Introduction.md
+++ b/content/Introduction.md
@@ -33,10 +33,11 @@ G |3 2 0 0 0 3|      Gm |3 x 0 3 3 3|      G7 |3 2 3 0 0 1|
 
 Variations:
 
-  |E A D G B e|
-  |-----------|
-F |0 0 3 2 1 1| Easier, no barre
-G |3 x 0 0 0 1| Easier, A string muted
+   |E A D G B e|
+   |-----------|
+F  |0 0 3 2 1 1| Easier, no barre
+G  |3 x 0 0 0 1| Easier, A string muted
+Gm |3 x 0 0 1 1| Easier, A string muted
 
 Feeling bored of major chords (A, D, E...)?
   => Try playing a seventh chord instead (A7, D7, E7...)!

--- a/content/legacy-songs/50 ways to leave your lover (Paul Simon).md
+++ b/content/legacy-songs/50 ways to leave your lover (Paul Simon).md
@@ -32,34 +32,34 @@ E |--------|  |-------|
 
 ## Intro
 
-[Em(2)] [D6] [CM7] [Cm6] [B7(2)]  
+[Em(2)] [D6] [CM7] [Cm6] [B7(2)]
 [Em] [Am] [Cdim7] [B7(3)] [B7(4)]
 
-[Em(3)] [D6] [CM7] [Cm6] [B7(2)]  
+[Em(3)] [D6] [CM7] [Cm6] [B7(2)]
 [Em] [Am] [Em]
 
 ## Verse 1
 
-[Em(2)] "The problem is [D6] all inside your head"  
-[CM7] she said to me [Cm6] [B7(2)]  
-[Em] "the answer is ea[Am]sy if you  
+[Em(2)] "The problem is [D6] all inside your head"
+[CM7] she said to me [Cm6] [B7(2)]
+[Em] "the answer is ea[Am]sy if you
 [Cdim7] take it logic'lly. [B7(3)] [B7(4)]
 
-[Em(3)] I'd like to help [D6] you in your  
-[CM7] struggle to be free [Cm6] [B7(2)]  
-there must be [Em] fifty ways [Am]  
+[Em(3)] I'd like to help [D6] you in your
+[CM7] struggle to be free [Cm6] [B7(2)]
+there must be [Em] fifty ways [Am]
 to leave your lov[Em]er."
 
 ---
 
-[Em(2)] She said, "It's [D6] really not my  
-[CM7] habit to intrude [Cm6] [B7(2)]  
-Further[Em]more I hope my mea[Am]ning won't be  
+[Em(2)] She said, "It's [D6] really not my
+[CM7] habit to intrude [Cm6] [B7(2)]
+Further[Em]more I hope my mea[Am]ning won't be
 lost [Cdim7] or misconstrued. [B7(3)] [B7(4)]
 
-But I'll re[Em(3)]peat myself [D6] at the  
-[CM7] risk of being crude [Cm6] there [B7(2)] must be  
-[Em] fifty ways [Am] to leave your lov[Em]er  
+But I'll re[Em(3)]peat myself [D6] at the
+[CM7] risk of being crude [Cm6] there [B7(2)] must be
+[Em] fifty ways [Am] to leave your lov[Em]er
 [Em] fifty ways [Am7] to leave your lov[Em]er
 
 _(Riff)_
@@ -82,29 +82,29 @@ _(x2)_
 
 ## Verse 2
 
-[Em(2)] She said, "It [D6] grieves me so to  
-[CM7] see you in such pain [Cm6] [B7(2)]  
-oh I wish [Em] there's somethin' [Am] I could do to  
+[Em(2)] She said, "It [D6] grieves me so to
+[CM7] see you in such pain [Cm6] [B7(2)]
+oh I wish [Em] there's somethin' [Am] I could do to
 [Cdim7] make you smile again." [B7(3)] And I said [B7(4)]
 
-"I a[Em(3)]ppreciate that, [D6] and  
-[CM7] could you please explain [Cm6] about [B7(2)]  
+"I a[Em(3)]ppreciate that, [D6] and
+[CM7] could you please explain [Cm6] about [B7(2)]
 the fifty wa[Em]ys?" [Am] [Em]
 
 ---
 
-[Em(2)] She said, "Why [D6] don't we both just  
-[CM7] sleep on it tonight [Cm6] [B7(2)]  
-I be[Em]lieve that in the mor[Am]ning  
+[Em(2)] She said, "Why [D6] don't we both just
+[CM7] sleep on it tonight [Cm6] [B7(2)]
+I be[Em]lieve that in the mor[Am]ning
 you'll be[Cdim7]gin to see the light. [B7(3)] And then [B7(4)]
 
-she [Em(3)] kissed me and I [D6] realized she  
-[CM7] probably was right [Cm6] there [B7(2)] must be  
-[Em] fifty ways [Am] to leave your lov[Em]er  
+she [Em(3)] kissed me and I [D6] realized she
+[CM7] probably was right [Cm6] there [B7(2)] must be
+[Em] fifty ways [Am] to leave your lov[Em]er
 [Em] fifty ways [Am7] to leave your lov[Em]er
 
 _(Riff)_
- 
+
 ## Chorus
 
 _(Rhythm guitar)_

--- a/content/legacy-songs/911 (Wyclef Jean feat. Mary J. Blige).md
+++ b/content/legacy-songs/911 (Wyclef Jean feat. Mary J. Blige).md
@@ -2,86 +2,86 @@
 
 ## Intro (Wyclef)
 
-[Am] Yo, what's up, this is Wyclef with Mary J. [Em]  
-[Dm] I serenade the girls with my accoustic guitar  
+[Am] Yo, what's up, this is Wyclef with Mary J. [Em]
+[Dm] I serenade the girls with my accoustic guitar
 [C] You know what I'm sayin'? [Em] _(Mary: Uuuuuh)_
 
-[Am] Yo, fellas havin' problems with the chicks? [Em]  
-[Dm] I want you right now to turn the lights down low  
-[C] Pull your girl up next to you  
+[Am] Yo, fellas havin' problems with the chicks? [Em]
+[Dm] I want you right now to turn the lights down low
+[C] Pull your girl up next to you
 [Em] I want you to sing this to her
 
 ## Verse 1 (Wyclef)
 
-If death comes for me to[Am]night, girl [Em]  
-I want you to know that I [Dm] loved you [C] [Em]  
-And no mat[Am]ter how tough I wouldn't dare [Em]  
+If death comes for me to[Am]night, girl [Em]
+I want you to know that I [Dm] loved you [C] [Em]
+And no mat[Am]ter how tough I wouldn't dare [Em]
 Only to you I would re[Dm]veal my tears [C] [Em]
 
-So tell the [Am] police I ain't home tonight [Em]  
-Messin' around with you is gonna [Dm] get me life [C] [Em]  
-But when I [Am] look into your eyes [Em]  
+So tell the [Am] police I ain't home tonight [Em]
+Messin' around with you is gonna [Dm] get me life [C] [Em]
+But when I [Am] look into your eyes [Em]
 (Man) You're worth that [Dm] sacrafice [C] [Em]
 
 ## Bridge (Wyclef)
 
-If [Am] this is the kind of love  
-That my mom used to [Em] warn me about  
-Man, I'm in [Dm] trouble  
+If [Am] this is the kind of love
+That my mom used to [Em] warn me about
+Man, I'm in [Dm] trouble
 I'm in real big [C] trouble [Em]
 
-If [Am] this is the kind of love  
-That the old folks used to [Em] warn me about  
-Man, I'm in [Dm] trouble  
-I'm in real big [C] trouble [Em]  
+If [Am] this is the kind of love
+That the old folks used to [Em] warn me about
+Man, I'm in [Dm] trouble
+I'm in real big [C] trouble [Em]
 
 (I need y'all to do me a favor)
 
 ## Chorus (Wyclef)
 
-[Am] Someone please call 91[Em]1 (pick up the phone yo)  
-[Dm] Tell them I just been shot [C] down  
-and the [Em] bullet's in my [Am] heart  
+[Am] Someone please call 91[Em]1 (pick up the phone yo)
+[Dm] Tell them I just been shot [C] down
+and the [Em] bullet's in my [Am] heart
 And it's piercin through my [Em] soul (I'm losin blood yo)
 [Dm] Feel my body gettin' [C] cold [Em]
 
-[Am] Someone please call 91[Em]1 (pick up the phone yo)  
-[Dm] The alleged assai[C]lant, is [Em] five foot [Am] one  
-and she shot me through my [Em] soul [Dm]  
+[Am] Someone please call 91[Em]1 (pick up the phone yo)
+[Dm] The alleged assai[C]lant, is [Em] five foot [Am] one
+and she shot me through my [Em] soul [Dm]
 Feel my body gettin [C] cold [Em] (_Mary:_ so cold)
 
 ## Verse 2 (Mary)
 
-Some[Am]times I feel like I'm a prisoner [Em]  
-I think I'm trapped here [Dm] for a while [C] yeah [Em] yeah  
-(_Wyclef:_ but I'm always right here with you girl)  
-And [Am] every breath I fight to take [Em]  
+Some[Am]times I feel like I'm a prisoner [Em]
+I think I'm trapped here [Dm] for a while [C] yeah [Em] yeah
+(_Wyclef:_ but I'm always right here with you girl)
+And [Am] every breath I fight to take [Em]
 Is as hard as these [Dm] four walls I wanna break [C] [Em]
 
-I [Am] told the cops you wasn't here tonight [Em] (_Wyclef:_ right)  
-Messin' around with me is gonna [Dm] get you life  
-[C] Oh yeah, [Em] yeah  
-But ev[Am]erytime I look into your eyes [Em]  
+I [Am] told the cops you wasn't here tonight [Em] (_Wyclef:_ right)
+Messin' around with me is gonna [Dm] get you life
+[C] Oh yeah, [Em] yeah
+But ev[Am]erytime I look into your eyes [Em]
 Then it's worth the [Dm] sacrifice [C] [Em]
 
 ## Bridge (Wyclef)
 
-If [Am] this is the kind of love  
-That your mom used to [Em] warn you about  
-Mary, your are in [Dm] trouble (I am in real Big Trouble)  
+If [Am] this is the kind of love
+That your mom used to [Em] warn you about
+Mary, your are in [Dm] trouble (I am in real Big Trouble)
 You're in real big [C] trouble [Em] (_Mary:_ Lord Knows I am in trouble)
 
-If [Am] this is the kind of love  
-That the old folks used to [Em] warn me about  
-(everyday, everynight) I'm in [Dm] trouble  
-I'm in real big [C] trouble  
+If [Am] this is the kind of love
+That the old folks used to [Em] warn me about
+(everyday, everynight) I'm in [Dm] trouble
+I'm in real big [C] trouble
 [Em] You got anything to say, girl?
- 
+
 ## Chorus (Mary)
 
-[Am] Someone please call 91[Em]1 (_Wyclef:_ pick up the phone yo)  
-[Dm] Tell them I just ~~been~~ **got** shot [C] down  
-~~and the bullet's in my heart~~  
+[Am] Someone please call 91[Em]1 (_Wyclef:_ pick up the phone yo)
+[Dm] Tell them I just ~~been~~ **got** shot [C] down
+~~and the bullet's in my heart~~
 **(Tell them I [Em] just got shot down)**
 
 [Am] And it's piercin through my [Em] soul (_Wyclef:_ I'm losin blood yo)
@@ -89,9 +89,9 @@ I'm in real big [C] trouble
 
 ## Chorus (Wyclef)
 
-[Am] Someone please call 91[Em]1 (can you do that for me)  
-[Dm] The alleged assai[C]lant, ~~is~~ **was** [Em] five foot [Am] one  
-and she shot me through my [Em] soul (_Mary:_ and he shot me through my heart) [Dm]  
+[Am] Someone please call 91[Em]1 (can you do that for me)
+[Dm] The alleged assai[C]lant, ~~is~~ **was** [Em] five foot [Am] one
+and she shot me through my [Em] soul (_Mary:_ and he shot me through my heart) [Dm]
 Feel my body gettin [C] cold [Em]
 
 (_Mary:_ He didn't care, he didn't worry, he didn't wonder...)
@@ -102,7 +102,7 @@ Feel my body gettin [C] cold [Em]
 
 (_Wyclef:_ I'm feelin you girl, I understand)
 
-(_Mary:_ And you're doin' what you're doin', would you do it  
+(_Mary:_ And you're doin' what you're doin', would you do it
 and do it and do it and do it for me...)
 
 ## Resources

--- a/content/legacy-songs/Alles aus Liebe (Die Toten Hosen).md
+++ b/content/legacy-songs/Alles aus Liebe (Die Toten Hosen).md
@@ -2,54 +2,54 @@
 
 ## Verse 1
 
-Ich [C] würde dir gern sagen, wie [Am] sehr ich dich mag  
-Und wa[F]rum ich nur noch an dich [G] denken kann.  
-Ich [C] fühl mich wie verhext und in Ge[Am]fangenschaft  
+Ich [C] würde dir gern sagen, wie [Am] sehr ich dich mag
+Und wa[F]rum ich nur noch an dich [G] denken kann.
+Ich [C] fühl mich wie verhext und in Ge[Am]fangenschaft
 Und [F] du allein trägst [G] Schuld daran.
 
-[Am] Worte sind da[F]für zu schwach  
-Ich be[G]fürchte du glaubst mir [E] nicht.  
-Mir kommt es [Am] vor als ob mich [F] jemand warnt:  
+[Am] Worte sind da[F]für zu schwach
+Ich be[G]fürchte du glaubst mir [E] nicht.
+Mir kommt es [Am] vor als ob mich [F] jemand warnt:
 Dieses [G] Märchen wird nicht gut ausgehen.
 
 ---
 
-Es ist die [C] Eifersucht, die [Am] mich auffrisst  
+Es ist die [C] Eifersucht, die [Am] mich auffrisst
 Immer [F] dann wenn du nicht in meiner [G] Nähe bist.
-Von [C] Dr. Jekyll werd ich zu [Am] Mr. Hide  
+Von [C] Dr. Jekyll werd ich zu [Am] Mr. Hide
 Ich kann [F] nichts dagegen tun plötzlich [G] ist es soweit.
 
 ## Pre-Chorus
 
-Ich bin [Am] kurz davor, [F] durchzudrehen  
+Ich bin [Am] kurz davor, [F] durchzudrehen
 Aus [G] Angst dich zu ver[E]lieren.
-Und [Am] dass uns jetzt kein [F] Unglück geschieht  
+Und [Am] dass uns jetzt kein [F] Unglück geschieht
 Dafür [G] kann ich nicht garantieren.
 
 ## Chorus
 
-Und alles [C] nur, [E] weil ich dich [Am] liebe  
-[G] Und ich nicht [C] weiß wie ich's beweisen [G] soll.  
-Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist  
+Und alles [C] nur, [E] weil ich dich [Am] liebe
+[G] Und ich nicht [C] weiß wie ich's beweisen [G] soll.
+Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist
 Und [C] bringe mich [G] für dich [C] um.
 
 ## Verse 2
 
-So[C]bald deine Laune etwas [Am] schlechter ist  
-[F] Bild ich mir gleich ein, dass du mich [G] nicht mehr Willst.  
-Ich [C] sterbe beim Ge[Am]danken daran  
+So[C]bald deine Laune etwas [Am] schlechter ist
+[F] Bild ich mir gleich ein, dass du mich [G] nicht mehr Willst.
+Ich [C] sterbe beim Ge[Am]danken daran
 Dass [F] ich dich nicht für immer [G] halten kann.
-                                                             
-Auf [Am] einmal brennt ein [F] Feuer in mir  
+
+Auf [Am] einmal brennt ein [F] Feuer in mir
 Und der [G] Rest der Welt wird [E] schwarz.
-Ich [Am] spür wie unsere [F] Zeit verrinnt  
+Ich [Am] spür wie unsere [F] Zeit verrinnt
 Wir [G] nähern uns dem letzten Akt.
 
 ## Chorus
 
-Und alles [C] nur, [E] weil ich dich [Am] liebe  
-[G] Und ich nicht [C] weiß wie ich's beweisen [G] soll.  
-Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist  
+Und alles [C] nur, [E] weil ich dich [Am] liebe
+[G] Und ich nicht [C] weiß wie ich's beweisen [G] soll.
+Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist
 Und [C] bringe mich [G] für dich [C] um.
 
 ## Bridge
@@ -58,21 +58,21 @@ _(Instrumental)_
 
 ## Pre-Chorus
 
-Ich bin [Am] kurz davor, [F] durchzudrehen  
+Ich bin [Am] kurz davor, [F] durchzudrehen
 Aus [G] Angst dich zu ver[E]lieren.
-Und [Am] dass uns jetzt kein [F] Unglück geschieht  
+Und [Am] dass uns jetzt kein [F] Unglück geschieht
 Dafür [G] kann ich nicht garantieren.
 
 ## Chorus
 
-Und alles [C] nur, [E] weil ich dich [Am] liebe  
-[G] Und ich nicht [C] weiß wie ich's beweisen [G] soll.  
-Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist  
+Und alles [C] nur, [E] weil ich dich [Am] liebe
+[G] Und ich nicht [C] weiß wie ich's beweisen [G] soll.
+Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist
 Und [C] bringe mich [G] für dich [C] um.
 
 _(x2)_
 
-Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist  
+Komm ich [C] zeig dir wie [E] gross meine [Am] Liebe [F] ist
 Und [C] bringe uns [G] beide [C] um.
 
 ## Resources

--- a/content/legacy-songs/Buenas tardes amigo (Ween).md
+++ b/content/legacy-songs/Buenas tardes amigo (Ween).md
@@ -22,57 +22,57 @@ Dsus4 |x x 0 2 3 3| Just add pinky to Dm
 
 _(🎸 One strum per bar)_
 
-[Am] Buenos [G] Tardes, A[Am]migo  
-[Am] Hola, [G] my good [Am] friend  
-[Am] Cinco de [G] Mayo's on [Dm] Tuesday [Dsus4] [Dm]  
+[Am] Buenos [G] Tardes, A[Am]migo
+[Am] Hola, [G] my good [Am] friend
+[Am] Cinco de [G] Mayo's on [Dm] Tuesday [Dsus4] [Dm]
 And I'd [Am] hope we'd [G] see each other a[Am]gain
 
 ## Verse 1
 
 _(🎸 Start strumming pattern)_
 
-[Am] You killed my [G] brother last [Am] winter  
-You [Am] shot him [G] three times in the back [Am]  
-In the night [Am] I still [G] hear mama [Dm] weeping [Dsus4] [Dm]  
+[Am] You killed my [G] brother last [Am] winter
+You [Am] shot him [G] three times in the back [Am]
+In the night [Am] I still [G] hear mama [Dm] weeping [Dsus4] [Dm]
 Oh [Am] mama still [G] dresses in [Am] black
 
 ## Verse 2
 
-I [Am] looked at [G] every fi[Am]esta  
-For [Am] you I [G] wanted to [Am] greet  
-[Am] Maybe I'd [G] sell you a [Dm] chicken [Dsus4] [Dm]  
+I [Am] looked at [G] every fi[Am]esta
+For [Am] you I [G] wanted to [Am] greet
+[Am] Maybe I'd [G] sell you a [Dm] chicken [Dsus4] [Dm]
 With [Am] poison inter[G]laced with the meat [Am]
 
 ## Verse 3
 
-[Am] You - you [G] look like my [Am] brother  
-[Am] Mama [G] loved him the best [Am]  
-[Am] He was head [G] honcho with the [Dm] ladies [Dsus4] [Dm]  
+[Am] You - you [G] look like my [Am] brother
+[Am] Mama [G] loved him the best [Am]
+[Am] He was head [G] honcho with the [Dm] ladies [Dsus4] [Dm]
 [Am] Mama always [G] said he was [Am] blessed
 
 ## Verse 4
 
 _(Add 🥁)_
 
-The [Am] village all [G] gathered a[Am]round him  
-They [Am] could'nt be[G]lieve what they [Am] saw  
-I [Am] said it was [G] you that had [Dm] killed him [Dsus4] [Dm]  
+The [Am] village all [G] gathered a[Am]round him
+They [Am] could'nt be[G]lieve what they [Am] saw
+I [Am] said it was [G] you that had [Dm] killed him [Dsus4] [Dm]
 And then I'd [Am] find you and [G] upstand the [Am] law
 
 ## Verse 5
 
-The [Am] people of the [G] village be[Am]lieved me  
-[Am] Mama she [G] wanted re[Am]venge  
-I [Am] told her that I [G] see that she was [Dm] honored [Dsus4] [Dm]  
+The [Am] people of the [G] village be[Am]lieved me
+[Am] Mama she [G] wanted re[Am]venge
+I [Am] told her that I [G] see that she was [Dm] honored [Dsus4] [Dm]
 I'd [Am] find you and [G] put you to death! [Am]
 
 ## Solo
 
 _(Intense 🎸 and 🥁)_
 
-[Am] [G] [Am]  
-[Am] [G] [Am]  
-[Am] [G] [Dm] [Dsus4] [Dm]    
+[Am] [G] [Am]
+[Am] [G] [Am]
+[Am] [G] [Dm] [Dsus4] [Dm]
 [Am] [G] [Am]
 
 _(x2)_
@@ -81,21 +81,21 @@ _(x2)_
 
 _(Soft 🎸 and 🥁)_
 
-So [Am] now, [G] now that I [Am] found you  
-On [Am] this such a [G] joyous [Am] day  
-I [Am] tell you: it was [G] me who [Dm] killed him [Dsus4] [Dm]  
+So [Am] now, [G] now that I [Am] found you
+On [Am] this such a [G] joyous [Am] day
+I [Am] tell you: it was [G] me who [Dm] killed him [Dsus4] [Dm]
 But the [Am] truth I'll [G] never have to [Am] say
 
 ## Outro
 
 _(Fading 🎸 and 🥁)_
 
-[Am] Buenos [G] Tardes, A[Am]migo  
-[Am] Hola, [G] my good [Am] friend  
-[Am] Cinco de [G] Mayo's on [Dm] Tuesday [Dsus4] [Dm]  
+[Am] Buenos [G] Tardes, A[Am]migo
+[Am] Hola, [G] my good [Am] friend
+[Am] Cinco de [G] Mayo's on [Dm] Tuesday [Dsus4] [Dm]
 And I'd [Am] hope we'd [G] see each other a[Am]gain
 
-Yes I [Am] hoped we'd [G] see each other  
+Yes I [Am] hoped we'd [G] see each other
 a[Am]gain _(Repeat and fade)_
 
 ## Resources

--- a/content/legacy-songs/Fanpost (Clueso).md
+++ b/content/legacy-songs/Fanpost (Clueso).md
@@ -2,62 +2,62 @@
 
 ## Intro
 
-[G] [Em] _(x2)_  
+[G] [Em] _(x2)_
 [G] [Em] C
 
 Hey [Am] mmmh [C] mmmh... [D] [Em] [C]
 
 ## Verse 1
 
-[G] Was da so ab und zu [Em] zwischen uns läuft  
-ist wirklich [G] schwer zu beschreiben  
+[G] Was da so ab und zu [Em] zwischen uns läuft
+ist wirklich [G] schwer zu beschreiben
 in einem [Em] Text.
 
-Nur wer bei [G] deinem Blick mal kurz  
-zwischen den [Em] Zeilen liest  
+Nur wer bei [G] deinem Blick mal kurz
+zwischen den [Em] Zeilen liest
 Ist völlig [C] hin, hin und weg und perplex
 
 ## Chorus
 
-[Am] Egal mit wem du [C] sonst noch rumhängst  
-Hey Lady, [D] ich [Em] bin dein grösster [C] Fan  
-[Am] Egal wer sonst so deinen [C] Namen noch nennt  
+[Am] Egal mit wem du [C] sonst noch rumhängst
+Hey Lady, [D] ich [Em] bin dein grösster [C] Fan
+[Am] Egal wer sonst so deinen [C] Namen noch nennt
 Hey Baby, [D] ich [Em] bin dein grösster [C] Fan
 
 ## Verse 2
 
-[G] Ein Schritt nach vorn [Em] kein Schritt zurück  
-Auf dem [G] Platz wo wir uns immer [Em] sehn  
-[G] N' Stück von dir ist wie 'n [Em] Stück vom Glück  
+[G] Ein Schritt nach vorn [Em] kein Schritt zurück
+Auf dem [G] Platz wo wir uns immer [Em] sehn
+[G] N' Stück von dir ist wie 'n [Em] Stück vom Glück
 Die Sonne [C] will einfach nicht untergehn
 
 ## Chorus
 
-[Am] Egal mit wem du [C] sonst noch rumhängst  
-Hey Lady, [D] ich [Em] bin dein grösster [C] Fan  
-[Am] Egal wer sonst so deinen [C] Namen noch nennt  
+[Am] Egal mit wem du [C] sonst noch rumhängst
+Hey Lady, [D] ich [Em] bin dein grösster [C] Fan
+[Am] Egal wer sonst so deinen [C] Namen noch nennt
 Hey Baby, [D] ich [Em] bin dein grösster [C] Fan
 
 ## Instrumental
 
-[G] U-huh! [Em] U-huh! _(x2)_  
+[G] U-huh! [Em] U-huh! _(x2)_
 [G] [Em] C
 
 ## Bridge
 
-[Am] Die kleinen Momente mit dir  
+[Am] Die kleinen Momente mit dir
 lassen nicht mehr [C] los
 
 [G] [Em] _(x3)_
 
-[C] Würd ja gern wissen wie du das gemacht hast  
+[C] Würd ja gern wissen wie du das gemacht hast
 Keine Ahnung wie du das geschafft hast
 
 ## Chorus
 
-[Am] Egal mit wem du [C] sonst noch rumhängst  
-Hey Lady, [D] ich [Em] bin dein grösster [C] Fan  
-[Am] Egal wer sonst so deinen [C] Namen noch nennt  
+[Am] Egal mit wem du [C] sonst noch rumhängst
+Hey Lady, [D] ich [Em] bin dein grösster [C] Fan
+[Am] Egal wer sonst so deinen [C] Namen noch nennt
 Hey Baby, [D] ich [Em] bin dein grösster [C] Fan
 
 ## Outro

--- a/content/legacy-songs/Gimme hope, Jo'anna (Eddy Grant).md
+++ b/content/legacy-songs/Gimme hope, Jo'anna (Eddy Grant).md
@@ -2,58 +2,58 @@
 
 ## Intro
 
-[A] [D] [A] [D]  
+[A] [D] [A] [D]
 [A] [D] [A] [E]
 [A]
 
 ## Verse 1
 
-Well Jo[A]'anna she runs a coun[D]try  
-She runs in [A] Durban and the Transvaal [E]  
-She makes a [A] few of her people ha[D]ppy, oh [Dm]  
+Well Jo[A]'anna she runs a coun[D]try
+She runs in [A] Durban and the Transvaal [E]
+She makes a [A] few of her people ha[D]ppy, oh [Dm]
 She don't [A] care about the [E] rest at all [A]
 
 ## Verse 2
 
-She's got a [A] system they call apart[D]heid  
-It keeps a [A] brother in a subjec[E]tion  
-But maybe [A] pressure can make Jo'[D]anna see [Dm]  
+She's got a [A] system they call apart[D]heid
+It keeps a [A] brother in a subjec[E]tion
+But maybe [A] pressure can make Jo'[D]anna see [Dm]
 How every[A]body could a [E] live as [A] one, oh [E]
 
 ## Chorus
 
-Gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
-Gimme [A] hope, Jo'anna  
+Gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
+Gimme [A] hope, Jo'anna
 'Fore the [E] morning come
 
-Oh gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
+Oh gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
 [A] Hope before the [E] morning come [A]
 
 ## Verse 3
 
-I hear she [A] makes all the golden mo[D]ney  
-To buy new [A] weapons, any shape of guns [E]  
-While every [A] mother in black So[D]weto fears [Dm]  
+I hear she [A] makes all the golden mo[D]ney
+To buy new [A] weapons, any shape of guns [E]
+While every [A] mother in black So[D]weto fears [Dm]
 The [A] killing of an[E]other son [A]
 
 ## Verse 4
 
-Sneakin' a[A]cross all the neighbors' bor[D]ders  
-Now and a[A]gain having little fun [E]  
-She doesn't [A] care if the fun and games [D] she play [Dm]  
+Sneakin' a[A]cross all the neighbors' bor[D]ders
+Now and a[A]gain having little fun [E]
+She doesn't [A] care if the fun and games [D] she play [Dm]
 is [A] dang'rous to [E] ev'ryone, [A] oh [E]
 
 ## Chorus
 
-Gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
-Gimme [A] hope, Jo'anna  
+Gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
+Gimme [A] hope, Jo'anna
 'Fore the [E] morning come
 
-Oh gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
+Oh gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
 [A] Hope before the [E] morning come [A]
 
 ## Instrumental
@@ -63,52 +63,52 @@ Gimme [D] hope, Jo'anna
 
 ## Verse 5
 
-She's got su[A]pporters in high up pla[D]ces  
-Who turn their [A] heads to the city sun [E]  
-Jo'anna [A] give them the fancy mo[D]ney, oh [Dm]  
+She's got su[A]pporters in high up pla[D]ces
+Who turn their [A] heads to the city sun [E]
+Jo'anna [A] give them the fancy mo[D]ney, oh [Dm]
 to [A] tempt any[E]one who'd [A] come
 
 ## Verse 6
 
-She even [A] knows how to swing o[D]pinion  
-In every [A] magazine and the journals [E]  
-For every [A] bad move that this Jo'[D]anna makes [Dm]  
+She even [A] knows how to swing o[D]pinion
+In every [A] magazine and the journals [E]
+For every [A] bad move that this Jo'[D]anna makes [Dm]
 They got a [A] good expla[E]nation, [A] oh [E]
 
 ## Chorus
 
-Gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
-Gimme [A] hope, Jo'anna  
+Gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
+Gimme [A] hope, Jo'anna
 'Fore the [E] morning come
 
-Oh gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
+Oh gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
 [A] Hope before the [E] morning come [A]
 
 ## Verse 7
 
-Even the [A] preacher who works for Je[D]sus  
-The Arch[A]bishop who's a peaceful man [E]  
-Together [A] say that the freedom fi[D]ghters will [Dm]  
+Even the [A] preacher who works for Je[D]sus
+The Arch[A]bishop who's a peaceful man [E]
+Together [A] say that the freedom fi[D]ghters will [Dm]
 [A]overcome the very [E] strong [A]
 
 ## Verse 8
 
-I want to [A] know if you're blind Jo'[D]anna  
-If you [A] want to hear the sound of drums [E]  
-Can't you [A] see that the tide is [D] turning, oh [Dm]  
+I want to [A] know if you're blind Jo'[D]anna
+If you [A] want to hear the sound of drums [E]
+Can't you [A] see that the tide is [D] turning, oh [Dm]
 don't make me [A] wait till the [E] morning [A] come, oh [E]
 
 ## Chorus
 
-Gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
-Gimme [A] hope, Jo'anna  
+Gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
+Gimme [A] hope, Jo'anna
 'Fore the [E] morning come
 
-Oh gimme [A] hope, Jo'anna  
-Gimme [D] hope, Jo'anna  
+Oh gimme [A] hope, Jo'anna
+Gimme [D] hope, Jo'anna
 [A] Hope before the [E] morning come [A]
 
 _(Repeat and fade)_

--- a/content/legacy-songs/I'm your man (Leonard Cohen).md
+++ b/content/legacy-songs/I'm your man (Leonard Cohen).md
@@ -14,77 +14,77 @@ F#m |2=4=4=2=2=2|
 
 ## Verse 1
 
-If you want a [Em] lover  
+If you want a [Em] lover
 I'll do anything you [D] ask me to.
-And if you want an[Em]other kind of love  
+And if you want an[Em]other kind of love
 I'll wear a [D] mask for you.
 
-If you want a [Bm] partner take my hand  
-or if you want to [G] strike me down in anger  
-[A] here I stand  
+If you want a [Bm] partner take my hand
+or if you want to [G] strike me down in anger
+[A] here I stand
 I'm your man [Bm]
 
 ## Verse 2
 
-If you want a [Em] boxer  
-I will step into the [D] ring for you  
-And if you want a [Em] doctor  
+If you want a [Em] boxer
+I will step into the [D] ring for you
+And if you want a [Em] doctor
 I'll examine every [D] inch of you
 
-If you want a [Bm] driver climb inside  
-Or if you want a [G] take me for a ride,  
-You [A] know you can  
+If you want a [Bm] driver climb inside
+Or if you want a [G] take me for a ride,
+You [A] know you can
 I'm your man [Bm]
 
 ## Bridge
 
-Ah, the [D] moon's too bright  
-the [G] chain's too tight  
+Ah, the [D] moon's too bright
+the [G] chain's too tight
 the [A] beast won't go to [D] sleep
 
-I've been [F#m] running through  
-these promises to you  
+I've been [F#m] running through
+these promises to you
 that I made [Bm] and I could not keep
 
 ---
 
-Ah, but a [F#] man never got a women back  
-not by [Bm] begging on his knees  
-Or I'd [G] crawl to you, baby  
+Ah, but a [F#] man never got a women back
+not by [Bm] begging on his knees
+Or I'd [G] crawl to you, baby
 and I'd [F#] fall at your feet
 
-And I'd [G] howl at your beauty  
-like a [F#] dog in heat  
-And I'd [G] claw at your heart  
+And I'd [G] howl at your beauty
+like a [F#] dog in heat
+And I'd [G] claw at your heart
 and I'd [E] tear at your sheet
 
-I'd say: please [A]  
+I'd say: please [A]
 please, I'm your man [Bm]
 
 ## Verse 3
 
-And if you've [Em] got to sleep a moment  
-on the road, I will [D] steer for you  
-And if you want to [Em] walk the street alone  
+And if you've [Em] got to sleep a moment
+on the road, I will [D] steer for you
+And if you want to [Em] walk the street alone
 I'll disa[D]ppear for you
 
-If you want a [Bm] father for your child  
-or only want to [G] walk with me  
-a while across the [A] sand  
+If you want a [Bm] father for your child
+or only want to [G] walk with me
+a while across the [A] sand
 I'm your man [Bm]
 
 ## Verse 1
 
 _(Fade out slowly)_
 
-If you want a [Em] lover  
+If you want a [Em] lover
 I'll do anything you [D] ask me to.
-And if you want an[Em]other kind of love  
+And if you want an[Em]other kind of love
 I'll wear a [D] mask for you.
 
-If you want a [Bm] driver climb inside  
-Or if you want a [G] take me for a ride,  
-You [A] know you can  
+If you want a [Bm] driver climb inside
+Or if you want a [G] take me for a ride,
+You [A] know you can
 I'm your man [Bm]
 
 ## Resources

--- a/content/legacy-songs/King of the road (Roger Miller).md
+++ b/content/legacy-songs/King of the road (Roger Miller).md
@@ -1,51 +1,51 @@
 # King of the road (Roger Miller)
- 
+
 ## Chorus
 
-[B] Trailer for [E] sale or rent  
-[F#] rooms to let [B] fifty cents  
-[B] No phone, no pool, [E] no pets  
+[B] Trailer for [E] sale or rent
+[F#] rooms to let [B] fifty cents
+[B] No phone, no pool, [E] no pets
 [F#] I ain't got no cigarettes, ah but
 
-[B] Two hours of [E] pushing broom buys an  
-[F#] eight by twelve [B] fourbit room  
+[B] Two hours of [E] pushing broom buys an
+[F#] eight by twelve [B] fourbit room
 I'm a [B] man of [E] means by no means
 
 [F#] King of the Road
- 
+
 ## Verse 1
 
-[B] Third box car [E] midnight train  
-[F#] destination [B] Bangor, Maine  
-[B] Old worn out [E] suit and shoes  
+[B] Third box car [E] midnight train
+[F#] destination [B] Bangor, Maine
+[B] Old worn out [E] suit and shoes
 [F#] I don't pay no union dues
 
-I smoke [B] old stogies [E] I have found  
-[F#] short, but not too [B] big around  
+I smoke [B] old stogies [E] I have found
+[F#] short, but not too [B] big around
 I'm a [B] man of [E] means by no means
 
 [F#] King of the Road
 
 ## Verse 2
 
-I know [C] every engineer on [F] every train  
-[G] All of the children and [C] all of their names  
+I know [C] every engineer on [F] every train
+[G] All of the children and [C] all of their names
 And [C] every handout in [F] every town
 
-And every [G] lock that ain't locked when  
+And every [G] lock that ain't locked when
 No one's around
 
 I sing...
 
 ## Chorus
 
-[C] Trailer for [F] sale or rent  
-[G] rooms to let [C] fifty cents  
-[C] No phone, no pool, [F] no pets  
+[C] Trailer for [F] sale or rent
+[G] rooms to let [C] fifty cents
+[C] No phone, no pool, [F] no pets
 [G] I ain't got no cigarettes, ah but
 
-[C] Two hours of [F] pushing broom buys an  
-[G] eight by twelve [C] fourbit room  
+[C] Two hours of [F] pushing broom buys an
+[G] eight by twelve [C] fourbit room
 I'm a [C] man of [F] means by no means
 
 [G] King of the Road
@@ -54,9 +54,9 @@ I'm a [C] man of [F] means by no means
 
 _(Fade out)_
 
-[C] Trailer for [F] sale or rent  
-[G] rooms to let [C] fifty cents  
-[C] No phone, no pool, [F] no pets  
+[C] Trailer for [F] sale or rent
+[G] rooms to let [C] fifty cents
+[C] No phone, no pool, [F] no pets
 [G] I ain't got no cigarettes
 
 ## Resources

--- a/content/legacy-songs/Leev Marie (Paveier).md
+++ b/content/legacy-songs/Leev Marie (Paveier).md
@@ -15,61 +15,61 @@ F# |2 4 4 3 2 2|
 
 ## Intro 2
 
-[Em] [Am] [D] [G] [B7]  
+[Em] [Am] [D] [G] [B7]
 [Em] [Am] [Em] [B7] [Em]
 
 ## Verse 1
 
-[Em] Wenn ich samstags Ovend eimol russ jon,  
-[Em] laufe mir die Mädche hinger[B7]her.  
-[B7] Ich kann doch nit dofür dat ich su us sinn.  
+[Em] Wenn ich samstags Ovend eimol russ jon,
+[Em] laufe mir die Mädche hinger[B7]her.
+[B7] Ich kann doch nit dofür dat ich su us sinn.
 [B7] Ne Mischung us George Clooney un nem [Em] Bär.
 
-[E7] Tag und Nacht such ich die große [Am] Liebe.  
-Selvs Mar[D]ie will immer [G] nur das [B7] eine  
-[Em] Ich - bin anders als die [Am] ander´n,  
+[E7] Tag und Nacht such ich die große [Am] Liebe.
+Selvs Mar[D]ie will immer [G] nur das [B7] eine
+[Em] Ich - bin anders als die [Am] ander´n,
 [F#] ich will noch so viel [B7] mehr
 
 ## Chorus
-                             
-[B7] Leev Ma[Em]rie, ich bin kein Mann für [Am] eine Nacht  
-Leev Ma[D]rie, das habe ich noch [G] nie gemacht  
-[B7]Leev Marie[Em], es [E7] muß die wahre [Am] Liebe sein  
+
+[B7] Leev Ma[Em]rie, ich bin kein Mann für [Am] eine Nacht
+Leev Ma[D]rie, das habe ich noch [G] nie gemacht
+[B7]Leev Marie[Em], es [E7] muß die wahre [Am] Liebe sein
 [Am] Für eine [Em] Nacht bleib ich [B7] lieber al[Em]lein
- 
+
 [Em] [Am] [Em] [B7] [Em]
 
 ## Verse 2
 
-[Em] Wat hann se mir nit alles schun versproche  
-[Em] Doch beim Fröhstück soß ich dann al[B7]lein  
-[B7]Wie oft hann se mir et Hätz jebroche  
+[Em] Wat hann se mir nit alles schun versproche
+[Em] Doch beim Fröhstück soß ich dann al[B7]lein
+[B7]Wie oft hann se mir et Hätz jebroche
 [B7] Veel zu oft fiehl ich dropp [Em]rin
 
-[E7] Mein Körper ist mir dafür viel zu [Am] schade  
-Nein ich [D] lasse mich nicht [G] mehr be[B7]nutzen  
-[Em] Ich kann sie nicht mehr hören diese [Am] Frage  
+[E7] Mein Körper ist mir dafür viel zu [Am] schade
+Nein ich [D] lasse mich nicht [G] mehr be[B7]nutzen
+[Em] Ich kann sie nicht mehr hören diese [Am] Frage
 [F#] Jon mer zu dir oder zu [B7] mir?
 
 ## Chorus
-                             
-[B7] Leev Ma[Em]rie, ich bin kein Mann für [Am] eine Nacht  
-Leev Ma[D]rie, das habe ich noch [G] nie gemacht  
-[B7]Leev Marie[Em], es [E7] muß die wahre [Am] Liebe sein  
+
+[B7] Leev Ma[Em]rie, ich bin kein Mann für [Am] eine Nacht
+Leev Ma[D]rie, das habe ich noch [G] nie gemacht
+[B7]Leev Marie[Em], es [E7] muß die wahre [Am] Liebe sein
 [Am] Für eine [Em] Nacht bleib ich [B7] lieber al[Em]lein
 
 ## Instrumental
 
-[Em] LaLa... [Am] [D] [G] [B7]  
-[Em] [Am] [Em] [B7] [Em]  
-[Em] LaLa... [Am] [D] [G] [B7]  
+[Em] LaLa... [Am] [D] [G] [B7]
+[Em] [Am] [Em] [B7] [Em]
+[Em] LaLa... [Am] [D] [G] [B7]
 [Em] [Am] [Em] [B7] [Em]
 
 ## Chorus
-                             
-[B7] Leev Ma[Em]rie, ich bin kein Mann für [Am] eine Nacht  
-Leev Ma[D]rie, das habe ich noch [G] nie gemacht  
-[B7]Leev Marie[Em], es [E7] muß die wahre [Am] Liebe sein  
+
+[B7] Leev Ma[Em]rie, ich bin kein Mann für [Am] eine Nacht
+Leev Ma[D]rie, das habe ich noch [G] nie gemacht
+[B7]Leev Marie[Em], es [E7] muß die wahre [Am] Liebe sein
 [Am] Für eine [Em] Nacht bleib ich [B7] lieber al[Em]lein _(2x)_
 
 ## Resources

--- a/content/legacy-songs/S.O.B. (Nathaniel Rateliff).md
+++ b/content/legacy-songs/S.O.B. (Nathaniel Rateliff).md
@@ -2,95 +2,95 @@
 
 ## Verse 1
 
-_(No guitar, only stomping on beat  
+_(No guitar, only stomping on beat
 and clapping off beat)_
 
-[E] Mmmm hmm, mmmm hmm  
+[E] Mmmm hmm, mmmm hmm
 mmmm hmm hmm hmm _(x2)_
 
 ---
 
 _(Continue)_
 
-[E] I'm gonna need someone to help me  
-I'm gonna need somebody's hand  
-[E] I'm gonna need someone to hold [A] me down  
+[E] I'm gonna need someone to help me
+I'm gonna need somebody's hand
+[E] I'm gonna need someone to hold [A] me down
 I'm gonna [E] need someone to care
 
-[E] I'm gonna writhe and shake my body  
-I'll start pulling out my hair  
-[E] I'm gonna cover myself with the [A] ashes of you  
+[E] I'm gonna writhe and shake my body
+I'll start pulling out my hair
+[E] I'm gonna cover myself with the [A] ashes of you
 and [E] nobody's gonna give a damn
- 
+
 ## Chorus
 
 _(Only guitar)_
 
-Son of a bitch [E] give me a drink [A]  
+Son of a bitch [E] give me a drink [A]
 One more night [E] this can't be me [B7]
 
-Son of a bitch [E] if I can't get clean [A]  
+Son of a bitch [E] if I can't get clean [A]
 I'm gonna drink [E] my life away [A] [E]
- 
+
 ## Verse 2
 
 _(Only stomping and clapping)_
 
-[E] **Whoa oh**, whoa oh  
+[E] **Whoa oh**, whoa oh
 whoa oh oh oh  _(x2)_
 
-Now for se[E]venteen years  
-I've been throwing them back  
-[E] Seventeen more will bury me  
-Can [E] somebody please just [A] tie me [E] down?  
+Now for se[E]venteen years
+I've been throwing them back
+[E] Seventeen more will bury me
+Can [E] somebody please just [A] tie me [E] down?
 Or [E] somebody give me a goddamn drink?
 
 ## Chorus
 
 _(Only guitar)_
 
-Son of a bitch [E] give me a drink [A]  
+Son of a bitch [E] give me a drink [A]
 One more night [E] this can't be me [B7]
 
-Son of a bitch [E] if I can't get clean [A]  
+Son of a bitch [E] if I can't get clean [A]
 I'm gonna drink [E] my life away [A] [E]
 
 ## Interlude
 
 _(Only stomping and clapping)_
 
-[E] **Mmmm hmm**, mmmm hmm  
+[E] **Mmmm hmm**, mmmm hmm
 mmmm hmm hmm hmm _(x2)_
 
 _(Only finger snapping off beat)_
 
-My [E] heart was breaking, hands are shaking  
+My [E] heart was breaking, hands are shaking
 bugs are crawling all over me _(x4, cont. raise voice)_
 
 ## Chorus
 
 _(Only guitar)_
 
-Son of a bitch [E] give me a drink [A]  
+Son of a bitch [E] give me a drink [A]
 One more night [E] this can't be me [B7]
 
-Son of a bitch [E] if I can't get clean [A]  
+Son of a bitch [E] if I can't get clean [A]
 I'm gonna drink [E] my life away [A] [E]
 
-_(Repeat and add 2nd voice)_  
-[E] **Whoa oh**, whoa oh  
+_(Repeat and add 2nd voice)_
+[E] **Whoa oh**, whoa oh
 whoa oh oh oh...
 
 ## Outro
 
 _(Only stomping and clapping)_
 
-[E] **Whoa oh**, whoa oh  
+[E] **Whoa oh**, whoa oh
 whoa oh oh oh  _(x2)_
 
 _(Vocals only)_
 
-[E] Whoa oh, whoa oh  
+[E] Whoa oh, whoa oh
 whoa oh oh oh
 
 ## Resources

--- a/content/legacy-songs/Schunder-Song (Die Ärzte).md
+++ b/content/legacy-songs/Schunder-Song (Die Ärzte).md
@@ -18,26 +18,26 @@ G/B |x 2 0 0 x x|
 
 [C] [B] [Am]
 
-Du hast mich so oft angespuckt  
-geschlagen und getreten  [C] [B] [Am]  
-Das war nicht sehr nett von dir  
+Du hast mich so oft angespuckt
+geschlagen und getreten  [C] [B] [Am]
+Das war nicht sehr nett von dir
 ich hatte nie darum gebe[G]ten [C] [B] [Am]
 
-Deine Feunde haben [F] applaudiert  
-[C] sie fanden es ganz [G] toll  
-[Am] Wenn du mich ver[F]möbelt hast  
+Deine Feunde haben [F] applaudiert
+[C] sie fanden es ganz [G] toll
+[Am] Wenn du mich ver[F]möbelt hast
 doch [C] jetzt ist das Fass [G] voll
 
 ## Pre-Chorus
 
-[C] Gewalt erzeugt [G] Gegengewalt  
-hat man [F] dir das nicht erklärt? [G]  
-Oder [C] hast du da auch [G] wie so oft  
+[C] Gewalt erzeugt [G] Gegengewalt
+hat man [F] dir das nicht erklärt? [G]
+Oder [C] hast du da auch [G] wie so oft
 einfach [F] nicht genau zugehört? [G]
 
-[F] Jetzt stehst du vor mir  
-und [G] wir sind ganz allein  
-[F] Keiner kann dir helfen, [G] keiner steht dir bei  
+[F] Jetzt stehst du vor mir
+und [G] wir sind ganz allein
+[F] Keiner kann dir helfen, [G] keiner steht dir bei
 [F] Ich schlag nur noch auf dich ein [G]
 
 ## Chorus
@@ -47,27 +47,27 @@ Immer mitten in die [C] Fresse rein [G] [Dm] [F] _(x2)_
 ## Verse 2
 
 [C] [B] [Am]
-Ich bin nicht stark und ich bin kein Held  
-doch was zuviel ist ist zuviel [C] [B] [Am]  
-Für deine Agressionen  
+Ich bin nicht stark und ich bin kein Held
+doch was zuviel ist ist zuviel [C] [B] [Am]
+Für deine Agressionen
 war ich immer das Ven[G]til [C] [B] [Am]
 
-Deine Kumpels waren [F] immer dabei  
-doch jetzt [C] wendet sich das Blatt [G]  
-[Am] Auch wenn ich morgen besser [F] umzieh'  
+Deine Kumpels waren [F] immer dabei
+doch jetzt [C] wendet sich das Blatt [G]
+[Am] Auch wenn ich morgen besser [F] umzieh'
 irgend[C]wo in eine andere [G] Stadt
 
 ## Pre-Chorus
 
-[C] Gewalt erzeugt [G] Gegengewalt  
-hat man [F] dir das nicht ~~erklärt~~ **erzählt**? [G]  
-Oder [C] hast du da auch [G] wie so oft  
-~~einfach nicht genau zugehört~~  
+[C] Gewalt erzeugt [G] Gegengewalt
+hat man [F] dir das nicht ~~erklärt~~ **erzählt**? [G]
+Oder [C] hast du da auch [G] wie so oft
+~~einfach nicht genau zugehört~~
 **im [F] Unterricht gefehlt?** [G]
 
-[F] Jetzt ~~stehst~~ **liegst** du vor mir  
-und [G] wir sind ganz allein  
-[F] Und ich schlage [G] weiter auf dich ein  
+[F] Jetzt ~~stehst~~ **liegst** du vor mir
+und [G] wir sind ganz allein
+[F] Und ich schlage [G] weiter auf dich ein
 [F] Das tut gut, das musste [G] einfach mal sein
 
 ## Chorus

--- a/content/legacy-songs/Sounds of silence (Simon and Garfunkel).md
+++ b/content/legacy-songs/Sounds of silence (Simon and Garfunkel).md
@@ -2,61 +2,61 @@
 
 ## Verse 1
 
-[Am] Hello darkness, my old [G] friend  
-I've come to talk with you a[Am]gain  
-Because a vision softly [F] cree[C]ping  
+[Am] Hello darkness, my old [G] friend
+I've come to talk with you a[Am]gain
+Because a vision softly [F] cree[C]ping
 [F] Left its seeds while I was slee[C]ping
 
-And the [F] vision that was planted  
-in my [C] brain still re[Am]mains  
+And the [F] vision that was planted
+in my [C] brain still re[Am]mains
 [C]Within the [G] sound of [Am] silence
- 
+
 ## Verse 2
 
-In restless dreams I walked a[G]lone  
-Narrow streets of cobble[Am]stone  
-'neath the halo of a [F] street [C] lamp  
+In restless dreams I walked a[G]lone
+Narrow streets of cobble[Am]stone
+'neath the halo of a [F] street [C] lamp
 I turned my collar to the [F] cold and [C] damp
 
-When my [F] eyes were stabbed  
-by the flash of a neon [C] light  
-That split the night [Am]  
+When my [F] eyes were stabbed
+by the flash of a neon [C] light
+That split the night [Am]
 [C] And touched the [G] sound of [Am] silence
- 
+
 ## Verse 3
 
-And in the naked light I [G] saw  
-Ten thousand people, maybe [Am] more  
-People talking with[F]out speak[C]ing  
+And in the naked light I [G] saw
+Ten thousand people, maybe [Am] more
+People talking with[F]out speak[C]ing
 People hearing with[F]out lis[C]tening
 
-People writing [F] songs  
-that voices never share [C]  
-And no one [Am] dare  
+People writing [F] songs
+that voices never share [C]
+And no one [Am] dare
 [C] Disturb the sound [G] of [Am] silence
- 
+
 ## Verse 4
 
-Fools said I, you do not [G] know  
-Silence like a cancer [Am] grows  
-Hear my words that I might [F] teach [C] you  
+Fools said I, you do not [G] know
+Silence like a cancer [Am] grows
+Hear my words that I might [F] teach [C] you
 Take my arms that I might [F] reach you [C]
 
-But my [F] words like silent raindrops [C] fell [Am]  
-_(Pause)_  
-[C] And echoed  
-In the [G] wells of [Am] silence  
- 
+But my [F] words like silent raindrops [C] fell [Am]
+_(Pause)_
+[C] And echoed
+In the [G] wells of [Am] silence
+
 ## Verse 5
 
-And the people bowed and [G] prayed  
-To the neon God they [Am] made  
-And the sign flashed out [F] its war[C]ning  
+And the people bowed and [G] prayed
+To the neon God they [Am] made
+And the sign flashed out [F] its war[C]ning
 In the words that it was [F] forming [C]
-                       
-And the sign said the [F] words of the prophets  
-Are written on the subway [C] walls  
-And tenement [Am] halls  
+
+And the sign said the [F] words of the prophets
+Are written on the subway [C] walls
+And tenement [Am] halls
 And [C] whisper'd in the [G] sounds of [Am] silence
 
 ## Resources

--- a/content/legacy-songs/You can get it if you really want (Jimmy Cliff).md
+++ b/content/legacy-songs/You can get it if you really want (Jimmy Cliff).md
@@ -1,62 +1,62 @@
 # You can get it if you really want (Jimmy Cliff)
 
 ## Intro
- 
+
 _(Slide up to)_ [C] _(x2)_
 
 ## Chorus
 
 [C] You can get it [G] if you [F] really want [G] _(x3)_
 
-But you must [C] try, try and [G] try, try and [F] try  
+But you must [C] try, try and [G] try, try and [F] try
 [G] You'll succeed at last
 
-[C] [G] [F] Mmh hm [G]  
+[C] [G] [F] Mmh hm [G]
 [C] [G] [F] [G]
 
 ## Verse 1
 
-[C] Perse[G]cution [F] you must bear [G]  
-[C] Win or lose, [G] you [F] got to get your share  
-[Em] Got your mind set [F] on a dream  
+[C] Perse[G]cution [F] you must bear [G]
+[C] Win or lose, [G] you [F] got to get your share
+[Em] Got your mind set [F] on a dream
 [G] You can get it though [G7] hard it may seem, now
 
 ## Chorus
 
 [C] You can get it [G] if you [F] really want [G] _(x3)_
 
-But you must [C] try, try and [G] try, try and [F] try  
+But you must [C] try, try and [G] try, try and [F] try
 [G] You'll succeed at last
 
-[C] [G] [F] I know it [G]  
+[C] [G] [F] I know it [G]
 [C] [G] [F] listen [G]
 
 ## Verse 2
 
-[C] Rome was [G] not [F] built in a day [G]  
-[C] Opposition [G] will [F] come your way  
-[Em] But the harder the [F] battle you see  
+[C] Rome was [G] not [F] built in a day [G]
+[C] Opposition [G] will [F] come your way
+[Em] But the harder the [F] battle you see
 [G] It's the sweeter the [G7] victory, now
 
 ## Chorus
 
 [C] You can get it [G] if you [F] really want [G] _(x3)_
 
-But you must [C] try, try and [G] try, try and [F] try  
+But you must [C] try, try and [G] try, try and [F] try
 [G] You'll succeed at last
 
 ## Interlude
 
 _(All barred)_
 
-[C] [Eb] [F]  
+[C] [Eb] [F]
 [G] [F] [Eb] [Db] _(x2)_
 
 ## Chorus
 
 [C] You can get it [G] if you [F] really want [G] _(x3)_
 
-But you must [C] try, try and [G] try, try and [F] try  
+But you must [C] try, try and [G] try, try and [F] try
 [G] You'll succeed at last _(Repeat and fade)_
 
 ## Resources

--- a/content/songs/A-N-N-A (Freundeskreis).md
+++ b/content/songs/A-N-N-A (Freundeskreis).md
@@ -2,174 +2,174 @@
 
 ## Chorus
 
-Immer wenn es [Em] regnet  
-muss ich an Dich [D] denken  
-Wie wir uns be[Am]gegneten  
-kann mich nicht ablenken  
-Nass bis auf die [Em] Haut  
-so stand sie [D] da  
+Immer wenn es [Em] regnet
+muss ich an Dich [D] denken
+Wie wir uns be[Am]gegneten
+kann mich nicht ablenken
+Nass bis auf die [Em] Haut
+so stand sie [D] da
 
-_(1st time:)_ Um uns war es [Am]  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es [Am]
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-[Am]A
 
 ## Verse 1
 
-[C] Pitsch, patsch nass, floh ich unter das  
-Vor[D]dach des Fachgeschäftes  
-Vom Himmel goss ein Bach. [Em]  
-Ich schätz' es war halb acht  
-Doch ich war hellwach  
+[C] Pitsch, patsch nass, floh ich unter das
+Vor[D]dach des Fachgeschäftes
+Vom Himmel goss ein Bach. [Em]
+Ich schätz' es war halb acht
+Doch ich war hellwach
 als mich Anna ansah, anlachte
 
 ---
 
-[C] Ich dachte: "Sprich sie an"  
-denn sie sprach mich an  
-Die [D] Kleidung ganz durchnässt  
-klebte an ihr fest  
-Die [Em] Tasche in der Hand  
-stand sie an der Wand  
-Die dunkeln Augen funkelten  
+[C] Ich dachte: "Sprich sie an"
+denn sie sprach mich an
+Die [D] Kleidung ganz durchnässt
+klebte an ihr fest
+Die [Em] Tasche in der Hand
+stand sie an der Wand
+Die dunkeln Augen funkelten
 wie 'ne Nacht in Asien
 
 ---
 
-[C] Strähnen im Gesicht  
-nehmen ihr die Sicht  
-Mein [D] Herz das klopft  
-die Nase tropft  
-Ich schäme mich  
-benehme mich [Em] dämlich  
-Bin nämlich eher schüchtern  
-"Mein Name ist Anna"  
+[C] Strähnen im Gesicht
+nehmen ihr die Sicht
+Mein [D] Herz das klopft
+die Nase tropft
+Ich schäme mich
+benehme mich [Em] dämlich
+Bin nämlich eher schüchtern
+"Mein Name ist Anna"
 sagte sie sehr nüchtern
 
 ---
 
-Ich fing an zu flüstern:  
-[C] "Ich bin Max aus dem  
-Schosse der Kolchose"  
-Doch [D] so 'ne Katastrophe  
-das ging mächtig in die Hose  
-Mach' mich [Em] lächerlich  
-Doch sie lächelte  
-Ehrlich wahr man! Sieh da  
+Ich fing an zu flüstern:
+[C] "Ich bin Max aus dem
+Schosse der Kolchose"
+Doch [D] so 'ne Katastrophe
+das ging mächtig in die Hose
+Mach' mich [Em] lächerlich
+Doch sie lächelte
+Ehrlich wahr man! Sieh da
 Anna war ein Hip Hop – Fan
 
 ## Chorus
 
-Immer wenn es [Em] regnet  
-muss ich an Dich [D] denken  
-Wie wir uns be[Am]gegneten  
-kann mich nicht ablenken  
-Nass bis auf die [Em] Haut  
-so stand sie [D] da  
+Immer wenn es [Em] regnet
+muss ich an Dich [D] denken
+Wie wir uns be[Am]gegneten
+kann mich nicht ablenken
+Nass bis auf die [Em] Haut
+so stand sie [D] da
 
-_(1st time:)_ Um uns war es [Am]  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es [Am]
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-[Am]A
 
 ## Verse 2
 
-[C] Plitsch, platsch fiel  
-ein Regen wie die Sintflut  
-Das [D] Vordach, die Insel  
-Wir waren wie Strandgut  
-Ich [Em] fand Mut  
-Bin selber überrascht  
-Über das Selbstverständnis  
+[C] Plitsch, platsch fiel
+ein Regen wie die Sintflut
+Das [D] Vordach, die Insel
+Wir waren wie Strandgut
+Ich [Em] fand Mut
+Bin selber überrascht
+Über das Selbstverständnis
 meines Geständnis'
 
 ---
 
-"Anna, ich [C] fänd' es schön  
-mit Dir auszugehn  
-Könnt' mich [D] dran gewöhn'  
-Dich öfters zu sehn"  
-[Em] Anna zog mich an sich  
-An sich mach' ich das nicht  
-Spüre ihre süssen Küsse  
+"Anna, ich [C] fänd' es schön
+mit Dir auszugehn
+Könnt' mich [D] dran gewöhn'
+Dich öfters zu sehn"
+[Em] Anna zog mich an sich
+An sich mach' ich das nicht
+Spüre ihre süssen Küsse
 wie sie mein Gesicht lieb[C]kost
 
 ---
 
-Was geschieht bloss?  
-Lass mich nicht los, Anna  
-Ich [D] lieb bloss noch Dich  
-andere sind lieblos  
-Du bist wie [Em] Vinyl für meinen DJ  
-die Dialektik für Hegel  
-Pinsel für Picasso  
+Was geschieht bloss?
+Lass mich nicht los, Anna
+Ich [D] lieb bloss noch Dich
+andere sind lieblos
+Du bist wie [Em] Vinyl für meinen DJ
+die Dialektik für Hegel
+Pinsel für Picasso
 für Philip der Schlagzeugschlegel
 
 ---
 
-[C] Anna, wie war das da bei Dada?  
+[C] Anna, wie war das da bei Dada?
 
-Du bist von [D] hinten  
-wie von vorne: A-N-N-A  
+Du bist von [D] hinten
+wie von vorne: A-N-N-A
 
-Du bist von [Em] hinten  
+Du bist von [Em] hinten
 wie von vorne: A-N-N-A _(x2)_
 
 ## Chorus
 
-Immer wenn es [Em] regnet  
-muss ich an Dich [D] denken  
-Wie wir uns be[Am]gegneten  
-kann mich nicht ablenken  
-Nass bis auf die [Em] Haut  
-so stand sie [D] da  
+Immer wenn es [Em] regnet
+muss ich an Dich [D] denken
+Wie wir uns be[Am]gegneten
+kann mich nicht ablenken
+Nass bis auf die [Em] Haut
+so stand sie [D] da
 
-_(1st time:)_ Um uns war es [Am]  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es [Am]
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-[Am]A
 
 ## Verse 3
 
-Sie [C] gab mir 'nen Abschiedskuss  
-denn dann kam der Bus  
-Sie sagte: [D] "Max, ich muss!"  
-die Türe schloss  
-Was ist jetzt Schluss?  
+Sie [C] gab mir 'nen Abschiedskuss
+denn dann kam der Bus
+Sie sagte: [D] "Max, ich muss!"
+die Türe schloss
+Was ist jetzt Schluss?
 
-Es goss. Ich [Em] ging zu Fuss  
-Bin konfus, fast gerannt  
-Anna nahm mein' Verstand  
+Es goss. Ich [Em] ging zu Fuss
+Bin konfus, fast gerannt
+Anna nahm mein' Verstand
 Ich fand an Anna allerhand
 
 ---
 
-Manchmal [C] lach' ich drüber  
-doch dann merk' ich wieder  
-wie 's mich trifft  
-[D] Komik ist Tragik in Spiegelschrift:  
-A-N-N-A  
-[Em] Von hinten, wie von vorne  
-Dein Name sei gesegnet  
+Manchmal [C] lach' ich drüber
+doch dann merk' ich wieder
+wie 's mich trifft
+[D] Komik ist Tragik in Spiegelschrift:
+A-N-N-A
+[Em] Von hinten, wie von vorne
+Dein Name sei gesegnet
 Ich denk' an Dich, immer wenn es...
 
 ## Chorus
 
-Immer wenn es [Em] regnet  
-muss ich an Dich [D] denken  
-Wie wir uns be[Am]gegneten  
-kann mich nicht ablenken  
-Nass bis auf die [Em] Haut  
-so stand sie [D] da  
+Immer wenn es [Em] regnet
+muss ich an Dich [D] denken
+Wie wir uns be[Am]gegneten
+kann mich nicht ablenken
+Nass bis auf die [Em] Haut
+so stand sie [D] da
 
-_(1st time:)_ Um uns war es [Am]  
-laut und wir kamen uns nah  
+_(1st time:)_ Um uns war es [Am]
+laut und wir kamen uns nah
 _(2nd time:)_ A-N-N-[Am]A
 
 ## Outro
 
 [Em] [D] [Am] [Em] [D]
 
-(Lass mich nicht im Regen stehn  
-Ich will dich wiedersehn  
-A-N-N-A...  
+(Lass mich nicht im Regen stehn
+Ich will dich wiedersehn
+A-N-N-A...
 Yeah...)
 
 ## Resources

--- a/content/songs/Across the universe (Beatles).md
+++ b/content/songs/Across the universe (Beatles).md
@@ -15,58 +15,58 @@ F#m    |2=4=4=2=2=2|
 
 ## Verse 1
 
-[D] Words are flowing out [Bm]  
-like endless [F#m] rain into a paper cup  
-They [Em7] slither wildly as they slip away  
+[D] Words are flowing out [Bm]
+like endless [F#m] rain into a paper cup
+They [Em7] slither wildly as they slip away
 a[A]cross the [A7] universe
 
-[D] Pools of sorrow, [Bm] waves of joy  
-are [F#m] drifting through my opened mind  
+[D] Pools of sorrow, [Bm] waves of joy
+are [F#m] drifting through my opened mind
 Poss[Em7]essing and car[Gm]essing me
 
 ## Chorus
 
 [D] Jai guru deva om [A7sus4]
 
-[A] Nothing's gonna change my world [A7]  
+[A] Nothing's gonna change my world [A7]
 [G] Nothing's gonna change my world [D] _(x2)_
 
 ## Verse 2
 
-[D] Images of [Bm] broken light which  
-[F#m] dance before me like a million [Em7] eyes  
-They call me on and on  
+[D] Images of [Bm] broken light which
+[F#m] dance before me like a million [Em7] eyes
+They call me on and on
 a[A]cross the [A7] universe
 
-[D] Thoughts meander [Bm] like a restless  
-[F#m] wind inside a letterbox  
-They [Em7] tumble blindly  
-as they make their [A] way  
+[D] Thoughts meander [Bm] like a restless
+[F#m] wind inside a letterbox
+They [Em7] tumble blindly
+as they make their [A] way
 across the [A7] universe
 
 ## Chorus
 
 [D] Jai guru deva om [A7sus4]
 
-[A] Nothing's gonna change my world [A7]  
+[A] Nothing's gonna change my world [A7]
 [G] Nothing's gonna change my world [D] _(x2)_
 
 ## Verse 3
 
-[D] Sounds of laughter, [Bm] shades of life  
-are [F#m] ringing through my opened ears  
-In[Em7]citing and in[Gm]viting me  
+[D] Sounds of laughter, [Bm] shades of life
+are [F#m] ringing through my opened ears
+In[Em7]citing and in[Gm]viting me
 
-[D] Limitless, un[Bm]dying love  
-which [F#m]shines around me like  
-a million [Em7] suns and calls me on and on   
+[D] Limitless, un[Bm]dying love
+which [F#m]shines around me like
+a million [Em7] suns and calls me on and on
 a[A]cross the universe [A7]
 
 ## Chorus
 
 [D] Jai guru deva om [A7sus4]
 
-[A] Nothing's gonna change my world [A7]  
+[A] Nothing's gonna change my world [A7]
 [G] Nothing's gonna change my world [D] _(x2)_
 
 ## Outro

--- a/content/songs/As long as you love me (Backstreet Boys).md
+++ b/content/songs/As long as you love me (Backstreet Boys).md
@@ -2,45 +2,45 @@
 
 ## Intro
 
-[C] [G] [Em] [D]  
+[C] [G] [Em] [D]
 As long as you love me
 
 _(Repeat)_
 
 ## Verse 1
 
-Although [Em] loneliness has always been  
-a [C] friend of mine  
-I'm [D] leavin' my life in your hands [G] [D]  
-[Em] People say I'm crazy and that [C] I am blind  
+Although [Em] loneliness has always been
+a [C] friend of mine
+I'm [D] leavin' my life in your hands [G] [D]
+[Em] People say I'm crazy and that [C] I am blind
 [D] Risking it all in a glance [G] [D]
 
-And [Em] how you got me blind is still a [C] mystery  
-I [D] can't get you out of my head [G] [D]  
-[Em] Don't care what is written in your [C] history  
+And [Em] how you got me blind is still a [C] mystery
+I [D] can't get you out of my head [G] [D]
+[Em] Don't care what is written in your [C] history
 As [D] long as you're here with me [G]
 
 ## Chorus
 
-I don't care who [C] you are  
-Where [G] you're from  
-What [Em] you did  
+I don't care who [C] you are
+Where [G] you're from
+What [Em] you did
 As long [D] as you love me
 
 _(Repeat)_
 
 ## Verse 2
 
-[Em] Every little thing that you have [C] said and done  
-Feels [D] like it's deep within me [G] [D]  
-[Em] Doesn't really matter if you're [C] on the run  
+[Em] Every little thing that you have [C] said and done
+Feels [D] like it's deep within me [G] [D]
+[Em] Doesn't really matter if you're [C] on the run
 It [D] seems like we're [G] meant to be [D]
 
 ## Chorus
 
-I don't care who [C] you are  
-Where [G] you're from  
-What [Em] you did  
+I don't care who [C] you are
+Where [G] you're from
+What [Em] you did
 As long [D] as you love me (yeah)
 
 _(Repeat)_
@@ -49,19 +49,19 @@ _(Repeat)_
 
 ## Bridge
 
-[Em] I've tried to hide it so that [G] no one knows  
-But I [C] guess it shows  
-When you [C] look into my eyes [D]  
+[Em] I've tried to hide it so that [G] no one knows
+But I [C] guess it shows
+When you [C] look into my eyes [D]
 
-[Em] What you did and where you're [G] comin from  
-I don't [D] care, [C] as long [D] as you [C] love me, baby  
+[Em] What you did and where you're [G] comin from
+I don't [D] care, [C] as long [D] as you [C] love me, baby
 [G] [D] [Em] [C] [D]
 
 ## Chorus
 
-I don't care who [C] you are  
-Where [G] you're from  
-What [Em] you did  
+I don't care who [C] you are
+Where [G] you're from
+What [Em] you did
 As long [D] as you love me
 
 _(Repeat and fade)_

--- a/content/songs/Baby one more time (Britney Spears).md
+++ b/content/songs/Baby one more time (Britney Spears).md
@@ -3,76 +3,76 @@
 ## Intro
 
 [Am] Oh baby, baby _(x2)_
- 
+
 ## Verse 1
 
-[Am] Oh baby, baby  
-How [E] was I supposed to know [C]  
+[Am] Oh baby, baby
+How [E] was I supposed to know [C]
 That [Dm] something wasn't [E] right here
 
-[Am] Oh baby baby  
-I [E] shouldn't have let you go [C]  
+[Am] Oh baby baby
+I [E] shouldn't have let you go [C]
 And [Dm] now you're out of [E] sight, yeah
- 
+
 ## Pre-Chorus
 
-[Am] Show me, how you want it [E] to be  
-Tell me [C] baby  
+[Am] Show me, how you want it [E] to be
+Tell me [C] baby
 'Cause I need to [Dm] know now what we've got [E]
 
 ## Chorus
 
-[Am] My loneliness is [E] killing me  
+[Am] My loneliness is [E] killing me
 [C] I must confess  I [Dm] still believe
 [E] (still believe)
 
-[Am] When I'm not with you I lose [E] my mind  
-[G] Give me a sign [C]  
+[Am] When I'm not with you I lose [E] my mind
+[G] Give me a sign [C]
 [Dm] Hit me baby [E] one more time
 
 ## Verse 2
 
-[Am] Oh baby, baby  
-The [E] reason I breathe is you [C]  
+[Am] Oh baby, baby
+The [E] reason I breathe is you [C]
 [Dm] Boy you've got me [E] flying
 
-[Am] Oh pretty baby  
-There's [E] nothing that I woul[C]dn't do  
+[Am] Oh pretty baby
+There's [E] nothing that I woul[C]dn't do
 It's [Dm] not the way I [E] planned it
 
 ## Pre-Chorus
 
-[Am] Show me, how you want it [E] to be  
-Tell me [C] baby  
+[Am] Show me, how you want it [E] to be
+Tell me [C] baby
 'Cause I need to [Dm] know now what we've got [E]
 
 ## Chorus
 
-[Am] My loneliness is [E] killing me (and I)  
+[Am] My loneliness is [E] killing me (and I)
 [C] I must confess  I [Dm] still believe
 [E] (still believe)
 
-[Am] When I'm not with you I lose [E] my mind  
-[G] Give me a sign [C]  
+[Am] When I'm not with you I lose [E] my mind
+[G] Give me a sign [C]
 [Dm] Hit me baby [E] one more time
 
 ## Interlude
 
 [Am] Oh baby, baby _(x2)_
- 
-[Am] Oh baby, baby  
-How [E] was I supposed to know [C]  
+
+[Am] Oh baby, baby
+How [E] was I supposed to know [C]
 [Dm] [E]
 
-[F] Oh pretty baby  
+[F] Oh pretty baby
 I [G] shouldn't have let you go [Dm] [F] [G]
 
 ## Bridge
 
-I must confess [Am] that my loneliness [E]  
-Is killing me now [C]  
-don't you [Dm] know I [E] still believe [F]  
-That you will be here [G]  
+I must confess [Am] that my loneliness [E]
+Is killing me now [C]
+don't you [Dm] know I [E] still believe [F]
+That you will be here [G]
 Now give me a sign [F]
 
 [Dm] Hit me baby
@@ -80,16 +80,16 @@ Now give me a sign [F]
 
 ## Chorus
 
-[Am] My loneliness is [E] killing me (and I)  
+[Am] My loneliness is [E] killing me (and I)
 [C] I must confess  I [Dm] still believe
 [E] (still believe)
 
-[Am] When I'm not with you I lose [E] my mind  
-[G] Give me a sign [C]  
+[Am] When I'm not with you I lose [E] my mind
+[G] Give me a sign [C]
 [Dm] Hit me baby [E] ~~one more time~~ **I must confess...**
 
-_(Repeat and add 2nd voice)_ **...that my loneliness  
-is killing me now, don't you know I still believe  
+_(Repeat and add 2nd voice)_ **...that my loneliness
+is killing me now, don't you know I still believe
 that you would be here and give me a sign**
 
 _(Together)_ Hit me baby one more time! [Am]

--- a/content/songs/Bella ciao (Traditional).md
+++ b/content/songs/Bella ciao (Traditional).md
@@ -4,60 +4,60 @@
 
 Una mat[Am]tina mi son svegliato
 
-O bella, ciao! Bella, ciao!  
+O bella, ciao! Bella, ciao!
 Bella, [Am7] ciao, ciao, ciao!
 
-Una mat[Dm]tina mi son sveg[Am]liato  
+Una mat[Dm]tina mi son sveg[Am]liato
 e ho tro[E7]vato l'inva[Am]sor
 
 ## Verse 2
 
 O parti[Am]giano, portami via
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, [Am7] ciao, ciao, ciao!
 
-O parti[Dm]giano, portami Am via  
+O parti[Dm]giano, portami Am via
 ché mi [E7] sento di mo[Am]rir
 
 ## Verse 3
 
 E se io [Am] muoio da partigiano
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, [Am7] ciao, ciao, ciao!
 
-E se io [Dm] muoio da parti[Am]giano  
+E se io [Dm] muoio da parti[Am]giano
 tu mi [E7] devi seppel[Am]lir
 
 ## Verse 4
 
 E seppel[Am]lire lassù in montagna
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, [Am7] ciao, ciao, ciao!
 
-E seppel[Dm]lire lassù in mon[Am]tagna  
+E seppel[Dm]lire lassù in mon[Am]tagna
 Sotto [E7] l'ombra di un bel [Am] fior
 
 ## Verse 5
 
 Tutte le [Am] genti che passeranno
 
-O bella, ciao! Bella, ciao!  
+O bella, ciao! Bella, ciao!
 Bella, [Am7] ciao, ciao, ciao!
 
-Tutte le [Dm] genti che passe[Am]ranno  
+Tutte le [Dm] genti che passe[Am]ranno
 Ti di[E7]ranno "Che bel [Am] fior!"
 
 ## Verse 6
 
 "È questo il [Am] fiore del partigiano"
- 
-O bella, ciao! Bella, ciao!  
+
+O bella, ciao! Bella, ciao!
 Bella, [Am7] ciao, ciao, ciao!
 
-"È questo il [Dm] fiore del parti[Am]giano  
+"È questo il [Dm] fiore del parti[Am]giano
 morto [E7] per la liber[Am]tà!" _(Repeat and fade)_
 
 ## Resources

--- a/content/songs/Don't worry be happy (Bobby McFerrin).md
+++ b/content/songs/Don't worry be happy (Bobby McFerrin).md
@@ -8,14 +8,14 @@ _(Instrumental)_
 
 ## Verse 1
 
-[G] Here's a little song I wrote  
-You [Am] might want to sing it note for note   
+[G] Here's a little song I wrote
+You [Am] might want to sing it note for note
 Don't [C] worry, be [G] happy
 
-In [G] every life we have some trouble  
-[Am] When you worry you make it double  
-Don't [C] worry, be [G] happy 
- 
+In [G] every life we have some trouble
+[Am] When you worry you make it double
+Don't [C] worry, be [G] happy
+
 ## Chorus
 
 (Whistle)
@@ -24,12 +24,12 @@ Don't [C] worry, be [G] happy
 
 ## Verse 2
 
-[G] Ain't got no place to lay your head  
-[Am] Somebody came and took your bed  
-Don't [C] worry, be [G] happy  
+[G] Ain't got no place to lay your head
+[Am] Somebody came and took your bed
+Don't [C] worry, be [G] happy
 
-The [G] landlord say your rent is late  
-[Am] He may have to litigate  
+The [G] landlord say your rent is late
+[Am] He may have to litigate
 Don't [C] worry, be [G] happy
 
 ## Chorus
@@ -40,12 +40,12 @@ Don't [C] worry, be [G] happy
 
 ## Verse 3
 
-[G] Ain't got no cash, ain't got no style  
-[Am] Ain't got no girl to make you smile  
+[G] Ain't got no cash, ain't got no style
+[Am] Ain't got no girl to make you smile
 **But** don't [C] worry, be [G] happy
 
-Cause [G] when you worry, your face will frown  
-[Am] And that will bring everybody down  
+Cause [G] when you worry, your face will frown
+[Am] And that will bring everybody down
 **So** don't [C] worry, be [G] happy
 
 ## Chorus
@@ -56,14 +56,14 @@ Cause [G] when you worry, your face will frown
 
 ## Verse 4
 
-[G] There is this little song I wrote  
-[Am] I hope you learn it note for note  
+[G] There is this little song I wrote
+[Am] I hope you learn it note for note
 Don't [C] worry, be [G] happy
 
 (Listen to what I say!)
 
-[G] In your life expect some trouble 
-[Am] But when you worry, you make it double 
+[G] In your life expect some trouble
+[Am] But when you worry, you make it double
 Don't [C] worry, be [G] happy
 
 ## Chorus

--- a/content/songs/Dr Eskimo (Mani Matter).md
+++ b/content/songs/Dr Eskimo (Mani Matter).md
@@ -2,41 +2,41 @@
 
 ## Verse 1
 
-[Am] Kenned ihr das Gschichtli scho  
-[E] Vu dem arme [Am] Eskimo  
-[Em] Wo in [Am] Grönland [Em] einisch [Am] so  
+[Am] Kenned ihr das Gschichtli scho
+[E] Vu dem arme [Am] Eskimo
+[Em] Wo in [Am] Grönland [Em] einisch [Am] so
 [Em] Truurig [Am] isch ums [Em] Lebe [Am] cho.
- 
+
 ## Verse 2
 
-[Am] Er hät dank em Radio  
-[E] Freud ar Musig [Am] übercho  
-[Em] Und het [Am] denkt das [Em] chan i [Am] o  
+[Am] Er hät dank em Radio
+[E] Freud ar Musig [Am] übercho
+[Em] Und het [Am] denkt das [Em] chan i [Am] o
 [Em] So isch [Am] er is [Em] unglück [Am] cho.
- 
+
 ## Verse 3
 
-[Am] Nämlich hät er sich für zwo  
-[E] Fläsche Leber[Am]tran es no  
-[Em] Guet er[Am]haltnigs [Em] Cemba[Am]lo  
+[Am] Nämlich hät er sich für zwo
+[E] Fläsche Leber[Am]tran es no
+[Em] Guet er[Am]haltnigs [Em] Cemba[Am]lo
 [Em] Kouft und [Am] hets i d [Em] Höhli [Am] gno.
- 
+
 ## Verse 4
 
-[Am] Doch won er fortissimo  
-[E] Gspilt het uf sim [Am] Cembalo  
-[Em] Isch en [Am] Iisbär [Em] ine [Em] cho und  
+[Am] Doch won er fortissimo
+[E] Gspilt het uf sim [Am] Cembalo
+[Em] Isch en [Am] Iisbär [Em] ine [Em] cho und
 [Am] Hetne [Am] zwüsche d'[Em]Chralle [Am] gno.
- 
+
 ## Verse 5
 
-[Am] D'Kunst isch geng es Risiko  
-[E] So isch er ums [Am] Lebe cho  
-[Em] Und ihr [Am] gsänd d'Mo[Em]ral der[Am]vo  
-[Em] Choufed [Am] nie es [Em] Cemba[Am]lo  
-[Em] Süscht geits [Am] euch grad [Em] äbe[Am]so  
-[Em] Wie dem [Am] arme [Em] Eski[Am]mo  
-[Em] Wo in [Am] Grönland [Em] einisch [Am] so  
+[Am] D'Kunst isch geng es Risiko
+[E] So isch er ums [Am] Lebe cho
+[Em] Und ihr [Am] gsänd d'Mo[Em]ral der[Am]vo
+[Em] Choufed [Am] nie es [Em] Cemba[Am]lo
+[Em] Süscht geits [Am] euch grad [Em] äbe[Am]so
+[Em] Wie dem [Am] arme [Em] Eski[Am]mo
+[Em] Wo in [Am] Grönland [Em] einisch [Am] so
 [Em] Truurig [Am] isch ums [Em] Lebe [Am] cho.
 
 ## Resources

--- a/content/songs/Dr Sidi Abdel Assar (Mani Matter).md
+++ b/content/songs/Dr Sidi Abdel Assar (Mani Matter).md
@@ -2,43 +2,43 @@
 
 ## Verse 1
 
-Dr [Am] Sidi Abdel Assar vo El Hama  
-Het [Am] mal am Morge früe no im Pijama  
-Ir [Dm] Strass vor dr Moschee  
-Zwöi [Am] schöni Ouge gseh  
+Dr [Am] Sidi Abdel Assar vo El Hama
+Het [Am] mal am Morge früe no im Pijama
+Ir [Dm] Strass vor dr Moschee
+Zwöi [Am] schöni Ouge gseh
 Das [E] isch dr Afang worde vo sim [Am] Drama
 
 ## Verse 2
 
-S isch [Am] Tochter gsy vom Mohamed Mustafa  
-Dr [Am] Abdel Assar het nümm choenne schlafa  
-Bis [Dm] er bim Mohamed  
-Um [Am] d'Hand aghalte hed  
+S isch [Am] Tochter gsy vom Mohamed Mustafa
+Dr [Am] Abdel Assar het nümm choenne schlafa
+Bis [Dm] er bim Mohamed
+Um [Am] d'Hand aghalte hed
 Und [E] gseit: I biete hundertfüfzig [Am] Schaf a
 
 ## Verse 3
 
-Dr [Am] Mohamed het gantwortet: Bi Allah  
-Es [Am] froeit mi, dass mi Tochter dir het gfalla  
-Doch [Dm] wärt isch si, mi Seel  
-Zwöi[Am]hundertzwänzg Kamel  
+Dr [Am] Mohamed het gantwortet: Bi Allah
+Es [Am] froeit mi, dass mi Tochter dir het gfalla
+Doch [Dm] wärt isch si, mi Seel
+Zwöi[Am]hundertzwänzg Kamel
 Und [E] drunder chan i dir sen uf ke [Am] Fall la
 
 ## Verse 4
 
-Da [Am] het dr Abdel Assar gseit: O Sidi  
-Uf [Am] sone türe Handel gang i nid y  
-Isch [Dm] furt, het gly druf scho  
-E [Am] billigeri gno  
+Da [Am] het dr Abdel Assar gseit: O Sidi
+Uf [Am] sone türe Handel gang i nid y
+Isch [Dm] furt, het gly druf scho
+E [Am] billigeri gno
 Wo [E] nid so schoen isch gsy, defuer e [Am] gschydi
 
 ## Verse 5
 
 _(Langsam)_
 
-Doch [Am] wenn es Nacht wird ueber der Sahara  
-Luegt [Am] er dr Mond am Himmel hell und klar a  
-Und [Dm] truret hie und da  
+Doch [Am] wenn es Nacht wird ueber der Sahara
+Luegt [Am] er dr Mond am Himmel hell und klar a
+Und [Dm] truret hie und da
 De [Am] schoene Ouge na -
 
 _(Schnell)_

--- a/content/songs/Dr Wilhelm Täll (Mani Matter).md
+++ b/content/songs/Dr Wilhelm Täll (Mani Matter).md
@@ -2,87 +2,87 @@
 
 ## Verse 1
 
-Si [C] hei der Willhelm Täll ufgfüehrt  
-Im [G7] Löie z'Nottis[C]wil  
-Da [C] bruchts viel Volk, gwüss z'halbe Dorf  
+Si [C] hei der Willhelm Täll ufgfüehrt
+Im [G7] Löie z'Nottis[C]wil
+Da [C] bruchts viel Volk, gwüss z'halbe Dorf
 Hett [G7] mitgmacht i däm [C] Schpil
 
-Die [E7] andri Hälfti [Am] isch im Saal gsy  
-[G7] Bim'ne grosse [C] Bier  
-Als [F] publikum, het [C] zuegluegt  
+Die [E7] andri Hälfti [Am] isch im Saal gsy
+[G7] Bim'ne grosse [C] Bier
+Als [F] publikum, het [C] zuegluegt
 Und isch [G7] gschpannt gsy, was pas[C]sier
 
 ## Verse 2
 
-Am [C] Aafang isch es schön gsy  
-Do het [G7] als Schtouffache[C]rin  
-D'Frou [C] Pfarrer mit dem Schnyder gret  
+Am [C] Aafang isch es schön gsy
+Do het [G7] als Schtouffache[C]rin
+D'Frou [C] Pfarrer mit dem Schnyder gret
 I [G7] Wort vo tiefem [C] Sinn
 
-Und [E7] alls isch grüert gsy, [Am] sy het dasmal  
-[G7] Nid gseit, s'Chleid sig z'[C]tüür  
-Und [F] är het guet uf[C]passt  
+Und [E7] alls isch grüert gsy, [Am] sy het dasmal
+[G7] Nid gseit, s'Chleid sig z'[C]tüür
+Und [F] är het guet uf[C]passt
 Das är der [G7] Fade nid ver[C]lüür
 
 ## Verse 3
 
-Uf [C] z'Mal, churz vor em Öpfelschuss  
-Dr [G7] Lehrer chunnt als [C] Täll  
-Sy [C] Sohn, dä fragt'ne dis und äis  
+Uf [C] z'Mal, churz vor em Öpfelschuss
+Dr [G7] Lehrer chunnt als [C] Täll
+Sy [C] Sohn, dä fragt'ne dis und äis
 Do [G7] rüeft dert eine [C] schnäll
 
-Wo [E7] und'rem Huet als [Am] Wach isch gschtande  
-[G7] So dass' jede [C] ghört  
-Wi[F]so fragt dä so [C] dumm  
+Wo [E7] und'rem Huet als [Am] Wach isch gschtande
+[G7] So dass' jede [C] ghört
+Wi[F]so fragt dä so [C] dumm
 Het dä ir [G7] Schuel de nüt rächts [C] glehrt
 
 ## Verse 4
 
-E [C] Fründ vom Täll, e Maa us Altdorf  
-[G7] Zwickt em eis uf ds [C] Muul  
-Und [C] dise wo dr Huet bewacht  
+E [C] Fründ vom Täll, e Maa us Altdorf
+[G7] Zwickt em eis uf ds [C] Muul
+Und [C] dise wo dr Huet bewacht
 Git [G7] ume, gar nid [C] fuul
 
-Und [E7] stosst ihm mit syr [Am] Helebarde  
-[G7] Eine z'Mitzt i [C] Buuch  
-Da [F] chunnt scho s'Volk vo [C] Uri z'springe  
+Und [E7] stosst ihm mit syr [Am] Helebarde
+[G7] Eine z'Mitzt i [C] Buuch
+Da [F] chunnt scho s'Volk vo [C] Uri z'springe
 [G7] Donner jetzt geits [C] ruuch
 
 ## Verse 5
 
-Die [C] einte, die vo Öschterrich  
-[G7] Die näh für d'Wach Par[C]tei  
-Die [C] andre, die vo Altdorf  
+Die [C] einte, die vo Öschterrich
+[G7] Die näh für d'Wach Par[C]tei
+Die [C] andre, die vo Altdorf
 Füre [G7] Täll - ei Schläge[C]rei
 
-Mit [E7] Helebarde, [Am] Kartonschwärt  
-[G7] Kulisse schlöh sy [C] dry  
-[F] Der Täll liit und'rem [C] Gessler scho  
+Mit [E7] Helebarde, [Am] Kartonschwärt
+[G7] Kulisse schlöh sy [C] dry
+[F] Der Täll liit und'rem [C] Gessler scho
 Da [G7] mischt der Saal sech [C] y
 
 ## Verse 6
 
-Jitz [C] chöme Gläser z'flüge  
-Jede [G7] stillt sy gheimi Wuet [C]  
-Es [C] chrose Tisch, u bänk und's Bier  
+Jitz [C] chöme Gläser z'flüge
+Jede [G7] stillt sy gheimi Wuet [C]
+Es [C] chrose Tisch, u bänk und's Bier
 Ver[G7]mischt sech mit em [C] Bluet
 
-Dr [E7] Wirt rouft sech sys [Am] Haar  
-D'Frou schinet [G7] brochni glider y [C]  
-Zwo [F] Stund lang het das duu[C]ret  
+Dr [E7] Wirt rouft sech sys [Am] Haar
+D'Frou schinet [G7] brochni glider y [C]
+Zwo [F] Stund lang het das duu[C]ret
 Do isch [G7] Öschtrich gschlage [C] gsy
 
 ## Verse 7
 
-Si [C] hei der Willhelm Täll ufgfüehrt  
-Im [G7] Löie z'Nottis[C]wil  
-Und [C] gwüss no niene i  
+Si [C] hei der Willhelm Täll ufgfüehrt
+Im [G7] Löie z'Nottis[C]wil
+Und [C] gwüss no niene i
 natura[G7]listischerem [C] Stil
 
-D'Ver[E7]sicherig het [Am] zahlt  
+D'Ver[E7]sicherig het [Am] zahlt
 Hingäge [G7] eis weiss ig sit[C]här:
 
-Sy [F] würde d'Freiheit [C] gwinne  
+Sy [F] würde d'Freiheit [C] gwinne
 Wenn sy [G7] dä Wäg z'gwinne [C] wär _(x2)_
 
 ## Resources

--- a/content/songs/Dynamit (Mani Matter).md
+++ b/content/songs/Dynamit (Mani Matter).md
@@ -2,59 +2,59 @@
 
 ## Verse 1
 
-[Am] Einisch ir Nacht won i spät no bi [E7] gloffe  
-[Am] D'Bundesterrasse z'düruf gäge [G] hei  
-[Am] Han i e bärtige Kärli a[E7]troffe  
-[Am] Und gseh grad, dass dä sech dert, jemers nei [G7]  
-[C] Dass dä sech dert zu nachtschlafener [E] Zyt  
+[Am] Einisch ir Nacht won i spät no bi [E7] gloffe
+[Am] D'Bundesterrasse z'düruf gäge [G] hei
+[Am] Han i e bärtige Kärli a[E7]troffe
+[Am] Und gseh grad, dass dä sech dert, jemers nei [G7]
+[C] Dass dä sech dert zu nachtschlafener [E] Zyt
 [Am] Am Bundeshus z'schaffe macht [E7] mit Dyna[Am]mit
 
 ## Verse 2
 
-[Am] I bi erchlüpft und ha zuen ihm gseit: [E7] Säget  
-[Am] Exgüse, aber es gseht fasch so [G] us  
-[Am] Wi dass dir da jitze würklech er[E7]wäget  
-[Am] Das grad id Luft welle z'spränge das [G7] Hus  
-[C] Ja, seit dä Ma mir mit Füür, es mues [E] sy  
+[Am] I bi erchlüpft und ha zuen ihm gseit: [E7] Säget
+[Am] Exgüse, aber es gseht fasch so [G] us
+[Am] Wi dass dir da jitze würklech er[E7]wäget
+[Am] Das grad id Luft welle z'spränge das [G7] Hus
+[C] Ja, seit dä Ma mir mit Füür, es mues [E] sy
 [Am] Furt mit däm Ghütt, i bi [E7] für d'Anar[Am]chie
 
 ## Verse 3
 
-[Am] Was isch als Bürger mir da übrig[E7]blybe  
-[Am] Als ihm's probiere uszrede, i [G] ha  
-[Am] Ihm afa d'Vorteile alli be[E7]schrybe  
-[Am] Vo üsem Staat, eso guet dass i [G7] cha  
-[C] Ds Rütli und d'Freiheit und d'Demokra[E]tie  
+[Am] Was isch als Bürger mir da übrig[E7]blybe
+[Am] Als ihm's probiere uszrede, i [G] ha
+[Am] Ihm afa d'Vorteile alli be[E7]schrybe
+[Am] Vo üsem Staat, eso guet dass i [G7] cha
+[C] Ds Rütli und d'Freiheit und d'Demokra[E]tie
 [Am] Han i beschworen, är [E7] sölls doch la [Am] sy
 
 ## Verse 4
 
-[Am] D'Angscht het mys Rednertalänt la ent[E7]falte  
-[Am] Chüel het dr Wind um üs gwäit i dr [G] Nacht  
-[Am] Während ig ihm en Ouguschtred ha [E7] ghalte  
-[Am] Dass es es Ross patriotisch hätt [G7] gmacht  
-[C] Z'letscht hei dä Ma mini Wort so be[E]rückt  
+[Am] D'Angscht het mys Rednertalänt la ent[E7]falte
+[Am] Chüel het dr Wind um üs gwäit i dr [G] Nacht
+[Am] Während ig ihm en Ouguschtred ha [E7] ghalte
+[Am] Dass es es Ross patriotisch hätt [G7] gmacht
+[C] Z'letscht hei dä Ma mini Wort so be[E]rückt
 [Am] Dass är e Träne im [E7] Oug het ver[Am]drückt
 
 ## Verse 5
 
-[Am] So han i schliesslech dr Staat chönne [E7] rette  
-[Am] Är isch mit sym Dynamit wieder [G] hei  
-[Am] Und i ha mir a däm Abe im [E7] Bett en  
-[Am] Orde zuegsproche für my ganz al[G7]lei  
-[C] Glunge isch nume, dass zmonderischt^_*_^ [E] scho  
+[Am] So han i schliesslech dr Staat chönne [E7] rette
+[Am] Är isch mit sym Dynamit wieder [G] hei
+[Am] Und i ha mir a däm Abe im [E7] Bett en
+[Am] Orde zuegsproche für my ganz al[G7]lei
+[C] Glunge isch nume, dass zmonderischt^_*_^ [E] scho
 [Am] Über mi Red mir du [E7] Zwyfel si [Am] cho
 
-_^*^ Zmonderischt: Ein Tag, welcher nach einem schon  
+_^*^ Zmonderischt: Ein Tag, welcher nach einem schon
 vergangenen Tag gekommen ist. ([Quelle](https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi))_
 
 ## Verse 6
 
-[Am] Han ig ihm d'Schwyz o mit Rächt eso [E7] prise?  
-[Am] Fragen i mi no bis hüt hinde[G]dry  
-[Am] Und no uf eis het dä Ma mi hi[E7]gwise  
-[Am] Louf i am Bundeshus sider ver[G7]by  
-[C] Mues i gäng dänke, s'steit numen uf [E] Zyt  
+[Am] Han ig ihm d'Schwyz o mit Rächt eso [E7] prise?
+[Am] Fragen i mi no bis hüt hinde[G]dry
+[Am] Und no uf eis het dä Ma mi hi[E7]gwise
+[Am] Louf i am Bundeshus sider ver[G7]by
+[C] Mues i gäng dänke, s'steit numen uf [E] Zyt
 [Am] S'länge fürs z'Spränge paar [E7] Seck Dyna[Am]mit!
 
 [E7] [Am]

--- a/content/songs/Father and son (Cat Stevens).md
+++ b/content/songs/Father and son (Cat Stevens).md
@@ -20,43 +20,43 @@ E |3--3-3-3-3-------|
 ## Intro
 
 _(Riff x4)_
- 
+
 ## Verse 1 - Father
 
-It's not [G] time to make a change [D/F#]  
-just relax [C] and take it ea[Am7]sy  
-You're still [G] young, that's your fault [Em]  
+It's not [G] time to make a change [D/F#]
+just relax [C] and take it ea[Am7]sy
+You're still [G] young, that's your fault [Em]
 there's so [Am] much you have to know [D]
 
-Find a [G] girl, settle down [D/F#]  
-if you want [C], you can mar[Am7]ry  
-Look at me [G], I am old [Em]  
+Find a [G] girl, settle down [D/F#]
+if you want [C], you can mar[Am7]ry
+Look at me [G], I am old [Em]
 but I'm [Am] happy [D]
 
 ---
 
-I was [G] once like you are now [D]  
-and I know [C] that it's not ea[Am7]sy  
-To be [G] calm when you've found [Em]  
+I was [G] once like you are now [D]
+and I know [C] that it's not ea[Am7]sy
+To be [G] calm when you've found [Em]
 something [Am] going on [D]
 
-But take your time [G], think a lot [D]  
-why think of ev[C]erything you've got [Am7]  
-For you will [G] still be here tomorrow [Em]  
+But take your time [G], think a lot [D]
+why think of ev[C]erything you've got [Am7]
+For you will [G] still be here tomorrow [Em]
 but your [Am] dreams [D] may [G] not
 
 _(Riff x2)_
 
 ## Verse 2 - Son
 
-How can I [G] try to explain? [Bm]  
-'cause when I [C] do he turns a[Am7]way again  
-It's al[G]ways been the same [Em]  
+How can I [G] try to explain? [Bm]
+'cause when I [C] do he turns a[Am7]way again
+It's al[G]ways been the same [Em]
 same old [Am] story [D]
 
-From the mo[G]ment I could talk [Bm]  
-I was or[C]dered to lis[Am7]ten  
-Now there's a way [G], and I know [Em] that I [D] have to go away [G]  
+From the mo[G]ment I could talk [Bm]
+I was or[C]dered to lis[Am7]ten
+Now there's a way [G], and I know [Em] that I [D] have to go away [G]
 I [D] know I [C] have to [G] go
 
 _(Riff x2)_
@@ -65,34 +65,34 @@ _(Riff x2)_
 
 _(Instrumental)_
 
-[G] [D] [C] [Am7]  
-[G] [Em] [Am] [C] [D]  
-[G] [D] [C] [Am7]  
-[G] [Em] [D] [G]  
+[G] [D] [C] [Am7]
+[G] [Em] [Am] [C] [D]
+[G] [D] [C] [Am7]
+[G] [Em] [D] [G]
 [D] [C] [G]
 
 ## Verse 3 - Father
 
-It's not [G] time to make a change [D/F#]  
-just ~~relax~~ **sit down** [C] and take it ~~easy~~ **slow[Am7]ly**  
-You're still [G] young, that's your fault [Em]  
+It's not [G] time to make a change [D/F#]
+just ~~relax~~ **sit down** [C] and take it ~~easy~~ **slow[Am7]ly**
+You're still [G] young, that's your fault [Em]
 there's so [Am] much you have to ~~know~~ **go through** [D]
 
-Find a [G] girl, settle down [D/F#]  
-if you want [C], you can mar[Am7]ry  
-Look at me [G], I am old [Em]  
+Find a [G] girl, settle down [D/F#]
+if you want [C], you can mar[Am7]ry
+Look at me [G], I am old [Em]
 but I'm [Am] happy [D]
 
 ## Verse 4 - Son
 
-All the times [G] that I've cried [Bm]  
-keeping all [C] the things I knew [Am7] inside  
+All the times [G] that I've cried [Bm]
+keeping all [C] the things I knew [Am7] inside
 It's hard [G]
 but it's har[Em]der to ig[Am]nore it [D]
 
-If they were right [G], I'd agree [Bm] _(I love this one!)_  
+If they were right [G], I'd agree [Bm] _(I love this one!)_
 but it's them [C] they know, not me [Am7]
-Now there's a way [G], and I know [Em]  
+Now there's a way [G], and I know [Em]
 that I [D] have to go away [G]
 
 I [D] know I [C] have to [G] go

--- a/content/songs/Feel (Robbie Williams).md
+++ b/content/songs/Feel (Robbie Williams).md
@@ -6,52 +6,52 @@
 
 ## Verse 1
 
-Come on and hold my [Dm] hand  
-[Am] I wanna contact the living [A] [A7]  
-Not sure I under[Gm]stand  
+Come on and hold my [Dm] hand
+[Am] I wanna contact the living [A] [A7]
+Not sure I under[Gm]stand
 [Dm] This role I've been gi[A]ven [A7]
 
 ---
 
-I sit and talk to [Dm] God  
-[Am] and he just laughs at my [A] plans [A7]  
-My head speaks a [Gm] language  
+I sit and talk to [Dm] God
+[Am] and he just laughs at my [A] plans [A7]
+My head speaks a [Gm] language
 [Dm] I don't understand [A] [A7]
 
 ## Chorus 1
 
-I just wanna [Bb] feel real lo[F]ve  
-Fill the home that I li[C]ve in  
-Cause I got too much li[Bb]fe  
-Running through my ve[F]igns  
+I just wanna [Bb] feel real lo[F]ve
+Fill the home that I li[C]ve in
+Cause I got too much li[Bb]fe
+Running through my ve[F]igns
 Going to waste [C]
 
 ## Verse 2
 
-I dont wanna [Dm] die  
-[Am] But I ain't keen on living ei[A]ther [A7]  
-Before I fall in [Gm] love  
+I dont wanna [Dm] die
+[Am] But I ain't keen on living ei[A]ther [A7]
+Before I fall in [Gm] love
 [Dm] I'm preparing to le[A]ave her [A7]
 
 ---
 
-I scare myself to de[Dm]ath  
-[Am] That's why I keep on run[A]ning [A7]  
-Before I've ar[Gm]rived  
+I scare myself to de[Dm]ath
+[Am] That's why I keep on run[A]ning [A7]
+Before I've ar[Gm]rived
 [Dm] I can see myself co[A]ming [A7]
 
 ## Chorus 2
 
-I just wanna [Bb] feel real lo[F]ve  
-Fill the home that I li[C]ve in  
-Cause I got too much li[Bb]fe  
-Running through my ve[F]igns  
+I just wanna [Bb] feel real lo[F]ve
+Fill the home that I li[C]ve in
+Cause I got too much li[Bb]fe
+Running through my ve[F]igns
 Going to waste [C]
 
 ---
 
-I just wanna feel [Bb] real lo[F]ve  
-And the life ever af[C]ter  
+I just wanna feel [Bb] real lo[F]ve
+And the life ever af[C]ter
 I cannot get enough
 
 [Dm] [Am] [Dm] [Am] _(3x)_
@@ -60,27 +60,27 @@ I cannot get enough
 
 ## Chorus 2
 
-I just wanna [Bb] feel real lo[F]ve  
-Fill the home that I li[C]ve in  
-Cause I got too much li[Bb]fe  
-Running through my ve[F]igns  
+I just wanna [Bb] feel real lo[F]ve
+Fill the home that I li[C]ve in
+Cause I got too much li[Bb]fe
+Running through my ve[F]igns
 Going to [C] waste
 
 ---
 
-I just wanna feel [Bb] real lo[F]ve  
-And the life ever af[C]ter  
-There's a hole in my soul [Bb]  
-you can see it in my face [F]  
+I just wanna feel [Bb] real lo[F]ve
+And the life ever af[C]ter
+There's a hole in my soul [Bb]
+you can see it in my face [F]
 it's a real big place [C]
 
 ## Bridge
 
 [Dm] [Am] _(2x)_
 
-Come on and hold my [Dm] hand  
-[Am] I wanna contact the li[Dm]ving  
-[Am] Not sure I under[Dm]stand  
+Come on and hold my [Dm] hand
+[Am] I wanna contact the li[Dm]ving
+[Am] Not sure I under[Dm]stand
 [Am] This role I've been gi[Dm]ven
 
 [Am] Not sure I under[Dm]stand _(4x)_

--- a/content/songs/Further on up the road (Johnny Cash).md
+++ b/content/songs/Further on up the road (Johnny Cash).md
@@ -6,37 +6,37 @@
 
 ## Verse 1
 
-Where the road is [Am] dark  
-And the seed is [C] sowed  
-Where the gun is [Am] cocked  
+Where the road is [Am] dark
+And the seed is [C] sowed
+Where the gun is [Am] cocked
 As the bullet's [C] cold
 
-Where the miles are [Am] marked  
-[G] In the blood and the [Am] gold  
+Where the miles are [Am] marked
+[G] In the blood and the [Am] gold
 [G] I'll [F] meet you further [G] on up the road [Am]
 
 ## Verse 2
 
-Got on my dead man [Am] suit  
-And my smilin' skull [C] ring  
-My lucky graveyard [Am] boots  
+Got on my dead man [Am] suit
+And my smilin' skull [C] ring
+My lucky graveyard [Am] boots
 And a song to [C] sing
 
-I got a song to [Am] sing  
-[G] That keeps me out of the [Am] cold  
-[G] And I'll [F] meet you  
+I got a song to [Am] sing
+[G] That keeps me out of the [Am] cold
+[G] And I'll [F] meet you
 further [G] on up the [Am] road
 
 ## Chorus 1
 
-Further on up the [C] road  
-Further on up the [Am] road  
-Where the way is [C] dark  
+Further on up the [C] road
+Further on up the [Am] road
+Where the way is [C] dark
 And the night is [E7] cold
 
-One sunny [Am] mornin'  
-[G] We'll rise I [Am] know  
-[G] And I'll [F] meet you  
+One sunny [Am] mornin'
+[G] We'll rise I [Am] know
+[G] And I'll [F] meet you
 further [G] on up the [Am] road
 
 ## Instrumental
@@ -45,32 +45,32 @@ further [G] on up the [Am] road
 
 ## Verse 3
 
-Now I've been out in the [Am] desert  
-Just don't my [C] time  
-Searchin' through the [Am] dust  
+Now I've been out in the [Am] desert
+Just don't my [C] time
+Searchin' through the [Am] dust
 Lookin' for a [C] sign
 
-If there's a light up a[G]head  
-Well, brother I don't [Am] know  
-[G] But I've [F] got  
+If there's a light up a[G]head
+Well, brother I don't [Am] know
+[G] But I've [F] got
 this fever [G] burnin' in my soul [Am]
 
 ## Chours 2
 
-Further on up the [C] road  
-Further on up the [Am] road  
-Further on up the [C] road  
+Further on up the [C] road
+Further on up the [Am] road
+Further on up the [C] road
 Further on up the [E7] road
 
 ---
 
-One sunny [Am] mornin' [G]  
+One sunny [Am] mornin' [G]
 We'll rise I [Am] know [G]
 
-And I'll [F] meet you  
+And I'll [F] meet you
 further [G] on up the [Am] road [G] _(2x)_
 
-And I'll [F] meet you  
+And I'll [F] meet you
 further [G] on up the [Am] road
 
 ## Resources

--- a/content/songs/Griechischer Wein (Udo Jürgens).md
+++ b/content/songs/Griechischer Wein (Udo Jürgens).md
@@ -7,79 +7,79 @@
 
 ## Verse 1
 
-Es war schon [Am] dunkel, als ich durch  
-Vorstadtstrassen [F] heim[G]wärts [C] ging  
-Da war ein Wirtshaus, aus dem das  
+Es war schon [Am] dunkel, als ich durch
+Vorstadtstrassen [F] heim[G]wärts [C] ging
+Da war ein Wirtshaus, aus dem das
 Licht noch auf den Geh[F]steig [G] schien
 
-Ich hatte [Am] Zeit und mir war [E] kalt  
+Ich hatte [Am] Zeit und mir war [E] kalt
 drum trat ich [Am] ein
 
 ---
 
-Da sassen [Am] Männer mit braunen Augen  
-und mit [F] schwar[G]zem [C] Haar  
-Und aus der Jukebox erklang Musik  
+Da sassen [Am] Männer mit braunen Augen
+und mit [F] schwar[G]zem [C] Haar
+Und aus der Jukebox erklang Musik
 die fremd und süd[F]lich [G] war
 
-Als man mich sah [Am], stand einer auf [E]  
+Als man mich sah [Am], stand einer auf [E]
 und lud mich ein [Am]
 
 ## Chorus 1
 
-[F] Griechischer Wein ist so wie das Blut der Erde  
-[C] Komm schenk dir ein  
-Und wenn ich dann traurig werde, [G] liegt es daran  
+[F] Griechischer Wein ist so wie das Blut der Erde
+[C] Komm schenk dir ein
+Und wenn ich dann traurig werde, [G] liegt es daran
 Dass ich immer träume von da[C]heim
 
 Du musst ver[E]zeihen!
 
 ---
 
-[F] Griechischer Wein und die alt vertrauten Lieder  
-[C] Schenk nochmal ein  
-Denn ich fühl die Sehnsucht wieder  
+[F] Griechischer Wein und die alt vertrauten Lieder
+[C] Schenk nochmal ein
+Denn ich fühl die Sehnsucht wieder
 
-[G] In dieser Stadt  
-werd' ich immer nur ein Fremder [Am] sein  
+[G] In dieser Stadt
+werd' ich immer nur ein Fremder [Am] sein
 [E] und al[Am]lein
 
 ## Verse 2
 
-Und dann er[Am]zählten sie mir von grünen Hügeln  
-[F] Meer [G] und [C] Wind  
+Und dann er[Am]zählten sie mir von grünen Hügeln
+[F] Meer [G] und [C] Wind
 Von alten Häusern und jungen Frauen, die allei[F]ne [G] sind
 
-Und von dem [Am] Kind  
+Und von dem [Am] Kind
 das seinen [E] Vater noch nie [Am] sah
 
 ---
 
-Sie sagten [Am] sich immer wieder  
-irgendwann geht [F] es [G] zu[C]rück  
-Und das Ersparte genügt zu Hause  
+Sie sagten [Am] sich immer wieder
+irgendwann geht [F] es [G] zu[C]rück
+Und das Ersparte genügt zu Hause
 für ein klei[F]nes [G] Glück
 
-Und bald denkt [Am] keiner mehr da[E]ran  
+Und bald denkt [Am] keiner mehr da[E]ran
 wie es hier [Am] war
 
 ## Chorus 2
 
-[F] Griechischer Wein ist so wie das Blut der Erde  
-[C] Komm schenk dir ein  
-Und wenn ich dann traurig werde, [G] liegt es daran  
+[F] Griechischer Wein ist so wie das Blut der Erde
+[C] Komm schenk dir ein
+Und wenn ich dann traurig werde, [G] liegt es daran
 Dass ich immer träume von da[C]heim
 
 Du musst ver[E]zeihen!
 
 ---
 
-[F] Griechischer Wein und die alt vertrauten Lieder  
-[C] Schenk nochmal ein  
+[F] Griechischer Wein und die alt vertrauten Lieder
+[C] Schenk nochmal ein
 Denn ich fühl die Sehnsucht wieder
 
-[G] in dieser Stadt  
-Werd' ich immer nur ein Fremder [Am] sein  
+[G] in dieser Stadt
+Werd' ich immer nur ein Fremder [Am] sein
 [E] und al[Am]lein
 
 ## Outro

--- a/content/songs/Hallelujah (Leonard Cohen).md
+++ b/content/songs/Hallelujah (Leonard Cohen).md
@@ -6,107 +6,107 @@
 
 ## Verse 1
 
-Now I've [C] heard there was a [Am] secret chord  
-That [C] David played, and it [Am] pleased the Lord  
+Now I've [C] heard there was a [Am] secret chord
+That [C] David played, and it [Am] pleased the Lord
 But [F] you don't really [G] care for music, [C] do you? [G]
 
-It [C] goes like this, the [F] fourth, the [G] fifth  
-The [Am] minor fall, the [F] major lift  
+It [C] goes like this, the [F] fourth, the [G] fifth
+The [Am] minor fall, the [F] major lift
 The [G] baffled king [E] composing, halle[Am]lujah
 
 ## Chorus
 
-Halle[F]lujah, halle[Am]lujah  
+Halle[F]lujah, halle[Am]lujah
 Galle[F]lujah, halle[C]lu[G]jah [C] [G]
 
 ## Verse 2
 
-Your [C] faith was strong, but you [Am] needed proof  
-You [C] saw her bathing [Am] on the roof  
+Your [C] faith was strong, but you [Am] needed proof
+You [C] saw her bathing [Am] on the roof
 Her [F] beauty and the [G] moonlight over[C]threw ya [G]
 
-She [C] tied you to a [F] kitchen [G] chair  
-She [Am] broke your throne, and she [F] cut your hair  
+She [C] tied you to a [F] kitchen [G] chair
+She [Am] broke your throne, and she [F] cut your hair
 And [G] from your lips she [E] drew the [Am] hallelujah
 
 ## Chorus
 
-Halle[F]lujah, halle[Am]lujah  
+Halle[F]lujah, halle[Am]lujah
 Galle[F]lujah, halle[C]lu[G]jah [C] [G]
 
 ## Verse 3
 
 [C] Baby, I've been [Am] here before
-I [C] know this room, I've [Am] walked this floor  
+I [C] know this room, I've [Am] walked this floor
 I [F]used to live a[G]lone before I [C] knew you [G]
 
-I've [C] seen your flag on the [F] marble [G] arch  
-[Am]Love is not a [F] victory march  
+I've [C] seen your flag on the [F] marble [G] arch
+[Am]Love is not a [F] victory march
 It's a [G] cold, and it's a [E] broken halle[Am]lujah
 
 ## Chorus
 
-Halle[F]lujah, halle[Am]lujah  
+Halle[F]lujah, halle[Am]lujah
 Galle[F]lujah, halle[C]lu[G]jah [C] [G]
 
 ## Verse 4
 
-There [C] was a time when you [Am] let me know  
-What's [C] really going [Am] on below  
+There [C] was a time when you [Am] let me know
+What's [C] really going [Am] on below
 But [F] now you never [G] show it to me, [C] do you? [G]
 
-And re[C]member when I [F] moved in [G] you  
-The [Am] holy dove was [F] moving too  
+And re[C]member when I [F] moved in [G] you
+The [Am] holy dove was [F] moving too
 And [G] every breath we [E] drew was halle[Am]lujah
 
 ## Chorus
 
-Halle[F]lujah, halle[Am]lujah  
+Halle[F]lujah, halle[Am]lujah
 Galle[F]lujah, halle[C]lu[G]jah [C] [G]
 
 ## Verse 5
 
-[C] Maybe there's a [Am] God above  
-And [C] all I ever [Am] learned from love  
+[C] Maybe there's a [Am] God above
+And [C] all I ever [Am] learned from love
 Was [F] how to shoot at [G] someone who out[C]drew you [G]
 
-It's [C] not a cry you can [F] hear at [G] night  
-It's [Am] not somebody who has [F] seen the light  
+It's [C] not a cry you can [F] hear at [G] night
+It's [Am] not somebody who has [F] seen the light
 It's a [G] cold, and it's a [E] broken halle[Am]lujah
 
 ## Chorus
 
-Halle[F]lujah, halle[Am]lujah  
+Halle[F]lujah, halle[Am]lujah
 Galle[F]lujah, halle[C]lu[G]jah [C] [G]
 
 ## Verse 6
 
-You [C] say I took the [Am] name in vain  
-Though [C] I don't even [Am] know the name  
+You [C] say I took the [Am] name in vain
+Though [C] I don't even [Am] know the name
 But [F] if I did, well [G] really, what's it [C] to ya? [G]
 
-There's a [C] blaze of light in [F] every [G] word  
-It [Am] doesn't matter [F] which you heard  
+There's a [C] blaze of light in [F] every [G] word
+It [Am] doesn't matter [F] which you heard
 The [G] holy or the [E] broken halle[Am]lujah
 
 ## Chorus
 
-Halle[F]lujah, halle[Am]lujah  
+Halle[F]lujah, halle[Am]lujah
 Galle[F]lujah, halle[C]lu[G]jah [C] [G]
 
 ## Verse 7
 
-I [C] did my best, it [Am] wasn't much  
-I [C] couldn't feel, so I [Am] tried to touch  
+I [C] did my best, it [Am] wasn't much
+I [C] couldn't feel, so I [Am] tried to touch
 I've [F] told the truth, I [G] didn't come to [C] fool ya [G]
 
-And [C] even though it [F] all went [G] wrong  
-I'll [Am] stand before the [F] Lord of Song  
+And [C] even though it [F] all went [G] wrong
+I'll [Am] stand before the [F] Lord of Song
 With [G] nothing on my [E] tongue but halle[Am]lujah
 
 ## Chorus
 
-Halle[F]lujah, halle[Am]lujah  
+Halle[F]lujah, halle[Am]lujah
 Galle[F]lujah, halle[C]lu[G]jah [C] [G]
 
 _(4x)_

--- a/content/songs/Hemmige (Mani Matter).md
+++ b/content/songs/Hemmige (Mani Matter).md
@@ -2,30 +2,30 @@
 
 ## Verse 1
 
-S'git [Am] Lüt, die würden alletwäge [Dm] nie  
-Es [G] Lied vorsinge, so win ig jitz [C] hie  
-Eis singe [C] - um kei Pris, nei bhüetis [E7] nei!  
+S'git [Am] Lüt, die würden alletwäge [Dm] nie
+Es [G] Lied vorsinge, so win ig jitz [C] hie
+Eis singe [C] - um kei Pris, nei bhüetis [E7] nei!
 Will si [Am] hemmige [E7] hei
 
 ## Verse 2
 
 Si [Am] wäre vilicht gärn im Grund gno [Dm] fräch
-Und [G] dänke, das syg ires grosse [C] Päch  
-Und [C] s'laschtet uf ne wine schwäre [E7] Stei  
+Und [G] dänke, das syg ires grosse [C] Päch
+Und [C] s'laschtet uf ne wine schwäre [E7] Stei
 dass si [Am] Hemmige [E7] hei
 
 ## Verse 3
 
-I [Am] weis, das macht eim heiss, verschlat eim [Dm] d'Stimm  
-Doch [G] dünkt eim mängisch o s'syg nüt so [C] schlimm  
-S'isch [C] glych es Glück, o we mirs gar nid [E7] wei  
+I [Am] weis, das macht eim heiss, verschlat eim [Dm] d'Stimm
+Doch [G] dünkt eim mängisch o s'syg nüt so [C] schlimm
+S'isch [C] glych es Glück, o we mirs gar nid [E7] wei
 Dass mir [Am] Hemmige [E7] hei
 
 ## Verse 4
 
-Was [Am] unterscheidet d'Mönsche vom schim[Dm]pans?  
-S'isch [G] nid die glatti Huut, dr fählend [C] Schwanz^_(*)_^  
-Nid [C] dass mir schlächter d'Böim ufchöme, [E7] nei  
+Was [Am] unterscheidet d'Mönsche vom schim[Dm]pans?
+S'isch [G] nid die glatti Huut, dr fählend [C] Schwanz^_(*)_^
+Nid [C] dass mir schlächter d'Böim ufchöme, [E7] nei
 Dass mir [Am] Hemmige [E7] hei
 
 _(^*^ Fun Fact: Schimpanse haben gar keinen Schwanz!)_
@@ -34,16 +34,16 @@ _(^*^ Fun Fact: Schimpanse haben gar keinen Schwanz!)_
 
 _(Interlude in Stephan Eicher's Version)_
 
-Me [Am] stell sech d'Manne vor, wenns anders [Dm] wär  
-Und [G] s'chäm es hübsches Meiteli der[C]här  
-Jitz [C] luege mir doch höchstens chly uf d'[E7]Bei  
+Me [Am] stell sech d'Manne vor, wenns anders [Dm] wär
+Und [G] s'chäm es hübsches Meiteli der[C]här
+Jitz [C] luege mir doch höchstens chly uf d'[E7]Bei
 Will mir [Am] Hemmige [E7] hei
 
 ## Verse 6
 
 Und [Am] we me gseht, was hütt dr Mönschheit [Dm] droht
-So [G] gseht me würklech schwarz, nid nume [C] rot  
-Und [C] was me no cha hoffen isch a[E7]lei  
+So [G] gseht me würklech schwarz, nid nume [C] rot
+Und [C] was me no cha hoffen isch a[E7]lei
 Dass si [Am] Hemm[E7]ige [Am] hei
 
 ## Resources

--- a/content/songs/Hurt (Johnny Cash).md
+++ b/content/songs/Hurt (Johnny Cash).md
@@ -16,74 +16,74 @@ Just keep pinky on 3rd fret of e string
 
 ## Intro
 
-[Am]  
-[C] [D] [Am]  
+[Am]
 [C] [D] [Am]
- 
+[C] [D] [Am]
+
 ## Verse 1
 
-I [C] hurt myself [D] today [Am]  
-to see [C] if I [D] still feel [Am]  
-I [C] focus [D] on the pain [Am]  
+I [C] hurt myself [D] today [Am]
+to see [C] if I [D] still feel [Am]
+I [C] focus [D] on the pain [Am]
 the [C] only thing [D] that's real [Am]
 
-The [C] needle [D] tears a hole [Am]  
-the [C] old fa[D]miliar sting [Am]  
-Try to [C] kill it [D] all away [Am]  
+The [C] needle [D] tears a hole [Am]
+the [C] old fa[D]miliar sting [Am]
+Try to [C] kill it [D] all away [Am]
 but I re[C]member [D] everything [G]
- 
+
 ## Chorus 1
 
-[Am7] What have I become? [Fadd9]  
-[C/E] My sweetest friend [G]  
-[Am7] Everyone I know [Fadd9]  
+[Am7] What have I become? [Fadd9]
+[C/E] My sweetest friend [G]
+[Am7] Everyone I know [Fadd9]
 goes away [C/E] in the end [G]
 
-And [Am7] you could have it all [Fadd9]  
-[C/E] My empire of dirt [G]  
-[Am7] I will let you down [Fadd9]  
+And [Am7] you could have it all [Fadd9]
+[C/E] My empire of dirt [G]
+[Am7] I will let you down [Fadd9]
 [G] I will make you hurt [Am]
 
 ## Transition
 
-[C] [D] [Am]  
+[C] [D] [Am]
 [C] [D] [Am]
 
 ## Verse 2
 
-I [C] wear this crown [D] of thorns [Am]  
-u[C]pon my li[D]ar's chair [Am]  
-[C] Full of bro[D]ken thoughts [Am]  
+I [C] wear this crown [D] of thorns [Am]
+u[C]pon my li[D]ar's chair [Am]
+[C] Full of bro[D]ken thoughts [Am]
 [C]I cannot [D] re[Am]pair
 
-Be[C]neath the stains [D] of [Am] time  
-the [C] feelings [D] disappear [Am]  
-[C] You are some[D]one else [Am]  
+Be[C]neath the stains [D] of [Am] time
+the [C] feelings [D] disappear [Am]
+[C] You are some[D]one else [Am]
 [C] I am still [D] right [G] here
 
 _(x2)_
 
 ## Chorus 2
 
-[Am7] What have I become? [Fadd9]  
-[C/E] My sweetest friend [G]  
-[Am7] Everyone I know [Fadd9]  
+[Am7] What have I become? [Fadd9]
+[C/E] My sweetest friend [G]
+[Am7] Everyone I know [Fadd9]
 goes away [C/E] in the end [G]
 
-And [Am7] you could have it all [Fadd9]  
-[C/E] My empire of dirt [G]  
-[Am7] I will let you down [Fadd9]  
+And [Am7] you could have it all [Fadd9]
+[C/E] My empire of dirt [G]
+[Am7] I will let you down [Fadd9]
 [G] I will make you hurt [G] _(remain on G)_
 
 ---
 
-If I [Am7] could start again [Fadd9]  
-a [C/E] million miles a[G]way  
-[Am7] I would keep myself [Fadd9]  
+If I [Am7] could start again [Fadd9]
+a [C/E] million miles a[G]way
+[Am7] I would keep myself [Fadd9]
 [G] I would find a way
 
-[Am]  
-[C] [D] [Am]  
+[Am]
+[C] [D] [Am]
 [C] [D] [Am]
 
 ## Resources

--- a/content/songs/I am sailing (Rod Stewart).md
+++ b/content/songs/I am sailing (Rod Stewart).md
@@ -21,41 +21,41 @@ _(Riff)_
 
 ## Verse 1
 
-I am [G] sailing, I am [Em] sailing  
+I am [G] sailing, I am [Em] sailing
 home a[C]gain 'cross the [G] sea.
 
-I am [Am] sailing stormy [Em] waters  
+I am [Am] sailing stormy [Em] waters
 to be [Am] near you, to be [G] free. [D]
 
 ## Verse 2
- 
-I am [G] flying, I am [Em] flying  
+
+I am [G] flying, I am [Em] flying
 like a [C] bird 'cross the [G] sea.
 
-I am [Am] flying passing [Em] high clouds  
+I am [Am] flying passing [Em] high clouds
 to be [Am] near you, to be [G] free. [D]
 
 ## Chorus
 
-Can you [G] hear me, can you [Em] hear me  
+Can you [G] hear me, can you [Em] hear me
 thru the [C] dark night far a[G]way?
 
-I am [Am] dying, forever [Em] trying  
+I am [Am] dying, forever [Em] trying
 to be [Am] with you, who can [G] say? [D]
- 
+
 _(x2)
- 
+
 [Verse 3]
 
-We are [G] sailing, we are [Em] sailing  
+We are [G] sailing, we are [Em] sailing
 home a[C]gain 'cross the [G] sea.
 
-We are [Am] sailing stormy [Em] waters  
+We are [Am] sailing stormy [Em] waters
 to be [Am] near you, to be [G] free. [D] Oh Lord
 
 ## Outro
- 
-To be [Am] near you, to be [G] free.  
+
+To be [Am] near you, to be [G] free.
 Oh Lord, to be [Am] near you, to be free. [G]
 
 ## Resources

--- a/content/songs/Jolene (Dolly Parton).md
+++ b/content/songs/Jolene (Dolly Parton).md
@@ -3,71 +3,71 @@
 ## Intro
 
 [Am] _(x4)_
- 
+
 ## Chorus
 
-Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene  
-I'm [G] begging of you  
+Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene
+I'm [G] begging of you
 please don't take my [Am] man
 
-Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene  
-[G] Please don't take him  
+Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene
+[G] Please don't take him
 [Em] just because you [Am] can
- 
+
 ## Verse 1
 
-Your [Am] beauty is be[C]yond compare  
-With [G] flaming locks of [Am] auburn hair  
-With [G] ivory skin  
+Your [Am] beauty is be[C]yond compare
+With [G] flaming locks of [Am] auburn hair
+With [G] ivory skin
 and [Em] eyes of emerald [Am] green
 
-Your [Am] smile is like a [C] breath of spring  
-Your [G] voice is soft like [Am] summer rain  
-And [G] I cannot com[Em]pete with you  
+Your [Am] smile is like a [C] breath of spring
+Your [G] voice is soft like [Am] summer rain
+And [G] I cannot com[Em]pete with you
 [Am] Jolene
 
 ## Verse 2
 
-He [Am] talks about you [C] in his sleep  
-There's [G] nothing I can [Am] do to keep  
-From [G] crying when he [Em] calls your name  
+He [Am] talks about you [C] in his sleep
+There's [G] nothing I can [Am] do to keep
+From [G] crying when he [Em] calls your name
 Jo[Am]lene
 
-And [Am] I can easily [C] understand  
-How [G] you could easily [Am] take my man  
-But you [G] don't know what he [Em] means to me  
+And [Am] I can easily [C] understand
+How [G] you could easily [Am] take my man
+But you [G] don't know what he [Em] means to me
 Jo[Am]lene
 
 ## Chorus
 
-Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene  
-I'm [G] begging of you  
+Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene
+I'm [G] begging of you
 please don't take my [Am] man
 
-Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene  
-[G] Please don't take him  
+Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene
+[G] Please don't take him
 [Em] just because you [Am] can
 
 ## Verse 3
 
-[Am] You could have your [C] choice of men  
-But [G] I could never [Am] love again  
-[G] He's the only [Em] one for me  
+[Am] You could have your [C] choice of men
+But [G] I could never [Am] love again
+[G] He's the only [Em] one for me
 Jo[Am]lene
 
-I [Am] had to have this [C] talk with you  
-My [G] happiness de[Am]pends on you  
-What[G]ever you de[Em]cide to do  
+I [Am] had to have this [C] talk with you
+My [G] happiness de[Am]pends on you
+What[G]ever you de[Em]cide to do
 Jo[Am]lene
- 
+
 ## Chorus
 
-Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene  
-I'm [G] begging of you  
+Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene
+I'm [G] begging of you
 please don't take my [Am] man
 
-Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene  
-[G] Please don't take him  
+Jo[Am]lene, Jo[C]lene, Jo[G]lene, Jo[Am]lene
+[G] Please don't take him
 [Em] ~~just because~~ **even though** you [Am] can
 
 ## Resources

--- a/content/songs/Junge (Die Ärzte).md
+++ b/content/songs/Junge (Die Ärzte).md
@@ -8,30 +8,30 @@
 
 _(Picking)_
 
-[F] Junge, warum [G] hast Du  
-nichts gelernt? [Am]  
-Guck Dir den [F] Dieter an:  
+[F] Junge, warum [G] hast Du
+nichts gelernt? [Am]
+Guck Dir den [F] Dieter an:
 [G] der hat sogar ein [Am] Auto! [Em]
 
-Warum [F] gehst Du nicht zu  
-Onkel Werner in die Werk[G]statt?  
+Warum [F] gehst Du nicht zu
+Onkel Werner in die Werk[G]statt?
 Der gibt Dir ne [Am] Festanstellung
 wenn Du ihn darum bittest
 
 [F] Junge... [G]
- 
+
 ## Chorus 1
 
 _(Strumming)_
 
-...und wie du wieder aus[F]siehst  
-Löcher in der Ho[Dm]se  
-und ständig dieser Lärm [Am]  
+...und wie du wieder aus[F]siehst
+Löcher in der Ho[Dm]se
+und ständig dieser Lärm [Am]
 (Was soll'n die Nach[C]barn sagen?)
 
-Und dann noch deine Ha[F]are  
-da fehlen mir die Wor[Dm]te  
-musst du die denn färb'n? [Am]  
+Und dann noch deine Ha[F]are
+da fehlen mir die Wor[Dm]te
+musst du die denn färb'n? [Am]
 (Was soll'n die Nach[C]barn sagen?)
 
 Nie kommst du nach Hau[F]se
@@ -41,9 +41,9 @@ wir wissen nicht mehr wei[Dm]ter
 
 _(Picking)_
 
-[F] Junge, [G] brich deiner  
-Mutter nicht das Herz [Am]  
-es ist noch [F] nicht zu spät  
+[F] Junge, [G] brich deiner
+Mutter nicht das Herz [Am]
+es ist noch [F] nicht zu spät
 [G] dich an der Uni einzu[Am]schreiben
 
 du hast dich doch [F] früher so für Tiere interessiert [G]
@@ -56,43 +56,43 @@ eine eigene Praxis
 
 _(Strumming)_
 
-...und wie du wieder aus[F]siehst  
-Löcher in der Ho[Dm]se  
-und ständig dieser Lärm [Am]  
+...und wie du wieder aus[F]siehst
+Löcher in der Ho[Dm]se
+und ständig dieser Lärm [Am]
 (Was soll'n die Nach[C]barn sagen?)
 
-Elektrische Gi[F]tarren  
-und immer diese Tex[Dm]te  
-das will doch keiner hör'n [Am]  
+Elektrische Gi[F]tarren
+und immer diese Tex[Dm]te
+das will doch keiner hör'n [Am]
 (Was soll'n die Nach[C]barn sagen?)
 
 ---
 
-Nie kommst du nach Hau[F]se  
-so viel schlechter Um[Dm]gang  
-wir werden dich enterb'n [Am]  
+Nie kommst du nach Hau[F]se
+so viel schlechter Um[Dm]gang
+wir werden dich enterb'n [Am]
 (was soll das Finanz[C]amt sagen?)
 
-wo soll das alles en[F]den?  
+wo soll das alles en[F]den?
 Wir machen uns doch Sor[Dm]gen
- 
+
 ## Bridge
 
 _(Very fast strumming)_
 
-[F] und du warst [Dm] so ein süßes [Am] Kind  
-und du warst [C] so ein süßes [F] Kind  
-und du warst [Dm] so ein süßes [Am] Kind  
-du warst so [C] süss 
- 
+[F] und du warst [Dm] so ein süßes [Am] Kind
+und du warst [C] so ein süßes [F] Kind
+und du warst [Dm] so ein süßes [Am] Kind
+du warst so [C] süss
+
 ## Chorus
 
-Und immer deine Freun[F]de  
-ihr nehmt doch alle Dro[Dm]gen  
-und ständig dieser Lärm [Am]  
+Und immer deine Freun[F]de
+ihr nehmt doch alle Dro[Dm]gen
+und ständig dieser Lärm [Am]
 (Was soll'n die Nach[C]barn sagen?)
 
-denk' an deine Zu[F]kunft  
+denk' an deine Zu[F]kunft
 denk' an deine El[Dm]tern...
 
 ...willst du, dass wir [Am] sterb'n?

--- a/content/songs/Keep on the sunny side (Carter Family).md
+++ b/content/songs/Keep on the sunny side (Carter Family).md
@@ -4,69 +4,69 @@
 
 _(Instrumental)_
 
-[C] [F] [C]  
-[C] [G]  
-[G7] [C]  
+[C] [F] [C]
+[C] [G]
+[G7] [C]
 [G] [C]
 
 ## Verse 1
 
-There's a [C] dark and a [F] troubled side of [C] life  
-There's a [C] bright, there's a sunny side [G] too  
-Tho' we [G7] meet with the darkness and [C] strife  
+There's a [C] dark and a [F] troubled side of [C] life
+There's a [C] bright, there's a sunny side [G] too
+Tho' we [G7] meet with the darkness and [C] strife
 The [G] sunny side we also may [C] view
 
 ## Chorus
 
-[C] Keep on the sunny side [F] always on the [C] sunny side  
-Keep on the sunny side of [G] life  
-[C] It will help us every day  
-It will [F] brighten all the [C] way  
+[C] Keep on the sunny side [F] always on the [C] sunny side
+Keep on the sunny side of [G] life
+[C] It will help us every day
+It will [F] brighten all the [C] way
 If we'll [C] keep on the [G] sunny side of [C] life
- 
+
 ## Verse 2
 
-Well the [C] storm and its [F] fury broke to[C]day  
-Crushing [C] hopes that we cherish so [G] dear  
-Clouds and [G7] storms will, in time, pass a[C]way  
+Well the [C] storm and its [F] fury broke to[C]day
+Crushing [C] hopes that we cherish so [G] dear
+Clouds and [G7] storms will, in time, pass a[C]way
 The [G7] sun again will shine bright and [C] clear
 
 ## Chorus
 
-[C] Keep on the sunny side [F] always on the [C] sunny side  
-Keep on the sunny side of [G] life  
-[C] It will help us every day  
-It will [F] brighten all the [C] way  
+[C] Keep on the sunny side [F] always on the [C] sunny side
+Keep on the sunny side of [G] life
+[C] It will help us every day
+It will [F] brighten all the [C] way
 If we'll [C] keep on the [G] sunny side of [C] life
 
 ## Interlude
 
 _(Instrumental)_
 
-[C] [F] [C]  
-[C] [G]  
-[G7] [C]  
+[C] [F] [C]
+[C] [G]
+[G7] [C]
 [G] [C]
 
 ## Verse 3
 
-Let us [C] greet with a [F] song of hope each [C] day  
-Thou the [C] moment be cloudy or [G] fair  
-Let us [G7] trust in our Saviour al[C]ways  
+Let us [C] greet with a [F] song of hope each [C] day
+Thou the [C] moment be cloudy or [G] fair
+Let us [G7] trust in our Saviour al[C]ways
 Who [G7] keepeth everyone in His [C] care
 
 ## Chorus
 
-[C] Keep on the sunny side [F] always on the [C] sunny side  
-Keep on the sunny side of [G] life  
-[C] It will help us every day  
-It will [F] brighten all the [C] way  
+[C] Keep on the sunny side [F] always on the [C] sunny side
+Keep on the sunny side of [G] life
+[C] It will help us every day
+It will [F] brighten all the [C] way
 If we'll [C] keep on the [G] sunny side of [C] life
 
 _(Repeat)_
 
-[C] It will help us every day  
-It will [F] brighten all the [C] way  
+[C] It will help us every day
+It will [F] brighten all the [C] way
 If we'll [C] keep on the [G] sunny side of [C] life
 
 _(Fade out_

--- a/content/songs/Lemon tree (Fool's Garden).md
+++ b/content/songs/Lemon tree (Fool's Garden).md
@@ -25,91 +25,91 @@ Cadd9 |x 3 2 0 3 1|
 
 _(Barre chords)_
 
-[Em] [Bm] [Em] [Bm]  
+[Em] [Bm] [Em] [Bm]
 [Bbm] [Am] [Bm] [Em]
- 
+
 ## Verse 1
 
 _(Barre chords)_
 
-I'm [Em] sitting here in a [Bm] boring room  
-It's [Em] just another rainy sunday [Bm] afternoon  
-I'm [Em] wasting my time I got [Bm] nothing to do  
-I'm [Em] hanging around I'm [Bm] waiting for you  
+I'm [Em] sitting here in a [Bm] boring room
+It's [Em] just another rainy sunday [Bm] afternoon
+I'm [Em] wasting my time I got [Bm] nothing to do
+I'm [Em] hanging around I'm [Bm] waiting for you
 [Bbm] But [Am] nothing ever happens [Bm] - and I won[Em]der
 
 ## Verse 2
 
 _(Barre chords)_
 
-I'm [Em] driving around [Bm] in my car  
-I'm [Em] driving too fast I'm [Bm] driving too far  
-I'd [Em] like to change my [Bm] point of view  
-I [Em] feel so lonely I'm [Bm] waiting for you  
+I'm [Em] driving around [Bm] in my car
+I'm [Em] driving too fast I'm [Bm] driving too far
+I'd [Em] like to change my [Bm] point of view
+I [Em] feel so lonely I'm [Bm] waiting for you
 [Bbm] But [Am] nothing ever happens [Bm] - and I won[Em]der
 
 ## Chorus
 
 _(Open chords)_
 
-I [G] wonder how I [D] wonder why  
-[Em] Yesterday you told me 'bout the [Bm] blue blue sky  
-And all [C/G] that I can see [D]  
+I [G] wonder how I [D] wonder why
+[Em] Yesterday you told me 'bout the [Bm] blue blue sky
+And all [C/G] that I can see [D]
 Is just a yellow [G] lemon tree [D]
-                   
-I'm [G] turning my head [D] up and down  
-I'm [Em] turning turning turning turning [Bm] turning around  
+
+I'm [G] turning my head [D] up and down
+I'm [Em] turning turning turning turning [Bm] turning around
 And [C/G] all that I can [A7] see is just a yellow [D] lemon tree
 
 ## Bridge 1
 
 _(Barre chords)_
 
-[Em] [Bm] [Em] [Bm]  
-[Bbm] [Am] [Bm] [Em]  
+[Em] [Bm] [Em] [Bm]
+[Bbm] [Am] [Bm] [Em]
 Da da da...
 
 ## Verse 3
 
 _(Barre chords)_
 
-I'm [Em] sitting here I [Bm] miss the power  
-I'd [Em] like to go out [Bm] taking a shower  
-But [Em] there's a heavy cloud in[Bm]side my head  
-I [Em] feel so tired put my[Bm]self into bed  
+I'm [Em] sitting here I [Bm] miss the power
+I'd [Em] like to go out [Bm] taking a shower
+But [Em] there's a heavy cloud in[Bm]side my head
+I [Em] feel so tired put my[Bm]self into bed
 [Bbm] Where [Am] nothing ever happens [Bm] - and I won[Em]der
 
 ## Bridge 2
 
 _(Barre chords)_
-           
-[B7] Isolation [Em] is not good for me  
+
+[B7] Isolation [Em] is not good for me
 [D7] Isolation - [G] I don't want to [B7] sit on a lemon tree
-                                                   
+
 ## Verse 4
 
-I'm [Em] steppin' around in a [Bm] desert of joy  
-[Em] Baby anyhow I'll get an[Bm]other toy  
+I'm [Em] steppin' around in a [Bm] desert of joy
+[Em] Baby anyhow I'll get an[Bm]other toy
 And [Am] everything will happen - [Bm] and you'll won[Em]der
 
 ## Chorus
 
 _(Open chords)_
 
-I [G] wonder how I [D] wonder why  
-[Em] Yesterday you told me 'bout the [Bm] blue blue sky  
-And all [C/G] that I can see [D]  
+I [G] wonder how I [D] wonder why
+[Em] Yesterday you told me 'bout the [Bm] blue blue sky
+And all [C/G] that I can see [D]
 Is just a yellow [G] lemon tree [D]
-                   
-I'm [G] turning my head [D] up and down  
-I'm [Em] turning turning turning turning [Bm] turning around  
+
+I'm [G] turning my head [D] up and down
+I'm [Em] turning turning turning turning [Bm] turning around
 And [C/G] all that I can [A7] see is just a yellow [D] lemon tree
 And I wonder I wonder
 
 ---
-              
-I [G] wonder how I [D] wonder why  
-[Em] Yesterday you told me 'bout the [Bm] blue blue sky  
+
+I [G] wonder how I [D] wonder why
+[Em] Yesterday you told me 'bout the [Bm] blue blue sky
 And all [C/G] that I can see [D] _(x3)_
 Is [Cadd9] just a yellow [G7] lemon tree [G]
 

--- a/content/songs/Morning has broken (Cat Stevens).md
+++ b/content/songs/Morning has broken (Cat Stevens).md
@@ -14,77 +14,77 @@ G7sus4 |x x 0 0 1 1|
 
 ## Intro
 
-[D] [G] [A] [F#] [Bm]  
+[D] [G] [A] [F#] [Bm]
 [G7] [C] [F] [C]
 
 ## Verse 1
 
-Morning has [C]brok[Dm]en  
-[G] like the first [F] morn[C]ing  
-[C] Blackbird has [Em] spok[Am]en  
+Morning has [C]brok[Dm]en
+[G] like the first [F] morn[C]ing
+[C] Blackbird has [Em] spok[Am]en
 [D7sus4] like the first [G] bird
 
-[C] Praise for the [F] singing  
-[C] praise for the [Am] morn[D]ing  
-[G] Praise for them [C] spring[F]ing  
+[C] Praise for the [F] singing
+[C] praise for the [Am] morn[D]ing
+[G] Praise for them [C] spring[F]ing
 [G7] fresh from the [C] world
 
 ## Instrumental
 
-[F] [G] [E] [Am]  
+[F] [G] [E] [Am]
 [G7] [C] [G7sus4]
 
 ## Verse 2
 
-Sweet the rain's [C] new [Dm] fall  
-[G] sunlit from [F] heav[C]en  
-[C] Like the first [Em] dew [Am] fall  
+Sweet the rain's [C] new [Dm] fall
+[G] sunlit from [F] heav[C]en
+[C] Like the first [Em] dew [Am] fall
 [D7sus4] on the first [G] grass
 
-[C] Praise for the [F] sweetness  
-[C] of the wet [Am] gard[D]en  
-[G] Sprung in comp[C]lete[F]ness  
+[C] Praise for the [F] sweetness
+[C] of the wet [Am] gard[D]en
+[G] Sprung in comp[C]lete[F]ness
 [G7] where his feet [C] pass
 
 ## Instrumental
 
-[F] [G] [E] [Am]  
-[F#] [Bm] [G] [D]  
+[F] [G] [E] [Am]
+[F#] [Bm] [G] [D]
 [A7/D] [D]
 
 ## Verse 3
 
-Mine is the [D] sun[Em]light  
-[A] mine is the [G] morn[D]ing  
-Born of the [F#m] one [Bm] light  
+Mine is the [D] sun[Em]light
+[A] mine is the [G] morn[D]ing
+Born of the [F#m] one [Bm] light
 [E7] Eden saw [A] play [A7]
 
-[D] Praise with el[G]ation  
-[D] praise every [Bm] morn[E]ing  
-[A] God's recre[D]a[G]tion  
+[D] Praise with el[G]ation
+[D] praise every [Bm] morn[E]ing
+[A] God's recre[D]a[G]tion
 [A7] of the new [D] day
 
 ## Instrumental
 
-[G] [A] [F#] [Bm]  
+[G] [A] [F#] [Bm]
 [G7] [C] [F] [C]
 
 ## Verse 1
 
-Morning has [C]brok[Dm]en  
-[G] like the first [F] morn[C]ing  
-[C] Blackbird has [Em] spok[Am]en  
+Morning has [C]brok[Dm]en
+[G] like the first [F] morn[C]ing
+[C] Blackbird has [Em] spok[Am]en
 [D7sus4] like the first [G] bird
 
-[C] Praise for the [F] singing  
-[C] praise for the [Am] morn[D]ing  
-[G] Praise for them [C] spring[F]ing  
+[C] Praise for the [F] singing
+[C] praise for the [Am] morn[D]ing
+[G] Praise for them [C] spring[F]ing
 [G7] fresh from the [C] world
 
 ## Outro
 
-[F] [G] [E] [Am]  
-[F#] [Bm] [G] [D]  
+[F] [G] [E] [Am]
+[F#] [Bm] [G] [D]
 [A7/D] [D]
 
 ## Resources

--- a/content/songs/Männer sind Schweine (Die Ärzte).md
+++ b/content/songs/Männer sind Schweine (Die Ärzte).md
@@ -2,66 +2,66 @@
 
 ## Verse 1
 
-Hal[G]lo, mein Schatz, ich liebe Dich,  
-Du [Em] bist die einzige für mich.  
-Die [C] andern find' ich alle doof,  
+Hal[G]lo, mein Schatz, ich liebe Dich,
+Du [Em] bist die einzige für mich.
+Die [C] andern find' ich alle doof,
 Des[D]wegen mach ich Dir den Hof.
 
-Du [G] bist so anders, ganz speziell,  
-Ich [Em] merke sowas immer schnell.  
-Jetzt [C] zieh Dich aus und leg Dich hin,  
+Du [G] bist so anders, ganz speziell,
+Ich [Em] merke sowas immer schnell.
+Jetzt [C] zieh Dich aus und leg Dich hin,
 Weil [D] ich so verliebt in Dich bin.
 
 ## Bridge 1
 
-[C] Gleich wird es dunkel, [Bm] bald ist es Nacht,  
+[C] Gleich wird es dunkel, [Bm] bald ist es Nacht,
 Da [C] ist ein Wort der Warnung angebracht! [D]
 
 ## Chorus 1
 
-Männer sind [G] Schweine!  
-Traue ihnen [Em] nicht, mein Kind!  
-Sie wollen [Am] alle das eine!  
+Männer sind [G] Schweine!
+Traue ihnen [Em] nicht, mein Kind!
+Sie wollen [Am] alle das eine!
 Weil [C] Männer nun mal so [D] sind.
 
 ## Verse 2
 
-Ein [G] Mann fühlt sich erst dann als Mann,  
-Wenn [Em] er es Dir besorgen kann.  
-Er [C] lügt, dass sich die Balken biegen.  
+Ein [G] Mann fühlt sich erst dann als Mann,
+Wenn [Em] er es Dir besorgen kann.
+Er [C] lügt, dass sich die Balken biegen.
 [D] Nur, um Dich ins Bett zu kriegen.
 
-Und [G] dann am nächsten Morgen weiss er  
-[Em] Nicht einmal mehr, wie Du heisst.  
-[C] Rücksichtslos und ungehemmt,  
+Und [G] dann am nächsten Morgen weiss er
+[Em] Nicht einmal mehr, wie Du heisst.
+[C] Rücksichtslos und ungehemmt,
 Ge[D]fühle sind ihm völlig fremd.
 
 ## Bridge 2
 
-[C] Für ihn ist Liebe gleich [Bm] Samenverlust,  
+[C] Für ihn ist Liebe gleich [Bm] Samenverlust,
 [C] Mädchen, sei Dir dessen stets bewusst! [D]
 
 ## Chorus 2
 
-Männer sind [G] Schweine!  
-Frage nicht nach [Em] Sonnenschein.  
-Ausnahmen [Am] gibt's leider keine!  
+Männer sind [G] Schweine!
+Frage nicht nach [Em] Sonnenschein.
+Ausnahmen [Am] gibt's leider keine!
 In jedem [C] Mann steckt auch immer ein [D] Schwein!
 
-Männer sind [G] Säue!  
-Glaube ihnen [Em] nicht ein Wort!  
-Sie schwör'n Dir [Am] ewige Treue  
+Männer sind [G] Säue!
+Glaube ihnen [Em] nicht ein Wort!
+Sie schwör'n Dir [Am] ewige Treue
 Und dann am [C] nächsten Morgen sind sie fort. [D]
 
 ## Verse 3
 
-Und [G] falls Du doch den Fehler machst  
-Und [Em] Dir 'nen Ehemann anlachst.  
+Und [G] falls Du doch den Fehler machst
+Und [Em] Dir 'nen Ehemann anlachst.
 Mu[C]tiert dein Rosenkavalier
 Bald [D] nach der Hochzeit auch zum Tier.
 
-Da [G] zeigt er dann sein wahres Ich,  
-Ganz [Em] unrasiert und widerlich.  
+Da [G] zeigt er dann sein wahres Ich,
+Ganz [Em] unrasiert und widerlich.
 Trinkt [C] Bier, sieht fern und wird schnell fett.
 Und [D] rülpst und furzt im Ehebett.
 
@@ -72,26 +72,26 @@ Drum [C] sag' ich Dir - denk bitte stets daran: [D]
 
 ## Chorus 3
 
-Männer sind [G] Schweine!  
-Traue ihnen [Em] nicht, mein Kind!  
-Sie wollen [Am] alle das eine!  
+Männer sind [G] Schweine!
+Traue ihnen [Em] nicht, mein Kind!
+Sie wollen [Am] alle das eine!
 Für wahre [C] Liebe sind sie blind [D].
 
-Männer sind [G] Ratten  
-Begegne ihnen [Em] nur mit List  
-Sie wollen [Am] alles begatten  
+Männer sind [G] Ratten
+Begegne ihnen [Em] nur mit List
+Sie wollen [Am] alles begatten
 Was nicht bei [C] drei auf den Bäumen ist [D]
 
 ---
 
-Männer sind [G] Schweine!  
-Frage nicht nach [Em] Sonnenschein.  
-Ausnahmen [Am] gibt's leider keine!  
+Männer sind [G] Schweine!
+Frage nicht nach [Em] Sonnenschein.
+Ausnahmen [Am] gibt's leider keine!
 In jedem [C] Mann steckt auch immer ein [D] Schwein!
 
-Männer sind [G] Autos  
-Nur ohne Re[Em]serverad  
-Yeah, yeah, yeah, yeaääääää [Am]  
+Männer sind [G] Autos
+Nur ohne Re[Em]serverad
+Yeah, yeah, yeah, yeaääääää [Am]
 [C] Uh-hu, uh-hu [D]
 
 ## Resources

--- a/content/songs/No woman no cry (Bob Marley).md
+++ b/content/songs/No woman no cry (Bob Marley).md
@@ -1,98 +1,98 @@
 # No woman no cry (Bob Marley)
 
 ## Intro
- 
+
 _(Instrumental)_
- 
-[C] [G/B] [Am] [F]  
+
+[C] [G/B] [Am] [F]
 [C] [F] [C] [G]
- 
+
 ## Chorus
 
-[C] No [G/B] woman no cry [Am] [F]  
+[C] No [G/B] woman no cry [Am] [F]
 [C] No [F] woman no cry [C] [G]
 
 _(Repeat)_
 
 ## Verse 1
 
-Said said  
-[C] said I re[G/B]member  
-[Am] when we used to sit [F]  
-[C] In the govern[G/B]ment yard  
+Said said
+[C] said I re[G/B]member
+[Am] when we used to sit [F]
+[C] In the govern[G/B]ment yard
 in [Am] trenchtown [F]
 
-[C] Oba-oba[G/B]serving the [Am] hypo[F]crites  
-As they would [C] mingle  
+[C] Oba-oba[G/B]serving the [Am] hypo[F]crites
+As they would [C] mingle
 with the good [G/B] people we meet [Am] [F]
 
 ---
 
-[C] good friends [G/B] we had oh  
-[Am] good friend we lost [F]  
+[C] good friends [G/B] we had oh
+[Am] good friend we lost [F]
 [C] along [G/B] the way [Am] [F]
 
-[C] In this bright [G/B] future  
-you [Am] cant forget your past [F]  
+[C] In this bright [G/B] future
+you [Am] cant forget your past [F]
 [C] So dry your tears [G/B] I say [Am] [F]
 
 ## Chorus
 
-[C] No [G/B] woman no cry [Am] [F]  
+[C] No [G/B] woman no cry [Am] [F]
 [C] No [F] woman no cry [C] [G]
 
-~~No woman no cry~~  
-**[C] Here [G/B] little darlin'**  
-**[Am] don't shed no [F] tears**  
+~~No woman no cry~~
+**[C] Here [G/B] little darlin'**
+**[Am] don't shed no [F] tears**
 [C] No [F] woman no cry [C] [G]
 
 ## Verse 1
 
-Said said  
-[C] said I re[G/B]member  
-[Am] when we used to sit [F]  
-[C] In the govern[G/B]ment yard  
+Said said
+[C] said I re[G/B]member
+[Am] when we used to sit [F]
+[C] In the govern[G/B]ment yard
 in [Am] trenchtown [F]
 
-[C] And then [G/B] Georgie  
-would [Am] make a fire light [F]  
-as it was [C] log wood [G/B] burnin  
+[C] And then [G/B] Georgie
+would [Am] make a fire light [F]
+as it was [C] log wood [G/B] burnin
 through the nights [Am] [F]
 
 ---
 
-[C] Then we [G/B] would cook  
-corn [Am] meal porridge [F]  
-[C] of which I'll [G/B] share  
+[C] Then we [G/B] would cook
+corn [Am] meal porridge [F]
+[C] of which I'll [G/B] share
 with you [Am] yeah [F]
 
-[C] My feet [G/B] is my [Am] only carriage [F]  
-[C] and so I've got [G/B] to  
-push on through [Am]  
+[C] My feet [G/B] is my [Am] only carriage [F]
+[C] and so I've got [G/B] to
+push on through [Am]
 But while I'm [F] gone
 
 ## Bridge
 
-[C] Everything's gonna [G/B] be alright  
+[C] Everything's gonna [G/B] be alright
 [Am] Everything's gonna [F] be alright
 
 _(x4)_
 
 ## Chorus
 
-[C] No [G/B] woman no cry [Am] [F]  
+[C] No [G/B] woman no cry [Am] [F]
 [C] No [F] woman no cry [C] [G]
 
-~~No woman no cry~~  
-**[C] Here [G/B] little darlin'**  
-**[Am] don't shed no [F] tears**  
+~~No woman no cry~~
+**[C] Here [G/B] little darlin'**
+**[Am] don't shed no [F] tears**
 [C] No [F] woman no cry [C] [G]
 
 ## Outro
 
 _(Instrumental)_
 
-[C] [G/B] [Am] [F]  
+[C] [G/B] [Am] [F]
 [C] [F] [C] [G]
 
 _(Repeat and fade)_

--- a/content/songs/One (U2).md
+++ b/content/songs/One (U2).md
@@ -3,91 +3,91 @@
 ## Intro
 
 [Am] [Dsus2] [FM7] [G] _(x4)_
- 
+
 ## Verse 1
 
-[Am] Is it getting [Dsus2] better?  
-[FM7] Or do you feel the [G] same?  
-[Am] Will it make it [Dsus2] easier on you?  
+[Am] Is it getting [Dsus2] better?
+[FM7] Or do you feel the [G] same?
+[Am] Will it make it [Dsus2] easier on you?
 Now [FM7] you got someone to [G] blame
 
 You say
 
 ## Chorus 1
 
-[C] One love [Am] One life  
-[FM7] When it's one need [C] in the night  
-[C]One love [Am] We got to share it  
-[FM7] It leaves you baby  
+[C] One love [Am] One life
+[FM7] When it's one need [C] in the night
+[C]One love [Am] We got to share it
+[FM7] It leaves you baby
 if you [C] don't care for it
 
 [Am] [Dsus2] [FM7] [G]
 
 ## Verse 2
 
-[Am] Did I disap[Dsus2]point you?  
-[FM7] Or leave a bad taste in your [G] mouth?  
-[Am] You act like you never [Dsus2] had love  
+[Am] Did I disap[Dsus2]point you?
+[FM7] Or leave a bad taste in your [G] mouth?
+[Am] You act like you never [Dsus2] had love
 [FM7] And you want me to go with[G]out
 
 Well it's
- 
+
 ## Bridge 1
 
-[C] Too late [Am] Tonight  
-[FM7] To drag the past out in[C]to the light  
-[C] We're one, but we're [Am] not the same  
-We got to [FM7] carry each other  
+[C] Too late [Am] Tonight
+[FM7] To drag the past out in[C]to the light
+[C] We're one, but we're [Am] not the same
+We got to [FM7] carry each other
 [C] carry each other
 
 [Am] [Dsus2] [FM7] [G]
 
 ## Verse 3
 
-[Am] Have you come here for for[Dsus2]giveness?  
-[FM7] Have you come to raise [G] the dead?  
-[Am] Have you come here to play [Dsus2] Jesus  
+[Am] Have you come here for for[Dsus2]giveness?
+[FM7] Have you come to raise [G] the dead?
+[Am] Have you come here to play [Dsus2] Jesus
 [FM7] To the lepers in your [G] head?
 
 ## Bridge 2
 
-[C] Did I ask too much? [Am] More than a lot?  
-[FM7] You gave me nothing, now it's [C] all I got  
-[C] We're one, but we're [Am] not the same  
-Well we [FM7] hurt each other  
+[C] Did I ask too much? [Am] More than a lot?
+[FM7] You gave me nothing, now it's [C] all I got
+[C] We're one, but we're [Am] not the same
+Well we [FM7] hurt each other
 then we [C] do it again
 
 You say
 
 ## Interlude
 
-[C] Love is a temple [Am] Love's a higher law  
-[C] Love is a temple [Am] Love's the higher law  
-You [C] ask me to enter  
+[C] Love is a temple [Am] Love's a higher law
+[C] Love is a temple [Am] Love's the higher law
+You [C] ask me to enter
 but [G] then you make me crawl
-                      
-And [G] I can't be holding on [FM7]  
-To what you got [FM7]  
+
+And [G] I can't be holding on [FM7]
+To what you got [FM7]
 When all you got is hurt
 
 ## Chorus 3
 
-[C] One love [Am] One ~~life~~ **blood**  
-~~When it's one need in the night~~  
+[C] One love [Am] One ~~life~~ **blood**
+~~When it's one need in the night~~
 **[FM7] One life, You got to [C] do what you should**
-~~One love, we got to share it~~  
-**[C] One life [Am] with each other**  
-~~It leaves you baby~~  
-[FM7] Sisters  
-~~if you don't care for it~~  
+~~One love, we got to share it~~
+**[C] One life [Am] with each other**
+~~It leaves you baby~~
+[FM7] Sisters
+~~if you don't care for it~~
 **[C] Brothers**
 
 ## Outro
 
-[C] One life, but we're [Am] not the same  
+[C] One life, but we're [Am] not the same
 We got to [FM7] carry each other, car[C]ry each other
 
-One [C] [Am] One [FM7] [C]  
+One [C] [Am] One [FM7] [C]
 _(Repeat several times and fade)_
 
 ## Resources

--- a/content/songs/Rivers of Babylon (Boney M.).md
+++ b/content/songs/Rivers of Babylon (Boney M.).md
@@ -4,24 +4,24 @@
 
 _(Vocals only)_
 
-Mmmh [G] mmmh [G] mmmh [D7] mmmh [G]  
+Mmmh [G] mmmh [G] mmmh [D7] mmmh [G]
 Uuuh [G] uuuh [G] uuuh [D7] uuuh [G]
- 
+
 ## Chorus
 
-By the rivers of [G] Babylon  
-there we sat down  
-Ye-eah we [D7] wept  
+By the rivers of [G] Babylon
+there we sat down
+Ye-eah we [D7] wept
 when we remembered Zi[G]on
 
 _(x2)_
- 
+
 ## Verse 1
 
-(When the wicked)  
-[G] Carried us away in cap[G7]tivity  
-Re[C]quired from us a song [G]  
-Now how shall we sing the lord's song  
+(When the wicked)
+[G] Carried us away in cap[G7]tivity
+Re[C]quired from us a song [G]
+Now how shall we sing the lord's song
 in a stra[D7]nge [G] land
 
 _(x2)_
@@ -32,17 +32,17 @@ Mmmh [G] mmmh [G] mmmh [D7] mmmh [G]
 
 ## Bridge
 
-Let the [G] words of our [D7] mouth  
-and the medi[G]tations of our heart [D7]  
+Let the [G] words of our [D7] mouth
+and the medi[G]tations of our heart [D7]
 Be acc[G]eptable in thy sight [D7]here to[G]night
 
 _(x2)_
 
 ## Chorus
 
-By the rivers of [G] Babylon  
-there we sat down  
-Ye-eah we [D7] wept  
+By the rivers of [G] Babylon
+there we sat down
+Ye-eah we [D7] wept
 when we remembered Zi[G]on
 
 _(Repeat and fade)_

--- a/content/songs/Road to Mandalay (Robbie Williams).md
+++ b/content/songs/Road to Mandalay (Robbie Williams).md
@@ -19,62 +19,62 @@ X Stop playing
 
 ## Verse 1
 
-[Dm] Save me from drowning in the sea [Dm6]  
-[Am] Beat me up on the beach  
-[Dm]What a lovely holiday [E7(1)]  
+[Dm] Save me from drowning in the sea [Dm6]
+[Am] Beat me up on the beach
+[Dm]What a lovely holiday [E7(1)]
 There's nothing funny left to say [Asus] [Am]
 
-[Dm] This sombre song would drain the sun [Dm6]  
-[Am] But it won't shine until it's sung  
-[Dm] No water running in the stream [E7(2)]  
+[Dm] This sombre song would drain the sun [Dm6]
+[Am] But it won't shine until it's sung
+[Dm] No water running in the stream [E7(2)]
 The saddest place we've ever seen [A7sus4] [A7]
 
 ## Bridge 1
 
-[F/A] Everything I touched was gol[G7]den  
-Everything I loved got [C] broken  
+[F/A] Everything I touched was gol[G7]den
+Everything I loved got [C] broken
 On the road to Mandalay
 
-[F] Every mistake I've ever made [Em]  
-Has been rehashed and then re[Dm]played  
+[F] Every mistake I've ever made [Em]
+Has been rehashed and then re[Dm]played
 As I got lost along the way [G]
 
 ## Chorus
 
-[X] Bum bum bum [Dm] ba da dum bum bum [G]  
+[X] Bum bum bum [Dm] ba da dum bum bum [G]
 Bum bum bum [C] ba da dum bum bum [Am]
 
-Bum bum bum [F] ba da dum, bum bum [G]  
+Bum bum bum [F] ba da dum, bum bum [G]
 Bum ba dum [Am]
 
 ## Verse 2
 
-[Dm] There's nothing left for you to give [Dm6]  
-[Am] The truth is all that you're left with  
-[Dm] Twenty paces then at dawn [E7(1)]  
+[Dm] There's nothing left for you to give [Dm6]
+[Am] The truth is all that you're left with
+[Dm] Twenty paces then at dawn [E7(1)]
 We will [E7] die and be reborn [Asus] [Am]
 
-[Dm] I like to sleep beneath the trees [Dm6]  
-[Am] Have the universe at one with me  
-[Dm] Look down the barrel of a gun [E7(2)]  
+[Dm] I like to sleep beneath the trees [Dm6]
+[Am] Have the universe at one with me
+[Dm] Look down the barrel of a gun [E7(2)]
 And feel the moon replace the sun [A7sus4] [A7]
 
 ## Bridge 2
 
-[F/A] Everything we've ever sto[G7]len  
-Has been lost returned or [C] broken  
+[F/A] Everything we've ever sto[G7]len
+Has been lost returned or [C] broken
 No more dragons left to slay
 
-[F] Every mistake I've ever made [Em]  
-Has been rehashed and then re[Dm]played  
+[F] Every mistake I've ever made [Em]
+Has been rehashed and then re[Dm]played
 As I got lost along the way [G]
 
 ## Chorus
 
-[X] Bum bum bum [Dm] ba da dum bum bum [G]  
+[X] Bum bum bum [Dm] ba da dum bum bum [G]
 Bum bum bum [C] ba da dum bum bum [Am]
 
-Bum bum bum [F] ba da dum, bum bum [G]  
+Bum bum bum [F] ba da dum, bum bum [G]
 Bum ba dum [Am]
 
 _(x3)_
@@ -87,9 +87,9 @@ _(Instrumental)_
 
 ## Outro
 
-[Dm] Save me from drowning in the sea [Dm6]  
-[Am] Beat me up on the beach  
-[Dm]What a lovely holiday [E7(1)]  
+[Dm] Save me from drowning in the sea [Dm6]
+[Am] Beat me up on the beach
+[Dm]What a lovely holiday [E7(1)]
 There's nothing funny left to say [Am]
 
 ## Resources

--- a/content/songs/Road trippin' (Red Hot Chili Peppers).md
+++ b/content/songs/Road trippin' (Red Hot Chili Peppers).md
@@ -5,97 +5,97 @@
 _(Instrumental)_
 
 [Em] [C] [B] _(x2)_
- 
+
 ## Verse 1
 
-[Em] Road trippin with my two  
-[C] favorite all[B]ies  
-[Em] Fully loaded we got  
+[Em] Road trippin with my two
+[C] favorite all[B]ies
+[Em] Fully loaded we got
 [C] snacks and supp[B]lies
 
-[Em] It's time to leave this town  
-It's [C] time to steal away [B]  
-[Em] Let's go get lost  
+[Em] It's time to leave this town
+It's [C] time to steal away [B]
+[Em] Let's go get lost
 any[C]where in the U.S.A. [B]
 
 ---
 
-[Em] Let's go get lost  
+[Em] Let's go get lost
 let's go get [C] lost [B]
 
-[Em] Blue you sit so pretty  
-[C] West of the one [B]  
-[Em] Sparkles light with yellow [C] icing  
+[Em] Blue you sit so pretty
+[C] West of the one [B]
+[Em] Sparkles light with yellow [C] icing
 Just a [B] mirror for the sun [Em]
 
 ##  Chorus
 
-[C] Just a [B] mirror for the [Em] sun  
-[C] Just a [B] mirror for the  
+[C] Just a [B] mirror for the [Em] sun
+[C] Just a [B] mirror for the
 [Am] Sun [G/B] [C] [D]
 
-[Am] These smiling [G/B] eyes  
+[Am] These smiling [G/B] eyes
 are just a [C] mirror for [D]
- 
+
 ## Verse 2
 
-[Em] So much has come before  
-those [C] battles lost and [B] won  
-[Em] This life is shining  
+[Em] So much has come before
+those [C] battles lost and [B] won
+[Em] This life is shining
 more for[C]ever in the sun [B]
 
-[Em] Now let us check our heads  
-And [C] let us check the surf [B]  
-[Em] Staying high and dry's more [C] trouble  
+[Em] Now let us check our heads
+And [C] let us check the surf [B]
+[Em] Staying high and dry's more [C] trouble
 than it's [B] worth in the sun [Em]
 
 ##  Chorus
 
-[C] Just a [B] mirror for the [Em] sun  
-[C] Just a [B] mirror for the  
+[C] Just a [B] mirror for the [Em] sun
+[C] Just a [B] mirror for the
 [Am] Sun [G/B] [C] [D]
 
-[Am] These smiling [G/B] eyes  
+[Am] These smiling [G/B] eyes
 are just a [C] mirror for [D]
 
 ## Interlude
 
 _(Instrumental)_
- 
+
 [Em] [A] [C] [D] [Em] [A] [C] [Bdim] _(x2)_
- 
+
 [Bdim] _(x4)_
 
 ## Verse 3
 
 
-[Em] In Big Sur we take some  
-[C] time to linger on [B]  
-[Em] We three hunky dory's got  
+[Em] In Big Sur we take some
+[C] time to linger on [B]
+[Em] We three hunky dory's got
 [C] our snake[B]finger on
 
-[Em] Now let us drink the stars  
-[C] It's time to steal away [B]  
-[Em] Let's go get lost  
+[Em] Now let us drink the stars
+[C] It's time to steal away [B]
+[Em] Let's go get lost
 ~~anywhere~~ **right [C] here** in the U.S.A. [B]
 
 ---
 
-[Em] Let's go get lost  
+[Em] Let's go get lost
 let's go get [C] lost [B]
 
-[Em] Blue you sit so pretty  
-[C] West of the one [B]  
-[Em] Sparkles light with yellow [C] icing  
+[Em] Blue you sit so pretty
+[C] West of the one [B]
+[Em] Sparkles light with yellow [C] icing
 Just a [B] mirror for the sun [Em]
 
 ##  Chorus
 
-[C] Just a [B] mirror for the [Em] sun  
-[C] Just a [B] mirror for the  
+[C] Just a [B] mirror for the [Em] sun
+[C] Just a [B] mirror for the
 [Am] Sun [G/B] [C] [D]
 
-[Am] These smiling [G/B] eyes  
+[Am] These smiling [G/B] eyes
 are just a [C] mirror for [D] _(x3)_
 
 ## Resources

--- a/content/songs/S Zündhölzli (Mani Matter).md
+++ b/content/songs/S Zündhölzli (Mani Matter).md
@@ -2,74 +2,74 @@
 
 ## Verse 1
 
-I han es [C]Zündhölzli azündet  
-Und das [G7] het e Flamme gäh  
-Und i [Am] ha für d'Zigarette  
+I han es [C]Zündhölzli azündet
+Und das [G7] het e Flamme gäh
+Und i [Am] ha für d'Zigarette
 Welle [E] Füür vom Hölzli näh
 
 Aber ds [F] Hölzli isch dervogspickt
-Und [C] uf e Teppich cho  
-Und es [G7] hätt no fasch  
+Und [C] uf e Teppich cho
+Und es [G7] hätt no fasch
 Es Loch i Teppich [C] gäh dervo
 
 ## Verse 2
 
-Ja me [C] weiss was cha passiere  
-We me [G7] nid ufpasst mit Füür  
-Und für d'[Am]Gluet ar Zigarette  
+Ja me [C] weiss was cha passiere
+We me [G7] nid ufpasst mit Füür
+Und für d'[Am]Gluet ar Zigarette
 Isch e [E] Teppich doch de z'tüür
 
-Und vom [F] Teppich hätt - oh Grus  
-Chönne ds [C] Füür i ds ganze Hus  
-Und wär [G7] weiss, was da  
+Und vom [F] Teppich hätt - oh Grus
+Chönne ds [C] Füür i ds ganze Hus
+Und wär [G7] weiss, was da
 Nid alles no wär [C] worde drus
 
 ## Verse 3
 
-S'hätt e [C] Brand gäh im Quartier  
-Und s'hätti d'[G7]Füürwehr müesse cho  
-Hätti [Am] ghornet i de Strasse  
+S'hätt e [C] Brand gäh im Quartier
+Und s'hätti d'[G7]Füürwehr müesse cho
+Hätti [Am] ghornet i de Strasse
 Und dr [E] Schluuch vom Wage gno
 
-Und sie [F] hätte Wasser gsprützt  
-Und das [C] hätt de glych nüt gnützt  
-Und die [G7] ganzi Stadt hätt brönnt  
+Und sie [F] hätte Wasser gsprützt
+Und das [C] hätt de glych nüt gnützt
+Und die [G7] ganzi Stadt hätt brönnt
 Es hätt se [C] nüt meh gschützt
 
 ## Verse 4
 
-Und d'Lüt [C] wären umegsprunge  
-I dr [G7] Angscht um Hab und Guet  
-Hätte [Am] gmeint s'heig eine Füür gleit  
+Und d'Lüt [C] wären umegsprunge
+I dr [G7] Angscht um Hab und Guet
+Hätte [Am] gmeint s'heig eine Füür gleit
 Hätte ds [E] Sturmgwehr gno ir Wuet
 
-Alls hätt [F] brüelet: Wär isch tschuld?  
-Ds ganze [C] Land i eim Tumult  
-Dass me [G7] gschosse hätt  
+Alls hätt [F] brüelet: Wär isch tschuld?
+Ds ganze [C] Land i eim Tumult
+Dass me [G7] gschosse hätt
 Uf d'Bundesrät am [C] Rednerpult
 
 ## Verse 5
 
-D'UNO [C] hätt interveniert  
-Und d'UNO-[G7]Gägner sofort o  
-Für ir [Am] Schwyz dr Fride z'rette  
+D'UNO [C] hätt interveniert
+Und d'UNO-[G7]Gägner sofort o
+Für ir [Am] Schwyz dr Fride z'rette
 Wäre [E] beid mit Panzer cho
 
-S'hätt sech [F] usdehnt nadisna  
-Uf Eu[C]ropa, Afrika  
-S'hätt e [G7] Wältchrieg gäh  
+S'hätt sech [F] usdehnt nadisna
+Uf Eu[C]ropa, Afrika
+S'hätt e [G7] Wältchrieg gäh
 Und d'Mönschheit wär jitz [C] nümme da
 
 ## Verse 6
 
-I han es [C] Zündhölzli azündet  
-Und das [G7] het e Flamme gäh  
-Und i [Am] ha für d'Zigarette  
+I han es [C] Zündhölzli azündet
+Und das [G7] het e Flamme gäh
+Und i [Am] ha für d'Zigarette
 Welle [E] Füür vom Hölzli näh
 
-Aber ds [F] Hölzli isch dervogspickt  
+Aber ds [F] Hölzli isch dervogspickt
 Und [C] uf e Teppich cho -
-~~Und es hätt no fasch...~~ Gottsei[G7]dank  
+~~Und es hätt no fasch...~~ Gottsei[G7]dank
 Dass i's vom Teppich wider [C] furt ha gno
 
 ## Resources

--- a/content/songs/Sittin' on the dock of the bay (Otis Redding).md
+++ b/content/songs/Sittin' on the dock of the bay (Otis Redding).md
@@ -1,46 +1,46 @@
 # Sittin' on the dock of the bay (Otis Redding)
- 
+
 ## Verse 1
 
-[G] Sittin' in the mornin' sun [B7]  
-I'll be [C] sittin' when the evenin' comes [A]  
-[G] Watching the ships roll in [B7]  
+[G] Sittin' in the mornin' sun [B7]
+I'll be [C] sittin' when the evenin' comes [A]
+[G] Watching the ships roll in [B7]
 And then I [C] watch 'em roll away again [A] yeah
 
 ## Chorus
 
-I'm [G] sittin' on the dock of the [E] bay  
-Watching the [G] tide roll [E]away, ooo  
-I'm just [G] sittin' on the dock of the [A] bay  
+I'm [G] sittin' on the dock of the [E] bay
+Watching the [G] tide roll [E]away, ooo
+I'm just [G] sittin' on the dock of the [A] bay
 Wastin' [G] time [E]
 
 ## Verse 2
 
-I [G] left my home in [B7] Georgia  
-[C] Headed for the 'Frisco Bay [A]  
-[G] 'Cause I've had nothing to [B7] live for  
+I [G] left my home in [B7] Georgia
+[C] Headed for the 'Frisco Bay [A]
+[G] 'Cause I've had nothing to [B7] live for
 And look like [C] nothin's gonna come my way [A]
 
 ## Chorus
 
-~~I'm sittin'~~ **So I'm just gonna [G] sit** on the dock of the [E] bay  
-Watching the [G] tide roll [E]away, ooh  
-~~I'm just~~ **Ooo I'm** [G] sittin' on the dock of the [A] bay  
+~~I'm sittin'~~ **So I'm just gonna [G] sit** on the dock of the [E] bay
+Watching the [G] tide roll [E]away, ooh
+~~I'm just~~ **Ooo I'm** [G] sittin' on the dock of the [A] bay
 Wastin' [G] time [E]
 
 ## Bridge
 
-                         
-[G] Looks like [D] nothing's [C] gonna change [G]  
-[G] Everything [D] still remains [C] the same [G]  
-[G] I can't [D] do what [C] ten people [G] tell me to do  
+
+[G] Looks like [D] nothing's [C] gonna change [G]
+[G] Everything [D] still remains [C] the same [G]
+[G] I can't [D] do what [C] ten people [G] tell me to do
 So I [F] guess I'll remain the [D] same, yes
 
 ## Chorus
 
-**Now** I'm [G] sitting on the dock of the [E] bay  
-Watching the [G] tide roll [E]away, ooh  
-~~I'm just~~ **Ooo I'm** [G] sittin' on the dock of the [A] bay  
+**Now** I'm [G] sitting on the dock of the [E] bay
+Watching the [G] tide roll [E]away, ooh
+~~I'm just~~ **Ooo I'm** [G] sittin' on the dock of the [A] bay
 Wastin' [G] time [E]
 
 _(Repeat and whistle, fade)_

--- a/content/songs/Something stupid (Robbie Williams).md
+++ b/content/songs/Something stupid (Robbie Williams).md
@@ -25,81 +25,81 @@ D+ |x x 0 3 3 2| To switch from D, point pinky on G string
 
 ## Verse 1
 
-I [G6] know I stand in line  
-until you think you have the time  
+I [G6] know I stand in line
+until you think you have the time
 to spend an [Am] evening with me [D7] [Am] [D7]
 
-And [Am] if we go some[D7]place to dance  
-I [Am] know that there's a chance [D7]  
+And [Am] if we go some[D7]place to dance
+I [Am] know that there's a chance [D7]
 you won't be [G6] leaving with me
 
 ---
 
-Then [G] afterwards we drop  
-into a [G7] quiet little place  
+Then [G] afterwards we drop
+into a [G7] quiet little place
 and have a [C] drink or two [Eb]
 
-And [Am] then I go and [D7] spoil it all  
-by [Am] saying something [D7] stupid  
+And [Am] then I go and [D7] spoil it all
+by [Am] saying something [D7] stupid
 like: "I [G6] love you"
 
 ## Bridge
 
-I can [G] see it in your eyes  
-that you de[G7]spise the same old lies  
+I can [G] see it in your eyes
+that you de[G7]spise the same old lies
 you heard the [C] night before
 
-And [A7] though it's just a line to you  
-For me it's true and  
+And [A7] though it's just a line to you
+For me it's true and
 never seemed so [D] right before [D+]
 
 ## Verse 2
 
-I [G6] practice every day  
-to find some clever lines to say to make  
+I [G6] practice every day
+to find some clever lines to say to make
 the [Am] meaning come through [D7] [Am] [D7]
 
-But [Am] then I think I'll [D7] wait until  
-the [Am] evening gets late [D7]  
+But [Am] then I think I'll [D7] wait until
+the [Am] evening gets late [D7]
 and I'm [G6] alone with you
 
 ---
 
-The [G] time is right  
-your perfume fills my [G7] head  
-the stars get red  
+The [G] time is right
+your perfume fills my [G7] head
+the stars get red
 and oh the [C] night's so blue [Eb]
 
-And [Am] then I go and [D7] spoil it all  
-by [Am] saying something [D7] stupid  
+And [Am] then I go and [D7] spoil it all
+by [Am] saying something [D7] stupid
 like: "I [G6] love you"
 
 ## Bridge
 
 _(Instrumental, maybe add whistling)_
 
-[G] [G7] [C] 
+[G] [G7] [C]
 [A7] [D] [D+]
- 
+
 ## Verse 2
 
-I [G6] practice every day  
-to find some clever lines to say to make  
+I [G6] practice every day
+to find some clever lines to say to make
 the [Am] meaning come through [D7] [Am] [D7]
 
-But [Am] then I think I'll [D7] wait until  
-the [Am] evening gets late [D7]  
+But [Am] then I think I'll [D7] wait until
+the [Am] evening gets late [D7]
 and I'm [G6] alone with you
 
 ---
 
-The [G] time is right  
-your perfume fills my [G7] head  
-the stars get red  
+The [G] time is right
+your perfume fills my [G7] head
+the stars get red
 and oh the [C] night's so blue [Eb]
 
-And [Am] then I go and [D7] spoil it all  
-by [Am] saying something [D7] stupid  
+And [Am] then I go and [D7] spoil it all
+by [Am] saying something [D7] stupid
 like: "I [G] love you" [Eb]
 
 I [G] love you [Eb] _(Repeat and fade)_

--- a/content/songs/Somewhere over the rainbow (Israël Kamakawiwo'ole).md
+++ b/content/songs/Somewhere over the rainbow (Israël Kamakawiwo'ole).md
@@ -6,107 +6,107 @@ _(Instrumental)_
 
 [C] [G] [Am] [F] _(repeat)_
 
-[C] Ooo-ooo [Em] ooo-ooo  
-[F] ooo-ooo [C] ooo-ooo  
-[F] Ooo-ooo [E7] ooo-ooo  
+[C] Ooo-ooo [Em] ooo-ooo
+[F] ooo-ooo [C] ooo-ooo
+[F] Ooo-ooo [E7] ooo-ooo
 [Am] ooo-ooo [F] ooo-ooo
 
 ## Verse 1
 
-[C] Somewhere [Em] over the rainbow  
-[F] way up [C] high  
-[F] And the [C] dreams that you dream of  
+[C] Somewhere [Em] over the rainbow
+[F] way up [C] high
+[F] And the [C] dreams that you dream of
 [G] once in a lulla[Am]by [F]
 
-Oh [C] somewhere [Em] over the rainbow  
-[F] blue birds [C] fly  
-[F] And the [C] dreams that you dream of  
+Oh [C] somewhere [Em] over the rainbow
+[F] blue birds [C] fly
+[F] And the [C] dreams that you dream of
 [G] dreams really do come [Am] true [F]
 
 ## Verse 2
 
-Some[C]day i'll wish upon a star  
-[G] To wake up where the clouds are far  
+Some[C]day i'll wish upon a star
+[G] To wake up where the clouds are far
 be[Am]hind [F] me
 
-Where [C] trouble melts like lemon drops  
-[G] High above the chimney tops  
-that's [Am] where  
+Where [C] trouble melts like lemon drops
+[G] High above the chimney tops
+that's [Am] where
 you'll [F] find me
 
 ## Interlude 1
 
-Oh [C] somewhere [Em] over the rainbow  
-[F] blue birds [C] fly  
-[F] And the [C] dreams that you dare to oh  
+Oh [C] somewhere [Em] over the rainbow
+[F] blue birds [C] fly
+[F] And the [C] dreams that you dare to oh
 [G] why oh why can't [Am] I? [F]
 
 ## Verse 3
 
-Well I see [C] trees of [Em] green and  
-[F] Red roses [C] too  
-[F] I'll watch them [C] bloom for  
+Well I see [C] trees of [Em] green and
+[F] Red roses [C] too
+[F] I'll watch them [C] bloom for
 [E7] me and [Am] you
 
-And I [F] think to myself  
+And I [F] think to myself
 [G] what a wonderful [Am] world [F]
 
 ---
 
-Well I see [C] skies of [Em] blue and I see  
-[F] clouds of [C] white  
-And the [F] brightness of [C] day  
+Well I see [C] skies of [Em] blue and I see
+[F] clouds of [C] white
+And the [F] brightness of [C] day
 [E7] I like the [Am] dark
 
-And I [F] think to myself  
+And I [F] think to myself
 [G] what a wonderful [C] world [F] [C]
 
 ## Bridge
 
-The [G] colours of the rainbow  
-so [C] pretty in the sky  
-Are [G] also on the faces  
+The [G] colours of the rainbow
+so [C] pretty in the sky
+Are [G] also on the faces
 of [C] people passing bye
 
-See [F] friends shaking [C] hands  
-saying [F] how do you [C] do?  
-[F] They're really [C] saying  
+See [F] friends shaking [C] hands
+saying [F] how do you [C] do?
+[F] They're really [C] saying
 [Dm7] I - I love [D] you
 
 ## Interlude 2
 
-I hear [C] babies [Em] cry and I  
-[F] watch them [C] grow  
-[F] They'll learn much [C] more  
+I hear [C] babies [Em] cry and I
+[F] watch them [C] grow
+[F] They'll learn much [C] more
 [E7] than we'll [Am] know
 
-And I [F] think to myself  
+And I [F] think to myself
 [G] what a wonderful [Am] world [F] world
 
 ## Verse 2
 
-Some[C]day i'll wish upon a star  
-[G] To wake up where the clouds are far  
+Some[C]day i'll wish upon a star
+[G] To wake up where the clouds are far
 be[Am]hind [F] me
 
-Where [C] trouble melts like lemon drops  
-[G] High above the chimney tops  
-that's [Am] where  
+Where [C] trouble melts like lemon drops
+[G] High above the chimney tops
+that's [Am] where
 you'll [F] find me
 
 ## Interlude 1
 
-[C] Oh somewhere [Em] over the rainbow  
-~~blue birds fly~~  
-**[F] way up [C] high**  
-[F] And the [C] dreams that you dare to  
+[C] Oh somewhere [Em] over the rainbow
+~~blue birds fly~~
+**[F] way up [C] high**
+[F] And the [C] dreams that you dare to
 [G] why oh why can't [Am] I? [F]
 
 ## Outro
 
-[C] Ooo-ooo [Em] ooo-ooo  
-[F] ooo-ooo [C] ooo-ooo  
-[F] ooo-ooo [E7] ooo-ooo  
+[C] Ooo-ooo [Em] ooo-ooo
+[F] ooo-ooo [C] ooo-ooo
+[F] ooo-ooo [E7] ooo-ooo
 [Am] ooo-a-eh-a [F] a-a-a-a-a
 
 ## Resources

--- a/content/songs/Summer wine (Nancy Sinatra & Lee Hazlewood).md
+++ b/content/songs/Summer wine (Nancy Sinatra & Lee Hazlewood).md
@@ -4,24 +4,24 @@
 
 _(Female)_
 
-[Am] Strawberries, cherries and an  
-[G] angel's kiss in spring  
-[Am] My summer wine is really  
+[Am] Strawberries, cherries and an
+[G] angel's kiss in spring
+[Am] My summer wine is really
 [G] made from all these things
 
 [Am] (x4)
- 
+
 ## Verse 1
 
 _(Male)_
 
-[Am] I walked in town on silver  
-[G] spurs that jingled to  
-[Am] A song that I had only  
-[G] sang to just a few  
+[Am] I walked in town on silver
+[G] spurs that jingled to
+[Am] A song that I had only
+[G] sang to just a few
 
-[Dm] She saw my silver spurs and  
-[Am] said let's pass some time  
+[Dm] She saw my silver spurs and
+[Am] said let's pass some time
 [Dm] And I will give to you [Am] summer wine
 
 [G]Ohhh[Em]oh summer wine [Am]
@@ -29,14 +29,14 @@ _(Male)_
 ## Chorus
 
 _(Female)_
- 
-[Am] Strawberries, cherries and an  
-[G] angel's kiss in spring  
-[Am] My summer wine is really  
+
+[Am] Strawberries, cherries and an
+[G] angel's kiss in spring
+[Am] My summer wine is really
 [G] made from all these things
 
-[Dm] Take off your silver spurs and  
-[Am] help me pass the time  
+[Dm] Take off your silver spurs and
+[Am] help me pass the time
 [Dm] And I will give to you [Am] summer wine
 
 [G]Ohhh[Em]oh summer wine [Am]
@@ -44,67 +44,67 @@ _(Female)_
 ## Verse 2
 
 _(Male)_
- 
-                         
-[Am] My eyes grew heavy and my  
-[G] lips they could not speak  
-[Am] I tried to get up but I  
+
+
+[Am] My eyes grew heavy and my
+[G] lips they could not speak
+[Am] I tried to get up but I
 [G] couldn't find my feet
 
-[Dm] She reassured me with an  
-[Am] unfamiliar line  
+[Dm] She reassured me with an
+[Am] unfamiliar line
 [Dm] And then she gave to me [Am] more summer wine
 
 [G]Ohhh[Em]oh summer wine [Am]
- 
+
 ## Chorus
 
 _(Female)_
- 
-[Am] Strawberries, cherries and an  
-[G] angel's kiss in spring  
-[Am] My summer wine is really  
+
+[Am] Strawberries, cherries and an
+[G] angel's kiss in spring
+[Am] My summer wine is really
 [G] made from all these things
 
-[Dm] Take off your silver spurs and  
-[Am] help me pass the time  
+[Dm] Take off your silver spurs and
+[Am] help me pass the time
 [Dm] And I will give to you [Am] summer wine
 
 [G]Ohhh[Em]oh summer wine [Am]
- 
+
 ## Verse 2
- 
+
 _(Male)_
-                          
-[Am] When I woke up the sun was  
-[G] shining in my eyes  
-[Am] My silver spurs were gone  
+
+[Am] When I woke up the sun was
+[G] shining in my eyes
+[Am] My silver spurs were gone
 my [G] head felt twice its size
 
-[Dm] She took my silver spurs  
-a [Am] dollar and a dime  
+[Dm] She took my silver spurs
+a [Am] dollar and a dime
 [Dm] And left me cravin' for [Am] more summer wine
 
-[G]Ohhh[Em]oh summer wine [Am] 
- 
+[G]Ohhh[Em]oh summer wine [Am]
+
 ## Chorus
 
 _(Female)_
- 
-[Am] Strawberries, cherries and an  
-[G] angel's kiss in spring  
-[Am] My summer wine is really  
+
+[Am] Strawberries, cherries and an
+[G] angel's kiss in spring
+[Am] My summer wine is really
 [G] made from all these things
 
-[Dm] Take off your silver spurs and  
-[Am] help me pass the time  
+[Dm] Take off your silver spurs and
+[Am] help me pass the time
 [Dm] And I will give to you [Am] summer wine
 
 [G]Ohhh[Em]oh summer wine [Am]
 
 ## Outro
- 
-[Am] [G] [Am] [G]  
+
+[Am] [G] [Am] [G]
 [Dm] [Am] [Dm] [Am]
 
 ## Resources

--- a/content/songs/The river is flowing (Indian Summer).md
+++ b/content/songs/The river is flowing (Indian Summer).md
@@ -4,50 +4,50 @@
 
 _(Chords sequence remains the same)_
 
-The [Am] river is [C] flowing  
-[G] flowing in [Am] growing  
-the river is flowing  
+The [Am] river is [C] flowing
+[G] flowing in [Am] growing
+the river is flowing
 back to the sea
 
-Mother Earth is caring me  
-her child I will always be  
-Mother Earth is caring me  
+Mother Earth is caring me
+her child I will always be
+Mother Earth is caring me
 back to the sea
- 
+
 ## Verse 2
 
-The [Am] Moon she [C] is waiting  
-[G] waxing and [Am] waning  
-the Moon she is waiting  
+The [Am] Moon she [C] is waiting
+[G] waxing and [Am] waning
+the Moon she is waiting
 for us to be free
 
-Sister Moon watch over me  
-a child I will always be  
-Sister Moon watch over me  
+Sister Moon watch over me
+a child I will always be
+Sister Moon watch over me
 until we are free
- 
+
 ## Verse 3
 
-The [Am] Sun he [C] is shining  
-[G] brightly he's [Am] shining  
-the Sun he is shining  
+The [Am] Sun he [C] is shining
+[G] brightly he's [Am] shining
+the Sun he is shining
 lightning the way
 
-Father Sun shine over me  
-your child I will always be  
-father Sun shine over me  
-until we can see  
- 
+Father Sun shine over me
+your child I will always be
+father Sun shine over me
+until we can see
+
 ## Verse 4
 
-The [Am] Fire [C] is burning  
-[G] destroying and [Am] healing  
-the Fire is burning  
+The [Am] Fire [C] is burning
+[G] destroying and [Am] healing
+the Fire is burning
 for us to get pure
 
-Violet Flame burn over me  
-a child I will always be  
-violet Flame burn over me  
+Violet Flame burn over me
+a child I will always be
+violet Flame burn over me
 until we are pure
 
 ## Resources

--- a/content/songs/Verdammt ich lieb dich (Matthias Reim).md
+++ b/content/songs/Verdammt ich lieb dich (Matthias Reim).md
@@ -2,21 +2,21 @@
 
 ## Verse 1
 
-Ich [Am] ziehe durch die Straßen bis nach Mitternacht  
-hab das früher auch gern gemacht  
+Ich [Am] ziehe durch die Straßen bis nach Mitternacht
+hab das früher auch gern gemacht
 dich [G] brauch ich dafür [Am] nicht!
 
-Ich [Am] sitze am Tresen, trinke noch 'n Bier  
-früher war'n wir oft gemeinsam hier  
+Ich [Am] sitze am Tresen, trinke noch 'n Bier
+früher war'n wir oft gemeinsam hier
 das [G] macht mir, macht mir [Am] nichts!
 
 ---
 
-[C] Gegenüber sitzt 'n Typ wie'n Bär  
-ich [G] stell' mir vor, wenn das dein Neuer wär'  
+[C] Gegenüber sitzt 'n Typ wie'n Bär
+ich [G] stell' mir vor, wenn das dein Neuer wär'
 Das [Am] juckt mich [G] überhaupt [Am] nicht.
 
-Auf [C] einmal packt's mich, ich geh auf ihn zu  
+Auf [C] einmal packt's mich, ich geh auf ihn zu
 und [G] mach ihn an: "Lass meine Frau in Ruh!"
 Er [Am] fragt nur: [G] "Hast du'n [Am] Stich?"
 
@@ -26,39 +26,39 @@ Und ich [F] denke schon wieder nur an [G] dich...
 
 _(x2: gently first time, then repeat intensively)_
 
-Verdammt, ich [C] lieb' dich, ich lieb' dich [G] nicht.  
-Verdammt, ich [Dm] brauch' dich, brauch' dich [Am] nicht. [G]  
-Verdammt, ich [C] will dich, ich will dich [G] nicht,  
+Verdammt, ich [C] lieb' dich, ich lieb' dich [G] nicht.
+Verdammt, ich [Dm] brauch' dich, brauch' dich [Am] nicht. [G]
+Verdammt, ich [C] will dich, ich will dich [G] nicht,
 Ich [F] will dich nicht verli[Am]er'n!
 
 ## Verse 2
 
 So [Am] langsam fällt mir alles wieder ein:
-Ich wollt doch nur'n bisschen freier sein.  
+Ich wollt doch nur'n bisschen freier sein.
 Jetzt [G] bin ich's - oder [Am] nicht?
 
 
-Ich [Am] passte nicht in deine heile Welt  
-doch die und du ist, was mir jetzt so fehlt  
+Ich [Am] passte nicht in deine heile Welt
+doch die und du ist, was mir jetzt so fehlt
 ich [G] glaub das einfach [Am] nicht.
 
 ---
 
-[C] Gegenüber steht 'n Telefon  
-es [G] lacht mich ständig an voll Hohn  
+[C] Gegenüber steht 'n Telefon
+es [G] lacht mich ständig an voll Hohn
 Es [Am] klingelt, [G] klingelt aber [Am] nicht.
 
-[C] Sieben Bier, zuviel geraucht  
-das [G] ist es, was ein Mann so braucht,  
+[C] Sieben Bier, zuviel geraucht
+das [G] ist es, was ein Mann so braucht,
 Doch [F] niemand, [G] niemand sagt: "Hör auf". [Am]
 
 Und ich [F] denke schon wieder nur an [G] dich...
 
 ## Chorus
 
-Verdammt, ich [C] lieb' dich, ich lieb' dich [G] nicht.  
-Verdammt, ich [Dm] brauch' dich, brauch' dich [Am] nicht. [G]  
-Verdammt, ich [C] will dich, ich will dich [G] nicht,  
+Verdammt, ich [C] lieb' dich, ich lieb' dich [G] nicht.
+Verdammt, ich [Dm] brauch' dich, brauch' dich [Am] nicht. [G]
+Verdammt, ich [C] will dich, ich will dich [G] nicht,
 Ich [F] will dich nicht verli[Am]er'n! - Ooooh!
 
 _(Repeat and fade)_

--- a/content/songs/What's up (4 Non Blondes).md
+++ b/content/songs/What's up (4 Non Blondes).md
@@ -3,34 +3,34 @@
 ## Intro
 
 [D] [Em] [G] [D] _(x2)_
- 
+
 ## Verse 1
 
-[D] Twenty-five years and my life is still  
-[Em] Trying to get up that great big hill  
+[D] Twenty-five years and my life is still
+[Em] Trying to get up that great big hill
 Of [G] hope for a destina[D]tion
 
-I [D] realized quickly when I knew I should  
-That the world [Em] was made of this brotherhood  
+I [D] realized quickly when I knew I should
+That the world [Em] was made of this brotherhood
 Of man, [G] for whatever that means [D]
- 
+
 ## Pre-Chorus
 
-And so I [D] cry sometimes when I'm lying in bed  
-Just to [Em] get it all out, what's in my head  
+And so I [D] cry sometimes when I'm lying in bed
+Just to [Em] get it all out, what's in my head
 and I [G] - I am feeling a little pecu[D]liar
 
-And so I [D] wake in the morning and I step outside  
-and I [Em] take a deep breath and I get real high and  
+And so I [D] wake in the morning and I step outside
+and I [Em] take a deep breath and I get real high and
 I [G] scream at the top of my lungs:
 
 "What's going [D] on?"
 
 ## Chorus
 
-And I said [D] "Heyeyeyeyey [Em] Heyeyey"  
-I said "Hey, [G] what's going on?" [D]  
-And I said [D] "Heyeyeyeyey [Em] Heyeyey"  
+And I said [D] "Heyeyeyeyey [Em] Heyeyey"
+I said "Hey, [G] what's going on?" [D]
+And I said [D] "Heyeyeyeyey [Em] Heyeyey"
 I said "Hey, [G] what's going on?" [D]
 
 ## Interlude
@@ -38,30 +38,30 @@ I said "Hey, [G] what's going on?" [D]
 [D] Ooh [Em] Ooh [G] Ooh [D] _(x2)_
 
 ## Verse
-                         
-And I try, [D] oh my Aod do I try [Em]  
-I try all the time, [G] in this institu[D]tion  
+
+And I try, [D] oh my Aod do I try [Em]
+I try all the time, [G] in this institu[D]tion
 And I pray, [D] oh my god do I pray [Em]
-I pray every single day [G]  
+I pray every single day [G]
 For a revo[D]lution
 
 ## Pre-Chorus
 
-And so I [D] cry sometimes when I'm lying in bed  
-Just to [Em] get it all out, what's in my head  
+And so I [D] cry sometimes when I'm lying in bed
+Just to [Em] get it all out, what's in my head
 and I [G] - I am feeling a little pecu[D]liar
 
-And so I [D] wake in the morning and I step outside  
-and I [Em] take a deep breath and I get real high and  
+And so I [D] wake in the morning and I step outside
+and I [Em] take a deep breath and I get real high and
 I [G] scream at the top of my lungs:
 
 "What's going [D] on?"
 
 ## Chorus
 
-And I said [D] "Heyeyeyeyey [Em] Heyeyey"  
-I said "Hey, [G] what's going on?" [D]  
-And I said [D] "Heyeyeyeyey [Em] Heyeyey"  
+And I said [D] "Heyeyeyeyey [Em] Heyeyey"
+I said "Hey, [G] what's going on?" [D]
+And I said [D] "Heyeyeyeyey [Em] Heyeyey"
 I said "Hey, [G] what's going on?" [D]
 
 _(Repeat)_
@@ -72,8 +72,8 @@ _(Repeat)_
 
 ## Outro
 
-[D] Twenty-five years and my life is still  
-[Em] Trying to get up that great big hill  
+[D] Twenty-five years and my life is still
+[Em] Trying to get up that great big hill
 Of [G] hope for a destina[D]tion
 
 ## Resources

--- a/content/songs/Wild world (Cat Stevens).md
+++ b/content/songs/Wild world (Cat Stevens).md
@@ -20,55 +20,55 @@ E |------------3|3-3---------3-|
 
 ## Intro
 
-[Am] [D/F#] [G] [C] [F] [Dm] [E] [Esus4] [E]  
+[Am] [D/F#] [G] [C] [F] [Dm] [E] [Esus4] [E]
 La la la...
- 
+
 ## Verse 1
 
-[Am] Now that I've [D/F#] lost everything to [G] you  
-You say you [C] wanna start something [F] new  
-And it's [Dm] breaking my heart you're [E] leaving  
+[Am] Now that I've [D/F#] lost everything to [G] you
+You say you [C] wanna start something [F] new
+And it's [Dm] breaking my heart you're [E] leaving
 Baby I'm [Esus4] griev[E]ing
 
-But [Am] if you wanna [D/F#] leave take good [G] care  
-Hope you have a [C] lot of nice things to wear [F]  
-But then a [Dm] lot of nice things turn  
+But [Am] if you wanna [D/F#] leave take good [G] care
+Hope you have a [C] lot of nice things to wear [F]
+But then a [Dm] lot of nice things turn
 [E] bad out[E7]there [G] [G7] [G6] [G5]
 
 ## Chorus
 
-[C] Oh [G] baby, baby it's a [F] wild world  
-[C] _(Riff 1)_  
-[G] It's hard to get by [F] just upon a [C] smile  
+[C] Oh [G] baby, baby it's a [F] wild world
+[C] _(Riff 1)_
+[G] It's hard to get by [F] just upon a [C] smile
 [G] _(Riff 2)_
 
-[C] Oh [G] baby, baby it's a [F] wild world  
-[C] _(Riff 1)_  
+[C] Oh [G] baby, baby it's a [F] wild world
+[C] _(Riff 1)_
 [G] I'll always remember you [F] like a [C] child girl
 [Dm] [E]
 
 ## Verse 2
 
-[Am] You know I've seen a [D/F#] lot of  
-what the world can [G] do  
-And it's [C] breaking my heart in [F] two  
-'cause I [Dm] never want to see you [E] sad girl  
+[Am] You know I've seen a [D/F#] lot of
+what the world can [G] do
+And it's [C] breaking my heart in [F] two
+'cause I [Dm] never want to see you [E] sad girl
 Don't be a [Esus4] bad [E] girl
 
-But [Am] if you wanna [D/F#] leave take good [G] care  
-Hope you make a [C] lot of nice friends out there [F]  
-But just re[Dm]member there's a lot of bad  
+But [Am] if you wanna [D/F#] leave take good [G] care
+Hope you make a [C] lot of nice friends out there [F]
+But just re[Dm]member there's a lot of bad
 [E] and be[E7]ware [G] [G7] [G6] [G5]
 
 ## Chorus
 
-[C] Oh [G] baby, baby it's a [F] wild world  
-[C] _(Riff 1)_  
-[G] It's hard to get by [F] just upon a [C] smile  
+[C] Oh [G] baby, baby it's a [F] wild world
+[C] _(Riff 1)_
+[G] It's hard to get by [F] just upon a [C] smile
 [G] _(Riff 2)_
 
-[C] Oh [G] baby, baby it's a [F] wild world  
-[C] _(Riff 1)_  
+[C] Oh [G] baby, baby it's a [F] wild world
+[C] _(Riff 1)_
 [G] I'll always remember you [F] like a [C] child girl
 [Dm] [E]
 
@@ -77,20 +77,20 @@ But just re[Dm]member there's a lot of bad
 [Am] [D/F#] [G] [C] [F] [Dm] [E] [Esus4] [E]
 La la la... Baby I love you
 
-But [Am] if you wanna [D/F#] leave take good [G] care  
-Hope you make a [C] lot of nice friends out there [F]  
-But just re[Dm]member there's a lot of bad  
+But [Am] if you wanna [D/F#] leave take good [G] care
+Hope you make a [C] lot of nice friends out there [F]
+But just re[Dm]member there's a lot of bad
 [E] and be[E7]ware [G] [G7] [G6] [G5]
 
 ## Chorus
 
-[C] Oh [G] baby, baby it's a [F] wild world  
-[C] _(Riff 1)_  
-[G] It's hard to get by [F] just upon a [C] smile  
+[C] Oh [G] baby, baby it's a [F] wild world
+[C] _(Riff 1)_
+[G] It's hard to get by [F] just upon a [C] smile
 [G] _(Riff 2)_
 
-[C] Oh [G] baby, baby it's a [F] wild world  
-[C] _(Riff 1)_  
+[C] Oh [G] baby, baby it's a [F] wild world
+[C] _(Riff 1)_
 [G] I'll always remember you [F] like a [C] child girl
 [Dm] [E] _(1st time only)_
 

--- a/content/songs/Wish you were here (Pink Floyd).md
+++ b/content/songs/Wish you were here (Pink Floyd).md
@@ -4,64 +4,64 @@
 
 _(Instrumental)_
 
-[G] [Em]  
-[G] [Em]  
-[G] [Em]  
-[A] [Em]  
+[G] [Em]
+[G] [Em]
+[G] [Em]
+[A] [Em]
 [A] [G]
 
 _(Repeat with solo)_
 
 ## Verse 1
 
-[C] So, so you think you can [D] tell  
-heaven from [Am] hell?  
+[C] So, so you think you can [D] tell
+heaven from [Am] hell?
 Blue skies from [G] pain?
 
-Can you tell a green [D] field  
-from a cold steel [C] rail?  
-A smile from a [Am] veil?  
+Can you tell a green [D] field
+from a cold steel [C] rail?
+A smile from a [Am] veil?
 Do you think you can [G] tell?
 
 ## Verse 2
 
-Did they get you to [C] trade  
-your heroes for [D] ghosts?  
-Hot ashes for [Am] trees?  
+Did they get you to [C] trade
+your heroes for [D] ghosts?
+Hot ashes for [Am] trees?
 Hot air for a [G] cool breeze?
 
-Cold comfort for [D] change?  
-And did you ex[C]change  
-a walk-on part in the [Am] war  
+Cold comfort for [D] change?
+And did you ex[C]change
+a walk-on part in the [Am] war
 for a lead role in a [G] cage?
 
 ## Interlude
 
-[G] [Em]  
-[G] [Em]  
-[G] [Em]  
-[A] [Em]  
+[G] [Em]
+[G] [Em]
+[G] [Em]
+[A] [Em]
 [A] [G]
 
 ## Chorus
 
-[C] How I wish  
-how I wish you were [D] here  
-We're just [Am] two lost souls  
-swimming in a fishbowl  
+[C] How I wish
+how I wish you were [D] here
+We're just [Am] two lost souls
+swimming in a fishbowl
 [G] year after year
 
-[D] Running over the same old ground  
-[C] what have we found?  
-The same old [Am] fears  
+[D] Running over the same old ground
+[C] what have we found?
+The same old [Am] fears
 Wish you were [G] here
 
 ## Outro
 
-[G] [Em]  
-[G] [Em]  
-[G] [Em]  
-[A] [Em]  
+[G] [Em]
+[G] [Em]
+[G] [Em]
+[A] [Em]
 [A] [G]
 
 _(Fade out slowly)_

--- a/index.html
+++ b/index.html
@@ -668,10 +668,11 @@ G |3 2 0 0 0 3|      Gm |3 x 0 3 3 3|      G7 |3 2 3 0 0 1|
 
 Variations:
 
-  |E A D G B e|
-  |-----------|
-F |0 0 3 2 1 1| Easier, no barre
-G |3 x 0 0 0 1| Easier, A string muted
+   |E A D G B e|
+   |-----------|
+F  |0 0 3 2 1 1| Easier, no barre
+G  |3 x 0 0 0 1| Easier, A string muted
+Gm |3 x 0 0 1 1| Easier, A string muted
 
 Feeling bored of major chords (A, D, E...)?
   =&gt; Try playing a seventh chord instead (A7, D7, E7...)!</code></pre>
@@ -1094,7 +1095,8 @@ class="e">E</code></p>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
 killing me<br />
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe <code class="e">E</code> (still believe)</p>
+still believe<br />
+<code class="e">E</code> (still believe)</p>
 <p><code class="a">Am</code> When I’m not with you I lose <code
 class="e">E</code> my mind<br />
 <code class="g">G</code> Give me a sign <code class="c">C</code><br />
@@ -1127,7 +1129,8 @@ class="e">E</code></p>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
 killing me (and I)<br />
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe <code class="e">E</code> (still believe)</p>
+still believe<br />
+<code class="e">E</code> (still believe)</p>
 <p><code class="a">Am</code> When I’m not with you I lose <code
 class="e">E</code> my mind<br />
 <code class="g">G</code> Give me a sign <code class="c">C</code><br />
@@ -1155,16 +1158,17 @@ don’t you <code class="d">Dm</code> know I <code class="e">E</code>
 still believe <code class="f">F</code><br />
 That you will be here <code class="g">G</code><br />
 Now give me a sign <code class="f">F</code></p>
-<p><code class="d">Dm</code> Hit me baby <code class="g">G</code> one
-<code class="g">G#m</code> more <code class="a">Am</code> time <em>(use
-barre and move up)</em></p>
+<p><code class="d">Dm</code> Hit me baby<br />
+<code class="g">G</code> one <code class="g">G#m</code> more <code
+class="a">Am</code> time <em>(use barre and move up)</em></p>
 </section>
 <section id="chorus-12" class="slide level2">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
 killing me (and I)<br />
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe <code class="e">E</code> (still believe)</p>
+still believe<br />
+<code class="e">E</code> (still believe)</p>
 <p><code class="a">Am</code> When I’m not with you I lose <code
 class="e">E</code> my mind<br />
 <code class="g">G</code> Give me a sign <code class="c">C</code><br />
@@ -1333,9 +1337,10 @@ class="c">C</code> <code class="g">G</code> (x2)</p>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
 <p>(Listen to what I say!)</p>
-<p><code class="g">G</code> In your life expect some trouble <code
-class="a">Am</code> But when you worry, you make it double Don’t <code
-class="c">C</code> worry, be <code class="g">G</code> happy</p>
+<p><code class="g">G</code> In your life expect some trouble<br />
+<code class="a">Am</code> But when you worry, you make it double<br />
+Don’t <code class="c">C</code> worry, be <code class="g">G</code>
+happy</p>
 </section>
 <section id="chorus-16" class="slide level2">
 <h2>Chorus</h2>
@@ -1857,14 +1862,15 @@ but I’m <code class="a">Am</code> happy <code class="d">D</code></p>
 class="b">Bm</code><br />
 keeping all <code class="c">C</code> the things I knew <code
 class="a">Am7</code> inside<br />
-It’s hard <code class="g">G</code> but it’s har<code
-class="e">Em</code>der to ig<code class="a">Am</code>nore it <code
-class="d">D</code></p>
+It’s hard <code class="g">G</code><br />
+but it’s har<code class="e">Em</code>der to ig<code
+class="a">Am</code>nore it <code class="d">D</code></p>
 <p>If they were right <code class="g">G</code>, I’d agree <code
 class="b">Bm</code> <em>(I love this one!)</em><br />
 but it’s them <code class="c">C</code> they know, not me <code
-class="a">Am7</code> Now there’s a way <code class="g">G</code>, and I
-know <code class="e">Em</code><br />
+class="a">Am7</code><br />
+Now there’s a way <code class="g">G</code>, and I know <code
+class="e">Em</code><br />
 that I <code class="d">D</code> have to go away <code
 class="g">G</code></p>
 <p>I <code class="d">D</code> know I <code class="c">C</code> have to
@@ -2105,8 +2111,9 @@ class="title-slide slide level1">
 <section id="intro-7" class="slide level2">
 <h2>Intro</h2>
 <p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code> <code class="c">C</code>
-<code class="e">E</code> <code class="a">Am</code></p>
+class="f">F</code> <code class="g">G</code><br />
+<code class="c">C</code> <code class="e">E</code> <code
+class="a">Am</code></p>
 </section>
 <section id="verse-1-12" class="slide level2">
 <h2>Verse 1</h2>
@@ -2199,8 +2206,9 @@ Werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br />
 <section id="outro-2" class="slide level2">
 <h2>Outro</h2>
 <p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code> <code class="c">C</code>
-<code class="e">E</code> <code class="a">Am</code></p>
+class="f">F</code> <code class="g">G</code><br />
+<code class="c">C</code> <code class="e">E</code> <code
+class="a">Am</code></p>
 </section>
 <section id="resources-13" class="slide level2">
 <h2>Resources</h2>
@@ -2270,7 +2278,8 @@ class="g">G</code></p>
 <section id="verse-3-9" class="slide level2">
 <h2>Verse 3</h2>
 <p><code class="c">C</code> Baby, I’ve been <code class="a">Am</code>
-here before I <code class="c">C</code> know this room, I’ve <code
+here before<br />
+I <code class="c">C</code> know this room, I’ve <code
 class="a">Am</code> walked this floor<br />
 I <code class="f">F</code>used to live a<code class="g">G</code>lone
 before I <code class="c">C</code> knew you <code class="g">G</code></p>
@@ -2417,8 +2426,9 @@ hei</p>
 <section id="verse-2-14" class="slide level2">
 <h2>Verse 2</h2>
 <p>Si <code class="a">Am</code> wäre vilicht gärn im Grund gno <code
-class="d">Dm</code> fräch Und <code class="g">G</code> dänke, das syg
-ires grosse <code class="c">C</code> Päch<br />
+class="d">Dm</code> fräch<br />
+Und <code class="g">G</code> dänke, das syg ires grosse <code
+class="c">C</code> Päch<br />
 Und <code class="c">C</code> s’laschtet uf ne wine schwäre <code
 class="e">E7</code> Stei<br />
 dass si <code class="a">Am</code> Hemmige <code class="e">E7</code>
@@ -2463,8 +2473,9 @@ hei</p>
 <section id="verse-6-4" class="slide level2">
 <h2>Verse 6</h2>
 <p>Und <code class="a">Am</code> we me gseht, was hütt dr Mönschheit
-<code class="d">Dm</code> droht So <code class="g">G</code> gseht me
-würklech schwarz, nid nume <code class="c">C</code> rot<br />
+<code class="d">Dm</code> droht<br />
+So <code class="g">G</code> gseht me würklech schwarz, nid nume <code
+class="c">C</code> rot<br />
 Und <code class="c">C</code> was me no cha hoffen isch a<code
 class="e">E7</code>lei<br />
 Dass si <code class="a">Am</code> Hemm<code class="e">E7</code>ige <code
@@ -2834,8 +2845,8 @@ Guck Dir den <code class="f">F</code> Dieter an:<br />
 Auto! <code class="e">Em</code></p>
 <p>Warum <code class="f">F</code> gehst Du nicht zu<br />
 Onkel Werner in die Werk<code class="g">G</code>statt?<br />
-Der gibt Dir ne <code class="a">Am</code> Festanstellung wenn Du ihn
-darum bittest</p>
+Der gibt Dir ne <code class="a">Am</code> Festanstellung<br />
+wenn Du ihn darum bittest</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
 </section>
 <section id="chorus-1-5" class="slide level2">
@@ -2849,8 +2860,8 @@ und ständig dieser Lärm <code class="a">Am</code><br />
 da fehlen mir die Wor<code class="d">Dm</code>te<br />
 musst du die denn färb’n? <code class="a">Am</code><br />
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>Nie kommst du nach Hau<code class="f">F</code>se wir wissen nicht
-mehr wei<code class="d">Dm</code>ter</p>
+<p>Nie kommst du nach Hau<code class="f">F</code>se<br />
+wir wissen nicht mehr wei<code class="d">Dm</code>ter</p>
 </section>
 <section id="verse-2-18" class="slide level2">
 <h2>Verse 2</h2>
@@ -2862,8 +2873,9 @@ es ist noch <code class="f">F</code> nicht zu spät<br />
 <code class="g">G</code> dich an der Uni einzu<code
 class="a">Am</code>schreiben</p>
 <p>du hast dich doch <code class="f">F</code> früher so für Tiere
-interessiert <code class="g">G</code> wäre das nichts für <code
-class="a">Am</code> dich: eine eigene Praxis</p>
+interessiert <code class="g">G</code><br />
+wäre das nichts für <code class="a">Am</code> dich:<br />
+eine eigene Praxis</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
 </section>
 <section id="chorus-2-5" class="slide level2">
@@ -3166,8 +3178,8 @@ up and down<br />
 I’m <code class="e">Em</code> turning turning turning turning <code
 class="b">Bm</code> turning around<br />
 And <code class="c">C/G</code> all that I can <code class="a">A7</code>
-see is just a yellow <code class="d">D</code> lemon tree And I wonder I
-wonder</p>
+see is just a yellow <code class="d">D</code> lemon tree<br />
+And I wonder I wonder</p>
 </section>
 <section class="slide level2">
 
@@ -3176,8 +3188,9 @@ wonder why<br />
 <code class="e">Em</code> Yesterday you told me ’bout the <code
 class="b">Bm</code> blue blue sky<br />
 And all <code class="c">C/G</code> that I can see <code
-class="d">D</code> <em>(x3)</em> Is <code class="c">Cadd9</code> just a
-yellow <code class="g">G7</code> lemon tree <code class="g">G</code></p>
+class="d">D</code> <em>(x3)</em><br />
+Is <code class="c">Cadd9</code> just a yellow <code class="g">G7</code>
+lemon tree <code class="g">G</code></p>
 </section>
 <section id="resources-21" class="slide level2">
 <h2>Resources</h2>
@@ -3398,18 +3411,20 @@ Und dann am <code class="c">C</code> nächsten Morgen sind sie fort.
 <h2>Verse 3</h2>
 <p>Und <code class="g">G</code> falls Du doch den Fehler machst<br />
 Und <code class="e">Em</code> Dir ’nen Ehemann anlachst.<br />
-Mu<code class="c">C</code>tiert dein Rosenkavalier Bald <code
-class="d">D</code> nach der Hochzeit auch zum Tier.</p>
+Mu<code class="c">C</code>tiert dein Rosenkavalier<br />
+Bald <code class="d">D</code> nach der Hochzeit auch zum Tier.</p>
 <p>Da <code class="g">G</code> zeigt er dann sein wahres Ich,<br />
 Ganz <code class="e">Em</code> unrasiert und widerlich.<br />
-Trinkt <code class="c">C</code> Bier, sieht fern und wird schnell fett.
+Trinkt <code class="c">C</code> Bier, sieht fern und wird schnell
+fett.<br />
 Und <code class="d">D</code> rülpst und furzt im Ehebett.</p>
 </section>
 <section id="bridge-3-1" class="slide level2">
 <h2>Bridge 3</h2>
 <p><code class="c">C</code> Dann hast du King Kong <code
-class="b">Bm</code> zum Ehemann! Drum <code class="c">C</code> sag’ ich
-Dir - denk bitte stets daran: <code class="d">D</code></p>
+class="b">Bm</code> zum Ehemann!<br />
+Drum <code class="c">C</code> sag’ ich Dir - denk bitte stets daran:
+<code class="d">D</code></p>
 </section>
 <section id="chorus-3-1" class="slide level2">
 <h2>Chorus 3</h2>
@@ -3688,8 +3703,8 @@ When all you got is hurt</p>
 <del>life</del> <strong>blood</strong><br />
 <del>When it’s one need in the night</del><br />
 <strong><code class="f">FM7</code> One life, You got to <code
-class="c">C</code> do what you should</strong> <del>One love, we got to
-share it</del><br />
+class="c">C</code> do what you should</strong><br />
+<del>One love, we got to share it</del><br />
 <strong><code class="c">C</code> One life <code class="a">Am</code> with
 each other</strong><br />
 <del>It leaves you baby</del><br />
@@ -4054,8 +4069,8 @@ tutorial</a></li>
 Und das <code class="g">G7</code> het e Flamme gäh<br />
 Und i <code class="a">Am</code> ha für d’Zigarette<br />
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
-<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt Und <code
-class="c">C</code> uf e Teppich cho<br />
+<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
+Und <code class="c">C</code> uf e Teppich cho<br />
 Und es <code class="g">G7</code> hätt no fasch<br />
 Es Loch i Teppich <code class="c">C</code> gäh dervo</p>
 </section>
@@ -4110,8 +4125,9 @@ Und das <code class="g">G7</code> het e Flamme gäh<br />
 Und i <code class="a">Am</code> ha für d’Zigarette<br />
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
 <p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
-Und <code class="c">C</code> uf e Teppich cho - <del>Und es hätt no
-fasch…</del> Gottsei<code class="g">G7</code>dank<br />
+Und <code class="c">C</code> uf e Teppich cho -<br />
+<del>Und es hätt no fasch…</del> Gottsei<code
+class="g">G7</code>dank<br />
 Dass i’s vom Teppich wider <code class="c">C</code> furt ha gno</p>
 </section>
 <section id="resources-29" class="slide level2">
@@ -4298,8 +4314,9 @@ like: “I <code class="g">G6</code> love you”</p>
 <h2>Bridge</h2>
 <p><em>(Instrumental, maybe add whistling)</em></p>
 <p><code class="g">G</code> <code class="g">G7</code> <code
-class="c">C</code> <code class="a">A7</code> <code class="d">D</code>
-<code class="d">D+</code></p>
+class="c">C</code><br />
+<code class="a">A7</code> <code class="d">D</code> <code
+class="d">D+</code></p>
 </section>
 <section id="verse-2-29" class="slide level2">
 <h2>Verse 2</h2>
@@ -4698,9 +4715,10 @@ Das <code class="a">Am</code> juckt mich <code class="g">G</code>
 überhaupt <code class="a">Am</code> nicht.</p>
 <p>Auf <code class="c">C</code> einmal packt’s mich, ich geh auf ihn
 zu<br />
-und <code class="g">G</code> mach ihn an: “Lass meine Frau in Ruh!” Er
-<code class="a">Am</code> fragt nur: <code class="g">G</code> “Hast du’n
-<code class="a">Am</code> Stich?”</p>
+und <code class="g">G</code> mach ihn an: “Lass meine Frau in
+Ruh!”<br />
+Er <code class="a">Am</code> fragt nur: <code class="g">G</code> “Hast
+du’n <code class="a">Am</code> Stich?”</p>
 <p>Und ich <code class="f">F</code> denke schon wieder nur an <code
 class="g">G</code> dich…</p>
 </section>
@@ -4718,8 +4736,9 @@ class="a">Am</code>er’n!</p>
 </section>
 <section id="verse-2-35" class="slide level2">
 <h2>Verse 2</h2>
-<p>So <code class="a">Am</code> langsam fällt mir alles wieder ein: Ich
-wollt doch nur’n bisschen freier sein.<br />
+<p>So <code class="a">Am</code> langsam fällt mir alles wieder
+ein:<br />
+Ich wollt doch nur’n bisschen freier sein.<br />
 Jetzt <code class="g">G</code> bin ich’s - oder <code
 class="a">Am</code> nicht?</p>
 <p>Ich <code class="a">Am</code> passte nicht in deine heile Welt<br />
@@ -4824,8 +4843,8 @@ class="e">Em</code><br />
 I try all the time, <code class="g">G</code> in this institu<code
 class="d">D</code>tion<br />
 And I pray, <code class="d">D</code> oh my god do I pray <code
-class="e">Em</code> I pray every single day <code
-class="g">G</code><br />
+class="e">Em</code><br />
+I pray every single day <code class="g">G</code><br />
 For a revo<code class="d">D</code>lution</p>
 </section>
 <section id="pre-chorus-3" class="slide level2">
@@ -4938,8 +4957,8 @@ just upon a <code class="c">C</code> smile<br />
 a <code class="f">F</code> wild world<br />
 <code class="c">C</code> <em>(Riff 1)</em><br />
 <code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl <code
-class="d">Dm</code> <code class="e">E</code></p>
+class="f">F</code> like a <code class="c">C</code> child girl<br />
+<code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-2-36" class="slide level2">
 <h2>Verse 2</h2>
@@ -4974,16 +4993,16 @@ just upon a <code class="c">C</code> smile<br />
 a <code class="f">F</code> wild world<br />
 <code class="c">C</code> <em>(Riff 1)</em><br />
 <code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl <code
-class="d">Dm</code> <code class="e">E</code></p>
+class="f">F</code> like a <code class="c">C</code> child girl<br />
+<code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-3-21" class="slide level2">
 <h2>Verse 3</h2>
 <p><code class="a">Am</code> <code class="d">D/F#</code> <code
 class="g">G</code> <code class="c">C</code> <code class="f">F</code>
 <code class="d">Dm</code> <code class="e">E</code> <code
-class="e">Esus4</code> <code class="e">E</code> La la la… Baby I love
-you</p>
+class="e">Esus4</code> <code class="e">E</code><br />
+La la la… Baby I love you</p>
 <p>But <code class="a">Am</code> if you wanna <code
 class="d">D/F#</code> leave take good <code class="g">G</code>
 care<br />
@@ -5006,8 +5025,8 @@ just upon a <code class="c">C</code> smile<br />
 a <code class="f">F</code> wild world<br />
 <code class="c">C</code> <em>(Riff 1)</em><br />
 <code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl <code
-class="d">Dm</code> <code class="e">E</code> <em>(1st time
+class="f">F</code> like a <code class="c">C</code> child girl<br />
+<code class="d">Dm</code> <code class="e">E</code> <em>(1st time
 only)</em></p>
 <p><em>(Repeat)</em></p>
 </section>

--- a/print.html
+++ b/print.html
@@ -256,10 +256,11 @@ G |3 2 0 0 0 3|      Gm |3 x 0 3 3 3|      G7 |3 2 3 0 0 1|
 
 Variations:
 
-  |E A D G B e|
-  |-----------|
-F |0 0 3 2 1 1| Easier, no barre
-G |3 x 0 0 0 1| Easier, A string muted
+   |E A D G B e|
+   |-----------|
+F  |0 0 3 2 1 1| Easier, no barre
+G  |3 x 0 0 0 1| Easier, A string muted
+Gm |3 x 0 0 1 1| Easier, A string muted
 
 Feeling bored of major chords (A, D, E...)?
   =&gt; Try playing a seventh chord instead (A7, D7, E7...)!</code></pre>
@@ -652,7 +653,8 @@ class="e">E</code></p>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
 killing me<br />
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe <code class="e">E</code> (still believe)</p>
+still believe<br />
+<code class="e">E</code> (still believe)</p>
 <p><code class="a">Am</code> When I’m not with you I lose <code
 class="e">E</code> my mind<br />
 <code class="g">G</code> Give me a sign <code class="c">C</code><br />
@@ -685,7 +687,8 @@ class="e">E</code></p>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
 killing me (and I)<br />
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe <code class="e">E</code> (still believe)</p>
+still believe<br />
+<code class="e">E</code> (still believe)</p>
 <p><code class="a">Am</code> When I’m not with you I lose <code
 class="e">E</code> my mind<br />
 <code class="g">G</code> Give me a sign <code class="c">C</code><br />
@@ -713,16 +716,17 @@ don’t you <code class="d">Dm</code> know I <code class="e">E</code>
 still believe <code class="f">F</code><br />
 That you will be here <code class="g">G</code><br />
 Now give me a sign <code class="f">F</code></p>
-<p><code class="d">Dm</code> Hit me baby <code class="g">G</code> one
-<code class="g">G#m</code> more <code class="a">Am</code> time <em>(use
-barre and move up)</em></p>
+<p><code class="d">Dm</code> Hit me baby<br />
+<code class="g">G</code> one <code class="g">G#m</code> more <code
+class="a">Am</code> time <em>(use barre and move up)</em></p>
 </section>
 <section id="chorus-12" class="slide level2">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
 killing me (and I)<br />
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe <code class="e">E</code> (still believe)</p>
+still believe<br />
+<code class="e">E</code> (still believe)</p>
 <p><code class="a">Am</code> When I’m not with you I lose <code
 class="e">E</code> my mind<br />
 <code class="g">G</code> Give me a sign <code class="c">C</code><br />
@@ -871,9 +875,10 @@ class="c">C</code> <code class="g">G</code> (x2)</p>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
 <p>(Listen to what I say!)</p>
-<p><code class="g">G</code> In your life expect some trouble <code
-class="a">Am</code> But when you worry, you make it double Don’t <code
-class="c">C</code> worry, be <code class="g">G</code> happy</p>
+<p><code class="g">G</code> In your life expect some trouble<br />
+<code class="a">Am</code> But when you worry, you make it double<br />
+Don’t <code class="c">C</code> worry, be <code class="g">G</code>
+happy</p>
 </section>
 <section id="chorus-16" class="slide level2">
 <h2>Chorus</h2>
@@ -1355,14 +1360,15 @@ but I’m <code class="a">Am</code> happy <code class="d">D</code></p>
 class="b">Bm</code><br />
 keeping all <code class="c">C</code> the things I knew <code
 class="a">Am7</code> inside<br />
-It’s hard <code class="g">G</code> but it’s har<code
-class="e">Em</code>der to ig<code class="a">Am</code>nore it <code
-class="d">D</code></p>
+It’s hard <code class="g">G</code><br />
+but it’s har<code class="e">Em</code>der to ig<code
+class="a">Am</code>nore it <code class="d">D</code></p>
 <p>If they were right <code class="g">G</code>, I’d agree <code
 class="b">Bm</code> <em>(I love this one!)</em><br />
 but it’s them <code class="c">C</code> they know, not me <code
-class="a">Am7</code> Now there’s a way <code class="g">G</code>, and I
-know <code class="e">Em</code><br />
+class="a">Am7</code><br />
+Now there’s a way <code class="g">G</code>, and I know <code
+class="e">Em</code><br />
 that I <code class="d">D</code> have to go away <code
 class="g">G</code></p>
 <p>I <code class="d">D</code> know I <code class="c">C</code> have to
@@ -1575,8 +1581,9 @@ class="title-slide slide level1">
 <section id="intro-7" class="slide level2">
 <h2>Intro</h2>
 <p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code> <code class="c">C</code>
-<code class="e">E</code> <code class="a">Am</code></p>
+class="f">F</code> <code class="g">G</code><br />
+<code class="c">C</code> <code class="e">E</code> <code
+class="a">Am</code></p>
 </section>
 <section id="verse-1-12" class="slide level2">
 <h2>Verse 1</h2>
@@ -1669,8 +1676,9 @@ Werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br />
 <section id="outro-2" class="slide level2">
 <h2>Outro</h2>
 <p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code> <code class="c">C</code>
-<code class="e">E</code> <code class="a">Am</code></p>
+class="f">F</code> <code class="g">G</code><br />
+<code class="c">C</code> <code class="e">E</code> <code
+class="a">Am</code></p>
 </section>
 </section>
 <section>
@@ -1733,7 +1741,8 @@ class="g">G</code></p>
 <section id="verse-3-9" class="slide level2">
 <h2>Verse 3</h2>
 <p><code class="c">C</code> Baby, I’ve been <code class="a">Am</code>
-here before I <code class="c">C</code> know this room, I’ve <code
+here before<br />
+I <code class="c">C</code> know this room, I’ve <code
 class="a">Am</code> walked this floor<br />
 I <code class="f">F</code>used to live a<code class="g">G</code>lone
 before I <code class="c">C</code> knew you <code class="g">G</code></p>
@@ -1868,8 +1877,9 @@ hei</p>
 <section id="verse-2-14" class="slide level2">
 <h2>Verse 2</h2>
 <p>Si <code class="a">Am</code> wäre vilicht gärn im Grund gno <code
-class="d">Dm</code> fräch Und <code class="g">G</code> dänke, das syg
-ires grosse <code class="c">C</code> Päch<br />
+class="d">Dm</code> fräch<br />
+Und <code class="g">G</code> dänke, das syg ires grosse <code
+class="c">C</code> Päch<br />
 Und <code class="c">C</code> s’laschtet uf ne wine schwäre <code
 class="e">E7</code> Stei<br />
 dass si <code class="a">Am</code> Hemmige <code class="e">E7</code>
@@ -1914,8 +1924,9 @@ hei</p>
 <section id="verse-6-4" class="slide level2">
 <h2>Verse 6</h2>
 <p>Und <code class="a">Am</code> we me gseht, was hütt dr Mönschheit
-<code class="d">Dm</code> droht So <code class="g">G</code> gseht me
-würklech schwarz, nid nume <code class="c">C</code> rot<br />
+<code class="d">Dm</code> droht<br />
+So <code class="g">G</code> gseht me würklech schwarz, nid nume <code
+class="c">C</code> rot<br />
 Und <code class="c">C</code> was me no cha hoffen isch a<code
 class="e">E7</code>lei<br />
 Dass si <code class="a">Am</code> Hemm<code class="e">E7</code>ige <code
@@ -2237,8 +2248,8 @@ Guck Dir den <code class="f">F</code> Dieter an:<br />
 Auto! <code class="e">Em</code></p>
 <p>Warum <code class="f">F</code> gehst Du nicht zu<br />
 Onkel Werner in die Werk<code class="g">G</code>statt?<br />
-Der gibt Dir ne <code class="a">Am</code> Festanstellung wenn Du ihn
-darum bittest</p>
+Der gibt Dir ne <code class="a">Am</code> Festanstellung<br />
+wenn Du ihn darum bittest</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
 </section>
 <section id="chorus-1-5" class="slide level2">
@@ -2252,8 +2263,8 @@ und ständig dieser Lärm <code class="a">Am</code><br />
 da fehlen mir die Wor<code class="d">Dm</code>te<br />
 musst du die denn färb’n? <code class="a">Am</code><br />
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>Nie kommst du nach Hau<code class="f">F</code>se wir wissen nicht
-mehr wei<code class="d">Dm</code>ter</p>
+<p>Nie kommst du nach Hau<code class="f">F</code>se<br />
+wir wissen nicht mehr wei<code class="d">Dm</code>ter</p>
 </section>
 <section id="verse-2-18" class="slide level2">
 <h2>Verse 2</h2>
@@ -2265,8 +2276,9 @@ es ist noch <code class="f">F</code> nicht zu spät<br />
 <code class="g">G</code> dich an der Uni einzu<code
 class="a">Am</code>schreiben</p>
 <p>du hast dich doch <code class="f">F</code> früher so für Tiere
-interessiert <code class="g">G</code> wäre das nichts für <code
-class="a">Am</code> dich: eine eigene Praxis</p>
+interessiert <code class="g">G</code><br />
+wäre das nichts für <code class="a">Am</code> dich:<br />
+eine eigene Praxis</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
 </section>
 <section id="chorus-2-5" class="slide level2">
@@ -2548,8 +2560,8 @@ up and down<br />
 I’m <code class="e">Em</code> turning turning turning turning <code
 class="b">Bm</code> turning around<br />
 And <code class="c">C/G</code> all that I can <code class="a">A7</code>
-see is just a yellow <code class="d">D</code> lemon tree And I wonder I
-wonder</p>
+see is just a yellow <code class="d">D</code> lemon tree<br />
+And I wonder I wonder</p>
 </section>
 <section class="slide level2">
 
@@ -2558,8 +2570,9 @@ wonder why<br />
 <code class="e">Em</code> Yesterday you told me ’bout the <code
 class="b">Bm</code> blue blue sky<br />
 And all <code class="c">C/G</code> that I can see <code
-class="d">D</code> <em>(x3)</em> Is <code class="c">Cadd9</code> just a
-yellow <code class="g">G7</code> lemon tree <code class="g">G</code></p>
+class="d">D</code> <em>(x3)</em><br />
+Is <code class="c">Cadd9</code> just a yellow <code class="g">G7</code>
+lemon tree <code class="g">G</code></p>
 </section>
 </section>
 <section>
@@ -2760,18 +2773,20 @@ Und dann am <code class="c">C</code> nächsten Morgen sind sie fort.
 <h2>Verse 3</h2>
 <p>Und <code class="g">G</code> falls Du doch den Fehler machst<br />
 Und <code class="e">Em</code> Dir ’nen Ehemann anlachst.<br />
-Mu<code class="c">C</code>tiert dein Rosenkavalier Bald <code
-class="d">D</code> nach der Hochzeit auch zum Tier.</p>
+Mu<code class="c">C</code>tiert dein Rosenkavalier<br />
+Bald <code class="d">D</code> nach der Hochzeit auch zum Tier.</p>
 <p>Da <code class="g">G</code> zeigt er dann sein wahres Ich,<br />
 Ganz <code class="e">Em</code> unrasiert und widerlich.<br />
-Trinkt <code class="c">C</code> Bier, sieht fern und wird schnell fett.
+Trinkt <code class="c">C</code> Bier, sieht fern und wird schnell
+fett.<br />
 Und <code class="d">D</code> rülpst und furzt im Ehebett.</p>
 </section>
 <section id="bridge-3-1" class="slide level2">
 <h2>Bridge 3</h2>
 <p><code class="c">C</code> Dann hast du King Kong <code
-class="b">Bm</code> zum Ehemann! Drum <code class="c">C</code> sag’ ich
-Dir - denk bitte stets daran: <code class="d">D</code></p>
+class="b">Bm</code> zum Ehemann!<br />
+Drum <code class="c">C</code> sag’ ich Dir - denk bitte stets daran:
+<code class="d">D</code></p>
 </section>
 <section id="chorus-3-1" class="slide level2">
 <h2>Chorus 3</h2>
@@ -3033,8 +3048,8 @@ When all you got is hurt</p>
 <del>life</del> <strong>blood</strong><br />
 <del>When it’s one need in the night</del><br />
 <strong><code class="f">FM7</code> One life, You got to <code
-class="c">C</code> do what you should</strong> <del>One love, we got to
-share it</del><br />
+class="c">C</code> do what you should</strong><br />
+<del>One love, we got to share it</del><br />
 <strong><code class="c">C</code> One life <code class="a">Am</code> with
 each other</strong><br />
 <del>It leaves you baby</del><br />
@@ -3361,8 +3376,8 @@ are just a <code class="c">C</code> mirror for <code class="d">D</code>
 Und das <code class="g">G7</code> het e Flamme gäh<br />
 Und i <code class="a">Am</code> ha für d’Zigarette<br />
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
-<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt Und <code
-class="c">C</code> uf e Teppich cho<br />
+<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
+Und <code class="c">C</code> uf e Teppich cho<br />
 Und es <code class="g">G7</code> hätt no fasch<br />
 Es Loch i Teppich <code class="c">C</code> gäh dervo</p>
 </section>
@@ -3417,8 +3432,9 @@ Und das <code class="g">G7</code> het e Flamme gäh<br />
 Und i <code class="a">Am</code> ha für d’Zigarette<br />
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
 <p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
-Und <code class="c">C</code> uf e Teppich cho - <del>Und es hätt no
-fasch…</del> Gottsei<code class="g">G7</code>dank<br />
+Und <code class="c">C</code> uf e Teppich cho -<br />
+<del>Und es hätt no fasch…</del> Gottsei<code
+class="g">G7</code>dank<br />
 Dass i’s vom Teppich wider <code class="c">C</code> furt ha gno</p>
 </section>
 </section>
@@ -3588,8 +3604,9 @@ like: “I <code class="g">G6</code> love you”</p>
 <h2>Bridge</h2>
 <p><em>(Instrumental, maybe add whistling)</em></p>
 <p><code class="g">G</code> <code class="g">G7</code> <code
-class="c">C</code> <code class="a">A7</code> <code class="d">D</code>
-<code class="d">D+</code></p>
+class="c">C</code><br />
+<code class="a">A7</code> <code class="d">D</code> <code
+class="d">D+</code></p>
 </section>
 <section id="verse-2-29" class="slide level2">
 <h2>Verse 2</h2>
@@ -3952,9 +3969,10 @@ Das <code class="a">Am</code> juckt mich <code class="g">G</code>
 überhaupt <code class="a">Am</code> nicht.</p>
 <p>Auf <code class="c">C</code> einmal packt’s mich, ich geh auf ihn
 zu<br />
-und <code class="g">G</code> mach ihn an: “Lass meine Frau in Ruh!” Er
-<code class="a">Am</code> fragt nur: <code class="g">G</code> “Hast du’n
-<code class="a">Am</code> Stich?”</p>
+und <code class="g">G</code> mach ihn an: “Lass meine Frau in
+Ruh!”<br />
+Er <code class="a">Am</code> fragt nur: <code class="g">G</code> “Hast
+du’n <code class="a">Am</code> Stich?”</p>
 <p>Und ich <code class="f">F</code> denke schon wieder nur an <code
 class="g">G</code> dich…</p>
 </section>
@@ -3972,8 +3990,9 @@ class="a">Am</code>er’n!</p>
 </section>
 <section id="verse-2-35" class="slide level2">
 <h2>Verse 2</h2>
-<p>So <code class="a">Am</code> langsam fällt mir alles wieder ein: Ich
-wollt doch nur’n bisschen freier sein.<br />
+<p>So <code class="a">Am</code> langsam fällt mir alles wieder
+ein:<br />
+Ich wollt doch nur’n bisschen freier sein.<br />
 Jetzt <code class="g">G</code> bin ich’s - oder <code
 class="a">Am</code> nicht?</p>
 <p>Ich <code class="a">Am</code> passte nicht in deine heile Welt<br />
@@ -4068,8 +4087,8 @@ class="e">Em</code><br />
 I try all the time, <code class="g">G</code> in this institu<code
 class="d">D</code>tion<br />
 And I pray, <code class="d">D</code> oh my god do I pray <code
-class="e">Em</code> I pray every single day <code
-class="g">G</code><br />
+class="e">Em</code><br />
+I pray every single day <code class="g">G</code><br />
 For a revo<code class="d">D</code>lution</p>
 </section>
 <section id="pre-chorus-3" class="slide level2">
@@ -4173,8 +4192,8 @@ just upon a <code class="c">C</code> smile<br />
 a <code class="f">F</code> wild world<br />
 <code class="c">C</code> <em>(Riff 1)</em><br />
 <code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl <code
-class="d">Dm</code> <code class="e">E</code></p>
+class="f">F</code> like a <code class="c">C</code> child girl<br />
+<code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-2-36" class="slide level2">
 <h2>Verse 2</h2>
@@ -4209,16 +4228,16 @@ just upon a <code class="c">C</code> smile<br />
 a <code class="f">F</code> wild world<br />
 <code class="c">C</code> <em>(Riff 1)</em><br />
 <code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl <code
-class="d">Dm</code> <code class="e">E</code></p>
+class="f">F</code> like a <code class="c">C</code> child girl<br />
+<code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-3-21" class="slide level2">
 <h2>Verse 3</h2>
 <p><code class="a">Am</code> <code class="d">D/F#</code> <code
 class="g">G</code> <code class="c">C</code> <code class="f">F</code>
 <code class="d">Dm</code> <code class="e">E</code> <code
-class="e">Esus4</code> <code class="e">E</code> La la la… Baby I love
-you</p>
+class="e">Esus4</code> <code class="e">E</code><br />
+La la la… Baby I love you</p>
 <p>But <code class="a">Am</code> if you wanna <code
 class="d">D/F#</code> leave take good <code class="g">G</code>
 care<br />
@@ -4241,8 +4260,8 @@ just upon a <code class="c">C</code> smile<br />
 a <code class="f">F</code> wild world<br />
 <code class="c">C</code> <em>(Riff 1)</em><br />
 <code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl <code
-class="d">Dm</code> <code class="e">E</code> <em>(1st time
+class="f">F</code> like a <code class="c">C</code> child girl<br />
+<code class="d">Dm</code> <code class="e">E</code> <em>(1st time
 only)</em></p>
 <p><em>(Repeat)</em></p>
 </section>

--- a/tmp/all-songs.md
+++ b/tmp/all-songs.md
@@ -38,10 +38,11 @@ G |3 2 0 0 0 3|      Gm |3 x 0 3 3 3|      G7 |3 2 3 0 0 1|
 
 Variations:
 
-  |E A D G B e|
-  |-----------|
-F |0 0 3 2 1 1| Easier, no barre
-G |3 x 0 0 0 1| Easier, A string muted
+   |E A D G B e|
+   |-----------|
+F  |0 0 3 2 1 1| Easier, no barre
+G  |3 x 0 0 0 1| Easier, A string muted
+Gm |3 x 0 0 1 1| Easier, A string muted
 
 Feeling bored of major chords (A, D, E...)?
   => Try playing a seventh chord instead (A7, D7, E7...)!


### PR DESCRIPTION
## Summary

- Switch Pandoc to `-f markdown+hard_line_breaks` so every newline in lyrics renders as a `<br>` automatically — no more needing to remember trailing double-spaces in source files
- Fix `Encoding.default_external = UTF_8` so Ruby reads song files with German/special characters correctly (`ENV['LANG']` was ineffective at runtime)
- Strip all now-redundant trailing double-spaces from all 39 song files and the intro

## Test plan

- [ ] Open `index.html` and check that lyric line breaks render correctly (each line on its own line)
- [ ] Open `print.html` and verify the same
- [ ] Confirm no double line breaks appear where songs previously had trailing `  ` spaces