### PR TITLE
Dynamic layout with UI polish

### DIFF
--- a/all-songs.md
+++ b/all-songs.md
@@ -3049,9 +3049,14 @@ Und ich `F`{.f} denke schon wieder nur an `G`{.g} dich...
 
 _(x2: gently first time, then repeat intensively)_
 
-Verdammt, ich `C`{.c} lieb' dich, ich lieb' dich `G`{.g} nicht.
-Verdammt, ich `Dm`{.d} brauch' dich, brauch' dich `Am`{.a} nicht. `G`{.g}
-Verdammt, ich `C`{.c} will dich, ich will dich `G`{.g} nicht,
+Verdammt, ich `C`{.c} lieb' dich,
+ich lieb' dich `G`{.g} nicht.
+
+Verdammt, ich `Dm`{.d} brauch' dich,
+brauch' dich `Am`{.a} nicht. `G`{.g}
+
+Verdammt, ich `C`{.c} will dich,
+ich will dich `G`{.g} nicht,
 Ich `F`{.f} will dich nicht verli`Am`{.a}er'n!
 
 ## Verse 2
@@ -3078,9 +3083,14 @@ Und ich `F`{.f} denke schon wieder nur an `G`{.g} dich...
 
 ## Chorus
 
-Verdammt, ich `C`{.c} lieb' dich, ich lieb' dich `G`{.g} nicht.
-Verdammt, ich `Dm`{.d} brauch' dich, brauch' dich `Am`{.a} nicht. `G`{.g}
-Verdammt, ich `C`{.c} will dich, ich will dich `G`{.g} nicht,
+Verdammt, ich `C`{.c} lieb' dich,
+ich lieb' dich `G`{.g} nicht.
+
+Verdammt, ich `Dm`{.d} brauch' dich,
+brauch' dich `Am`{.a} nicht. `G`{.g}
+
+Verdammt, ich `C`{.c} will dich,
+ich will dich `G`{.g} nicht,
 Ich `F`{.f} will dich nicht verli`Am`{.a}er'n! - Ooooh!
 
 _(Repeat and fade)_
@@ -3214,15 +3224,15 @@ But then a `Dm`{.d} lot of nice things turn
 
 ## Chorus
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
-`C`{.c} _(Riff 1)_
-`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile
-`G`{.g} _(Riff 2)_
+`C`{.c} Oh `G`{.g} baby, baby
+it's a `F`{.f} wild world `C`{.c} _(Riff 1)_
+`G`{.g} It's hard to get by
+`F`{.f} just upon a `C`{.c} smile `G`{.g} _(Riff 2)_
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
-`C`{.c} _(Riff 1)_
-`G`{.g} I'll always remember you `F`{.f} like a `C`{.c} child girl
-`Dm`{.d} `E`{.e}
+`C`{.c} Oh `G`{.g} baby, baby
+it's a `F`{.f} wild world `C`{.c} _(Riff 1)_
+`G`{.g} I'll always remember you
+`F`{.f} like a `C`{.c} child girl `Dm`{.d} `E`{.e}
 
 ## Verse 2
 
@@ -3239,15 +3249,15 @@ But just re`Dm`{.d}member there's a lot of bad
 
 ## Chorus
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
-`C`{.c} _(Riff 1)_
-`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile
-`G`{.g} _(Riff 2)_
+`C`{.c} Oh `G`{.g} baby, baby
+it's a `F`{.f} wild world `C`{.c} _(Riff 1)_
+`G`{.g} It's hard to get by
+`F`{.f} just upon a `C`{.c} smile `G`{.g} _(Riff 2)_
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
-`C`{.c} _(Riff 1)_
-`G`{.g} I'll always remember you `F`{.f} like a `C`{.c} child girl
-`Dm`{.d} `E`{.e}
+`C`{.c} Oh `G`{.g} baby, baby
+it's a `F`{.f} wild world `C`{.c} _(Riff 1)_
+`G`{.g} I'll always remember you
+`F`{.f} like a `C`{.c} child girl `Dm`{.d} `E`{.e}
 
 ## Verse 3
 
@@ -3261,15 +3271,15 @@ But just re`Dm`{.d}member there's a lot of bad
 
 ## Chorus
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
-`C`{.c} _(Riff 1)_
-`G`{.g} It's hard to get by `F`{.f} just upon a `C`{.c} smile
-`G`{.g} _(Riff 2)_
+`C`{.c} Oh `G`{.g} baby, baby
+it's a `F`{.f} wild world `C`{.c} _(Riff 1)_
+`G`{.g} It's hard to get by
+`F`{.f} just upon a `C`{.c} smile `G`{.g} _(Riff 2)_
 
-`C`{.c} Oh `G`{.g} baby, baby it's a `F`{.f} wild world
-`C`{.c} _(Riff 1)_
-`G`{.g} I'll always remember you `F`{.f} like a `C`{.c} child girl
-`Dm`{.d} `E`{.e} _(1st time only)_
+`C`{.c} Oh `G`{.g} baby, baby
+it's a `F`{.f} wild world `C`{.c} _(Riff 1)_
+`G`{.g} I'll always remember you
+`F`{.f} like a `C`{.c} child girl `Dm`{.d} `E`{.e} _(1st time only)_
 
 _(Repeat)_
 

--- a/build
+++ b/build
@@ -4,6 +4,7 @@ require 'optparse'
 require 'shellwords'
 require 'json'
 require 'net/http'
+require 'nokogiri'
 
 ENV['LANG'] = 'en_US.UTF-8'
 Encoding.default_external = Encoding::UTF_8
@@ -29,6 +30,18 @@ def step(emoji, label)
   result = yield
   puts "✅ (#{"%.1f" % (Time.now - t)}s)"
   result
+end
+
+def wrap_slide_content(html)
+  doc = Nokogiri::HTML(html)
+  doc.css('section[id], section[class]').each do |section|
+    children = section.children.to_a
+    wrapper = Nokogiri::XML::Node.new('div', doc)
+    wrapper['class'] = 'slide-content'
+    section.add_child(wrapper)
+    children.each { |child| wrapper.add_child(child) }
+  end
+  doc.to_html
 end
 
 def pandoc(output:, theme:)
@@ -70,7 +83,9 @@ step("✨", "Post-processing index.html") do
   html.gsub!(%r{  <script src="./style/revealjs/plugin/(notes|search|zoom)/\1\.js"></script>\n}, "")
   html.sub!("plugins: [\n          RevealNotes,\n          RevealSearch,\n          RevealZoom\n        ]", "plugins: []")
   html.sub!("keyboard: true,", "keyboard: { 83: null }, // 's' disabled (was: speaker notes)")
+  html.sub!("display: 'block',", "display: 'flex',")
   html.sub!("</body>", "  <script src=\"#{MULTIPLEX_URL}/socket.io/socket.io.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js\"></script>\n</body>")
+  html = wrap_slide_content(html)
   File.write("index.html", html)
 end
 
@@ -83,6 +98,7 @@ step("✨", "Post-processing print.html") do
   html.sub!('<section id="title-slide"', '<section id="title-slide" data-background-image="style/background.jpg"')
   html.gsub!(%r{  <script src="./style/revealjs/plugin/(notes|search|zoom)/\1\.js"></script>\n}, "")
   html.sub!("plugins: [\n          RevealNotes,\n          RevealSearch,\n          RevealZoom\n        ]", "plugins: []")
+  html = wrap_slide_content(html)
   File.write("print.html", html)
 end
 

--- a/build
+++ b/build
@@ -83,6 +83,7 @@ step("✨", "Post-processing index.html") do
   html.gsub!(%r{  <script src="./style/revealjs/plugin/(notes|search|zoom)/\1\.js"></script>\n}, "")
   html.sub!("plugins: [\n          RevealNotes,\n          RevealSearch,\n          RevealZoom\n        ]", "plugins: []")
   html.sub!("keyboard: true,", "keyboard: { 83: null }, // 's' disabled (was: speaker notes)")
+  html.sub!("controls: true,", "controls: false,")
   html.sub!("display: 'block',", "display: 'flex',")
   html.sub!("</body>", "  <script src=\"#{MULTIPLEX_URL}/socket.io/socket.io.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js\"></script>\n  <script src=\"style/slide-zoom.js\"></script>\n</body>")
   html = wrap_slide_content(html)

--- a/build
+++ b/build
@@ -84,7 +84,7 @@ step("✨", "Post-processing index.html") do
   html.sub!("plugins: [\n          RevealNotes,\n          RevealSearch,\n          RevealZoom\n        ]", "plugins: []")
   html.sub!("keyboard: true,", "keyboard: { 83: null }, // 's' disabled (was: speaker notes)")
   html.sub!("display: 'block',", "display: 'flex',")
-  html.sub!("</body>", "  <script src=\"#{MULTIPLEX_URL}/socket.io/socket.io.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js\"></script>\n</body>")
+  html.sub!("</body>", "  <script src=\"#{MULTIPLEX_URL}/socket.io/socket.io.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js\"></script>\n  <script src=\"style/slide-zoom.js\"></script>\n</body>")
   html = wrap_slide_content(html)
   File.write("index.html", html)
 end

--- a/build
+++ b/build
@@ -32,7 +32,7 @@ def step(emoji, label)
 end
 
 def pandoc(output:, theme:)
-  result = `pandoc -f markdown+hard_line_breaks -t revealjs -s -o #{output} all-songs.md --slide-level=2 --syntax-highlighting=none --toc --toc-depth=1 -V theme=#{theme} -V progress=false -V revealjs-url=./style/revealjs -V width=960 -V height=640 2>&1`
+  result = `pandoc -f markdown+hard_line_breaks -t revealjs -s -o #{output} all-songs.md --slide-level=2 --syntax-highlighting=none --toc --toc-depth=1 -V theme=#{theme} -V progress=false -V revealjs-url=./style/revealjs -V disableLayout=true 2>&1`
   print result unless result.strip.empty?
 end
 

--- a/content/songs/Verdammt ich lieb dich (Matthias Reim).md
+++ b/content/songs/Verdammt ich lieb dich (Matthias Reim).md
@@ -26,9 +26,14 @@ Und ich [F] denke schon wieder nur an [G] dich...
 
 _(x2: gently first time, then repeat intensively)_
 
-Verdammt, ich [C] lieb' dich, ich lieb' dich [G] nicht.
-Verdammt, ich [Dm] brauch' dich, brauch' dich [Am] nicht. [G]
-Verdammt, ich [C] will dich, ich will dich [G] nicht,
+Verdammt, ich [C] lieb' dich,
+ich lieb' dich [G] nicht.
+
+Verdammt, ich [Dm] brauch' dich,
+brauch' dich [Am] nicht. [G]
+
+Verdammt, ich [C] will dich,
+ich will dich [G] nicht,
 Ich [F] will dich nicht verli[Am]er'n!
 
 ## Verse 2
@@ -55,9 +60,14 @@ Und ich [F] denke schon wieder nur an [G] dich...
 
 ## Chorus
 
-Verdammt, ich [C] lieb' dich, ich lieb' dich [G] nicht.
-Verdammt, ich [Dm] brauch' dich, brauch' dich [Am] nicht. [G]
-Verdammt, ich [C] will dich, ich will dich [G] nicht,
+Verdammt, ich [C] lieb' dich,
+ich lieb' dich [G] nicht.
+
+Verdammt, ich [Dm] brauch' dich,
+brauch' dich [Am] nicht. [G]
+
+Verdammt, ich [C] will dich,
+ich will dich [G] nicht,
 Ich [F] will dich nicht verli[Am]er'n! - Ooooh!
 
 _(Repeat and fade)_

--- a/content/songs/Wild world (Cat Stevens).md
+++ b/content/songs/Wild world (Cat Stevens).md
@@ -37,15 +37,15 @@ But then a [Dm] lot of nice things turn
 
 ## Chorus
 
-[C] Oh [G] baby, baby it's a [F] wild world
-[C] _(Riff 1)_
-[G] It's hard to get by [F] just upon a [C] smile
-[G] _(Riff 2)_
+[C] Oh [G] baby, baby
+it's a [F] wild world [C] _(Riff 1)_
+[G] It's hard to get by
+[F] just upon a [C] smile [G] _(Riff 2)_
 
-[C] Oh [G] baby, baby it's a [F] wild world
-[C] _(Riff 1)_
-[G] I'll always remember you [F] like a [C] child girl
-[Dm] [E]
+[C] Oh [G] baby, baby
+it's a [F] wild world [C] _(Riff 1)_
+[G] I'll always remember you
+[F] like a [C] child girl [Dm] [E]
 
 ## Verse 2
 
@@ -62,15 +62,15 @@ But just re[Dm]member there's a lot of bad
 
 ## Chorus
 
-[C] Oh [G] baby, baby it's a [F] wild world
-[C] _(Riff 1)_
-[G] It's hard to get by [F] just upon a [C] smile
-[G] _(Riff 2)_
+[C] Oh [G] baby, baby
+it's a [F] wild world [C] _(Riff 1)_
+[G] It's hard to get by
+[F] just upon a [C] smile [G] _(Riff 2)_
 
-[C] Oh [G] baby, baby it's a [F] wild world
-[C] _(Riff 1)_
-[G] I'll always remember you [F] like a [C] child girl
-[Dm] [E]
+[C] Oh [G] baby, baby
+it's a [F] wild world [C] _(Riff 1)_
+[G] I'll always remember you
+[F] like a [C] child girl [Dm] [E]
 
 ## Verse 3
 
@@ -84,15 +84,15 @@ But just re[Dm]member there's a lot of bad
 
 ## Chorus
 
-[C] Oh [G] baby, baby it's a [F] wild world
-[C] _(Riff 1)_
-[G] It's hard to get by [F] just upon a [C] smile
-[G] _(Riff 2)_
+[C] Oh [G] baby, baby
+it's a [F] wild world [C] _(Riff 1)_
+[G] It's hard to get by
+[F] just upon a [C] smile [G] _(Riff 2)_
 
-[C] Oh [G] baby, baby it's a [F] wild world
-[C] _(Riff 1)_
-[G] I'll always remember you [F] like a [C] child girl
-[Dm] [E] _(1st time only)_
+[C] Oh [G] baby, baby
+it's a [F] wild world [C] _(Riff 1)_
+[G] I'll always remember you
+[F] like a [C] child girl [Dm] [E] _(1st time only)_
 
 _(Repeat)_
 

--- a/index.html
+++ b/index.html
@@ -11,19 +11,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
   <link rel="stylesheet" href="./style/revealjs/dist/reset.css">
   <link rel="stylesheet" href="./style/revealjs/dist/reveal.css">
-  <style>#bottom-left-controls {
+  <style>.controls-group {
   position: fixed;
-  bottom: 2.5em;
-  left: 2em;
   z-index: 100;
   display: flex;
   align-items: center;
   gap: 0.75em;
 }
 
-#toggle-chords-visibility,
-#master-mode,
-#show-qr {
+.ctrl {
   position: relative;
   opacity: 0.75;
   background: none;
@@ -32,10 +28,14 @@
   cursor: pointer;
   font-family: inherit;
   line-height: 1;
+  text-decoration: none;
+}
+
+.ctrl::before {
+  font-size: 3em;
 }
 
 #toggle-chords-visibility::before {
-  font-size: 3em;
   content: '🎹';
 }
 
@@ -92,31 +92,21 @@ section#TOC::-webkit-scrollbar-thumb {
   border: 3px solid var(--scrollbarBG);
 }
 
-a#go-to-toc {
-  position: fixed;
-  top: 2em;
-  left: 1.5em;
-  z-index: 100;
-  opacity: 0.75;
-  text-decoration: none;
+#top-left-controls {
+  top: 1em;
+  left: 1em;
+}
+
+#top-right-controls {
+  top: 1em;
+  right: 1em;
 }
 
 a#go-to-toc::before {
-  font-size: 3em;
   content: '📖'
 }
 
-a#toggle-theme {
-  position: fixed;
-  top: 2em;
-  right: 1.5em;
-  z-index: 100;
-  opacity: 0.75;
-  text-decoration: none;
-}
-
 a#toggle-theme::before {
-  font-size: 3em;
   content: '🌙';
 }
 
@@ -129,7 +119,6 @@ a#toggle-theme::before {
 }
 
 #master-mode::before {
-  font-size: 3em;
   content: '🚀';
 }
 
@@ -142,7 +131,6 @@ a#toggle-theme::before {
 }
 
 #show-qr::before {
-  font-size: 3em;
   content: '🔗';
 }
 
@@ -396,13 +384,15 @@ section.slide.level2 {
   <link rel="stylesheet" href="./style/revealjs/dist/theme/night.css" id="theme">
 </head>
 <body>
-<script>window.MULTIPLEX={"url":"https://multiplex.up.railway.app","socketId":"c16324e0117e6da00c62c91a5594b6fc1d196313432409c79366c93078ac1fe7","secret":"cc58ea930602b842d3aecf51f01acba1","password":"guitar"};</script><div id="bottom-left-controls">
-  <button id="toggle-chords-visibility"></button>
-  <button id="show-qr"></button>
-  <button id="master-mode"></button>
+<script>window.MULTIPLEX={"url":"https://multiplex.up.railway.app","socketId":"c16324e0117e6da00c62c91a5594b6fc1d196313432409c79366c93078ac1fe7","secret":"cc58ea930602b842d3aecf51f01acba1","password":"guitar"};</script><div id="top-left-controls" class="controls-group">
+  <a href="#/1" id="go-to-toc" class="ctrl"></a>
+  <button id="toggle-chords-visibility" class="ctrl"></button>
 </div>
-<a href="#" id="toggle-theme"></a>
-<a href="#/1" id="go-to-toc"></a>
+<div id="top-right-controls" class="controls-group">
+  <button id="show-qr" class="ctrl"></button>
+  <button id="master-mode" class="ctrl"></button>
+  <a href="#" id="toggle-theme" class="ctrl"></a>
+</div>
 <script>
   document.getElementById('toggle-chords-visibility').addEventListener('click', function() {
     document.body.classList.toggle('chords-hidden');
@@ -4364,7 +4354,7 @@ tutorial</a></li>
       // https://revealjs.com/config/
       Reveal.initialize({
         // Display controls in the bottom right corner
-        controls: true,
+        controls: false,
 
         // Help the user learn the controls by providing hints, for example by
         // bouncing the down arrow when they first encounter a vertical slide

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
   <meta name="author" content="😊 Josua &amp; Monika ❤️">
@@ -302,8 +303,20 @@ body.theme-bright .modal-box button {
 body.theme-bright .modal-box button:hover {
   background: #ccc;
 }
+.reveal section .slide-content {
+  padding: 10px;
+}
+
 .reveal section h1 {
-  font-size: 3em;
+  font-size: 2em;
+}
+
+.reveal section h2 {
+  font-size: 1.5em;
+}
+
+.reveal section h3 {
+  font-size: 1.25em;
 }
 
 .reveal section code {
@@ -345,6 +358,20 @@ body.theme-bright .modal-box button:hover {
   text-align: left;
 }
 
+.reveal section.slide.level2 .slide-content {
+  white-space: nowrap;
+}
+
+section.stack {
+  flex-direction: column;
+  justify-content: center;
+}
+
+section.slide.level2 {
+  display: flex;
+  justify-content: center;
+}
+
     .reveal .sourceCode {  /* see #7635 */
       overflow: visible;
     }
@@ -368,7 +395,8 @@ body.theme-bright .modal-box button:hover {
   </style>
   <link rel="stylesheet" href="./style/revealjs/dist/theme/night.css" id="theme">
 </head>
-<body><script>window.MULTIPLEX={"url":"https://multiplex.up.railway.app","socketId":"c16324e0117e6da00c62c91a5594b6fc1d196313432409c79366c93078ac1fe7","secret":"cc58ea930602b842d3aecf51f01acba1","password":"guitar"};</script><div id="bottom-left-controls">
+<body>
+<script>window.MULTIPLEX={"url":"https://multiplex.up.railway.app","socketId":"c16324e0117e6da00c62c91a5594b6fc1d196313432409c79366c93078ac1fe7","secret":"cc58ea930602b842d3aecf51f01acba1","password":"guitar"};</script><div id="bottom-left-controls">
   <button id="toggle-chords-visibility"></button>
   <button id="show-qr"></button>
   <button id="master-mode"></button>
@@ -516,128 +544,94 @@ window.addEventListener('load', function() {
   <div class="reveal">
     <div class="slides">
 
-<section id="title-slide">
+<section id="title-slide"><div class="slide-content">
   <h1 class="title">Lieblings-Songs 🔥🎶🌛</h1>
   <p class="author">😊 Josua &amp; Monika ❤️</p>
-</section>
-<section id="TOC">
+</div></section>
+<section id="TOC"><div class="slide-content">
 <nav role="doc-toc"> 
 <ul>
-<li><a href="#/introduction"
-id="/toc-introduction">Introduction</a></li>
-<li><a href="#/across-the-universe-beatles"
-id="/toc-across-the-universe-beatles">Across the universe
+<li><a href="#/introduction" id="/toc-introduction">Introduction</a></li>
+<li><a href="#/across-the-universe-beatles" id="/toc-across-the-universe-beatles">Across the universe
 (Beatles)</a></li>
-<li><a href="#/as-long-as-you-love-me-backstreet-boys"
-id="/toc-as-long-as-you-love-me-backstreet-boys">As long as you love me
+<li><a href="#/as-long-as-you-love-me-backstreet-boys" id="/toc-as-long-as-you-love-me-backstreet-boys">As long as you love me
 (Backstreet Boys)</a></li>
-<li><a href="#/baby-one-more-time-britney-spears"
-id="/toc-baby-one-more-time-britney-spears">Baby one more time (Britney
+<li><a href="#/baby-one-more-time-britney-spears" id="/toc-baby-one-more-time-britney-spears">Baby one more time (Britney
 Spears)</a></li>
-<li><a href="#/bella-ciao-traditional"
-id="/toc-bella-ciao-traditional">Bella ciao (Traditional)</a></li>
-<li><a href="#/dont-worry-be-happy-bobby-mcferrin"
-id="/toc-dont-worry-be-happy-bobby-mcferrin">Don’t worry be happy (Bobby
+<li><a href="#/bella-ciao-traditional" id="/toc-bella-ciao-traditional">Bella ciao (Traditional)</a></li>
+<li><a href="#/dont-worry-be-happy-bobby-mcferrin" id="/toc-dont-worry-be-happy-bobby-mcferrin">Don’t worry be happy (Bobby
 McFerrin)</a></li>
 <li><a href="#/dr-eskimo-mani-matter" id="/toc-dr-eskimo-mani-matter">Dr
 Eskimo (Mani Matter)</a></li>
-<li><a href="#/dr-sidi-abdel-assar-mani-matter"
-id="/toc-dr-sidi-abdel-assar-mani-matter">Dr Sidi Abdel Assar (Mani
+<li><a href="#/dr-sidi-abdel-assar-mani-matter" id="/toc-dr-sidi-abdel-assar-mani-matter">Dr Sidi Abdel Assar (Mani
 Matter)</a></li>
-<li><a href="#/dr-wilhelm-täll-mani-matter"
-id="/toc-dr-wilhelm-täll-mani-matter">Dr Wilhelm Täll (Mani
+<li><a href="#/dr-wilhelm-t%C3%A4ll-mani-matter" id="/toc-dr-wilhelm-täll-mani-matter">Dr Wilhelm Täll (Mani
 Matter)</a></li>
-<li><a href="#/dynamit-mani-matter"
-id="/toc-dynamit-mani-matter">Dynamit (Mani Matter)</a></li>
-<li><a href="#/father-and-son-cat-stevens"
-id="/toc-father-and-son-cat-stevens">Father and son (Cat
+<li><a href="#/dynamit-mani-matter" id="/toc-dynamit-mani-matter">Dynamit (Mani Matter)</a></li>
+<li><a href="#/father-and-son-cat-stevens" id="/toc-father-and-son-cat-stevens">Father and son (Cat
 Stevens)</a></li>
 <li><a href="#/feel-robbie-williams" id="/toc-feel-robbie-williams">Feel
 (Robbie Williams)</a></li>
-<li><a href="#/further-on-up-the-road-johnny-cash"
-id="/toc-further-on-up-the-road-johnny-cash">Further on up the road
+<li><a href="#/further-on-up-the-road-johnny-cash" id="/toc-further-on-up-the-road-johnny-cash">Further on up the road
 (Johnny Cash)</a></li>
-<li><a href="#/griechischer-wein-udo-jürgens"
-id="/toc-griechischer-wein-udo-jürgens">Griechischer Wein (Udo
+<li><a href="#/griechischer-wein-udo-j%C3%BCrgens" id="/toc-griechischer-wein-udo-jürgens">Griechischer Wein (Udo
 Jürgens)</a></li>
-<li><a href="#/hallelujah-leonard-cohen"
-id="/toc-hallelujah-leonard-cohen">❤️ Hallelujah (Leonard
+<li><a href="#/hallelujah-leonard-cohen" id="/toc-hallelujah-leonard-cohen">❤️ Hallelujah (Leonard
 Cohen)</a></li>
-<li><a href="#/hemmige-mani-matter"
-id="/toc-hemmige-mani-matter">Hemmige (Mani Matter)</a></li>
+<li><a href="#/hemmige-mani-matter" id="/toc-hemmige-mani-matter">Hemmige (Mani Matter)</a></li>
 <li><a href="#/hurt-johnny-cash" id="/toc-hurt-johnny-cash">Hurt (Johnny
 Cash)</a></li>
-<li><a href="#/i-am-sailing-rod-stewart"
-id="/toc-i-am-sailing-rod-stewart">I am sailing (Rod Stewart)</a></li>
+<li><a href="#/i-am-sailing-rod-stewart" id="/toc-i-am-sailing-rod-stewart">I am sailing (Rod Stewart)</a></li>
 <li><a href="#/jolene-dolly-parton" id="/toc-jolene-dolly-parton">❤️
 Jolene (Dolly Parton)</a></li>
-<li><a href="#/junge-die-ärzte" id="/toc-junge-die-ärzte">Junge (Die
+<li><a href="#/junge-die-%C3%A4rzte" id="/toc-junge-die-ärzte">Junge (Die
 Ärzte)</a></li>
-<li><a href="#/keep-on-the-sunny-side-carter-family"
-id="/toc-keep-on-the-sunny-side-carter-family">Keep on the sunny side
+<li><a href="#/keep-on-the-sunny-side-carter-family" id="/toc-keep-on-the-sunny-side-carter-family">Keep on the sunny side
 (Carter Family)</a></li>
-<li><a href="#/lemon-tree-fools-garden"
-id="/toc-lemon-tree-fools-garden">Lemon tree (Fool’s Garden)</a></li>
-<li><a href="#/morning-has-broken-cat-stevens"
-id="/toc-morning-has-broken-cat-stevens">Morning has broken (Cat
+<li><a href="#/lemon-tree-fools-garden" id="/toc-lemon-tree-fools-garden">Lemon tree (Fool’s Garden)</a></li>
+<li><a href="#/morning-has-broken-cat-stevens" id="/toc-morning-has-broken-cat-stevens">Morning has broken (Cat
 Stevens)</a></li>
-<li><a href="#/männer-sind-schweine-die-ärzte"
-id="/toc-männer-sind-schweine-die-ärzte">Männer sind Schweine (Die
+<li><a href="#/m%C3%A4nner-sind-schweine-die-%C3%A4rzte" id="/toc-männer-sind-schweine-die-ärzte">Männer sind Schweine (Die
 Ärzte)</a></li>
-<li><a href="#/no-woman-no-cry-bob-marley"
-id="/toc-no-woman-no-cry-bob-marley">No woman no cry (Bob
+<li><a href="#/no-woman-no-cry-bob-marley" id="/toc-no-woman-no-cry-bob-marley">No woman no cry (Bob
 Marley)</a></li>
 <li><a href="#/one-u2" id="/toc-one-u2">One (U2)</a></li>
-<li><a href="#/rivers-of-babylon-boney-m."
-id="/toc-rivers-of-babylon-boney-m.">Rivers of Babylon (Boney
+<li><a href="#/rivers-of-babylon-boney-m." id="/toc-rivers-of-babylon-boney-m.">Rivers of Babylon (Boney
 M.)</a></li>
-<li><a href="#/road-to-mandalay-robbie-williams"
-id="/toc-road-to-mandalay-robbie-williams">Road to Mandalay (Robbie
+<li><a href="#/road-to-mandalay-robbie-williams" id="/toc-road-to-mandalay-robbie-williams">Road to Mandalay (Robbie
 Williams)</a></li>
-<li><a href="#/road-trippin-red-hot-chili-peppers"
-id="/toc-road-trippin-red-hot-chili-peppers">Road trippin’ (Red Hot
+<li><a href="#/road-trippin-red-hot-chili-peppers" id="/toc-road-trippin-red-hot-chili-peppers">Road trippin’ (Red Hot
 Chili Peppers)</a></li>
-<li><a href="#/s-zündhölzli-mani-matter"
-id="/toc-s-zündhölzli-mani-matter">S Zündhölzli (Mani Matter)</a></li>
-<li><a href="#/sittin-on-the-dock-of-the-bay-otis-redding"
-id="/toc-sittin-on-the-dock-of-the-bay-otis-redding">Sittin’ on the dock
+<li><a href="#/s-z%C3%BCndh%C3%B6lzli-mani-matter" id="/toc-s-zündhölzli-mani-matter">S Zündhölzli (Mani Matter)</a></li>
+<li><a href="#/sittin-on-the-dock-of-the-bay-otis-redding" id="/toc-sittin-on-the-dock-of-the-bay-otis-redding">Sittin’ on the dock
 of the bay (Otis Redding)</a></li>
-<li><a href="#/something-stupid-robbie-williams"
-id="/toc-something-stupid-robbie-williams">Something stupid (Robbie
+<li><a href="#/something-stupid-robbie-williams" id="/toc-something-stupid-robbie-williams">Something stupid (Robbie
 Williams)</a></li>
-<li><a href="#/somewhere-over-the-rainbow-israël-kamakawiwoole"
-id="/toc-somewhere-over-the-rainbow-israël-kamakawiwoole">Somewhere over
+<li><a href="#/somewhere-over-the-rainbow-isra%C3%ABl-kamakawiwoole" id="/toc-somewhere-over-the-rainbow-israël-kamakawiwoole">Somewhere over
 the rainbow (Israël Kamakawiwo’ole)</a></li>
-<li><a href="#/summer-wine-nancy-sinatra-lee-hazlewood"
-id="/toc-summer-wine-nancy-sinatra-lee-hazlewood">Summer wine (Nancy
+<li><a href="#/summer-wine-nancy-sinatra-lee-hazlewood" id="/toc-summer-wine-nancy-sinatra-lee-hazlewood">Summer wine (Nancy
 Sinatra &amp; Lee Hazlewood)</a></li>
-<li><a href="#/the-river-is-flowing-indian-summer"
-id="/toc-the-river-is-flowing-indian-summer">❤️ The river is flowing
+<li><a href="#/the-river-is-flowing-indian-summer" id="/toc-the-river-is-flowing-indian-summer">❤️ The river is flowing
 (Indian Summer)</a></li>
-<li><a href="#/verdammt-ich-lieb-dich-matthias-reim"
-id="/toc-verdammt-ich-lieb-dich-matthias-reim">Verdammt ich lieb dich
+<li><a href="#/verdammt-ich-lieb-dich-matthias-reim" id="/toc-verdammt-ich-lieb-dich-matthias-reim">Verdammt ich lieb dich
 (Matthias Reim)</a></li>
-<li><a href="#/whats-up-4-non-blondes"
-id="/toc-whats-up-4-non-blondes">Whats up (4 Non Blondes)</a></li>
-<li><a href="#/wild-world-cat-stevens"
-id="/toc-wild-world-cat-stevens">Wild world (Cat Stevens)</a></li>
-<li><a href="#/wish-you-were-here-pink-floyd"
-id="/toc-wish-you-were-here-pink-floyd">❤️ Wish you were here (Pink
+<li><a href="#/whats-up-4-non-blondes" id="/toc-whats-up-4-non-blondes">Whats up (4 Non Blondes)</a></li>
+<li><a href="#/wild-world-cat-stevens" id="/toc-wild-world-cat-stevens">Wild world (Cat Stevens)</a></li>
+<li><a href="#/wish-you-were-here-pink-floyd" id="/toc-wish-you-were-here-pink-floyd">❤️ Wish you were here (Pink
 Floyd)</a></li>
 </ul>
 </nav>
-</section>
+</div></section>
 
 <section>
-<section id="introduction" class="title-slide slide level1">
+<section id="introduction" class="title-slide slide level1"><div class="slide-content">
 <h1>Introduction</h1>
 
-</section>
-<section id="welcome" class="slide level2">
+</div></section>
+<section id="welcome" class="slide level2"><div class="slide-content">
 <h2>Welcome</h2>
-<p>This is a collection of my favourite guitar songs.<br />
-🎤😍🎸🔥 Find it on <a
-href="https://songs.josh.ch">songs.josh.ch</a>.</p>
+<p>This is a collection of my favourite guitar songs.<br>
+🎤😍🎸🔥 Find it on <a href="https://songs.josh.ch">songs.josh.ch</a>.</p>
 <ul>
 <li>Use arrow keys or swipe gestures to navigate</li>
 <li>To toggle chords display, click 🎹</li>
@@ -646,8 +640,8 @@ then open from there</li>
 </ul>
 <p>Let’s sing together and have some fun! 💫</p>
 <p>🙏 Cheers, Josua + Monika 🌛</p>
-</section>
-<section id="basic-chords" class="slide level2">
+</div></section>
+<section id="basic-chords" class="slide level2"><div class="slide-content">
 <h2>Basic chords</h2>
 <pre><code>x Not played / muted
 = Barre
@@ -674,893 +668,749 @@ Gm |3 x 0 0 1 1| Easier, A string muted
 
 Feeling bored of major chords (A, D, E...)?
   =&gt; Try playing a seventh chord instead (A7, D7, E7...)!</code></pre>
-</section></section>
+</div></section></section>
 <section>
-<section id="across-the-universe-beatles"
-class="title-slide slide level1">
+<section id="across-the-universe-beatles" class="title-slide slide level1"><div class="slide-content">
 <h1>Across the universe (Beatles)</h1>
 
-</section>
-<section id="instructions" class="slide level2">
+</div></section>
+<section id="instructions" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>       |E A D G B e|
        |-----------|
 A7sus4 |x 0 2 0 3 0|
 F#m    |2=4=4=2=2=2|</code></pre>
-</section>
-<section id="intro" class="slide level2">
+</div></section>
+<section id="intro" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-</section>
-<section id="verse-1" class="slide level2">
+</div></section>
+<section id="verse-1" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="d">D</code> Words are flowing out <code
-class="b">Bm</code><br />
-like endless <code class="f">F#m</code> rain into a paper cup<br />
-They <code class="e">Em7</code> slither wildly as they slip away<br />
+<p><code class="d">D</code> Words are flowing out <code class="b">Bm</code><br>
+like endless <code class="f">F#m</code> rain into a paper cup<br>
+They <code class="e">Em7</code> slither wildly as they slip away<br>
 a<code class="a">A</code>cross the <code class="a">A7</code>
 universe</p>
 <p><code class="d">D</code> Pools of sorrow, <code class="b">Bm</code>
-waves of joy<br />
-are <code class="f">F#m</code> drifting through my opened mind<br />
-Poss<code class="e">Em7</code>essing and car<code
-class="g">Gm</code>essing me</p>
-</section>
-<section id="chorus" class="slide level2">
+waves of joy<br>
+are <code class="f">F#m</code> drifting through my opened mind<br>
+Poss<code class="e">Em7</code>essing and car<code class="g">Gm</code>essing me</p>
+</div></section>
+<section id="chorus" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code></p>
-<p><code class="a">A</code> Nothing’s gonna change my world <code
-class="a">A7</code><br />
-<code class="g">G</code> Nothing’s gonna change my world <code
-class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse-2" class="slide level2">
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code></p>
+<p><code class="a">A</code> Nothing’s gonna change my world <code class="a">A7</code><br>
+<code class="g">G</code> Nothing’s gonna change my world <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-2" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p><code class="d">D</code> Images of <code class="b">Bm</code> broken
-light which<br />
-<code class="f">F#m</code> dance before me like a million <code
-class="e">Em7</code> eyes<br />
-They call me on and on<br />
+light which<br>
+<code class="f">F#m</code> dance before me like a million <code class="e">Em7</code> eyes<br>
+They call me on and on<br>
 a<code class="a">A</code>cross the <code class="a">A7</code>
 universe</p>
 <p><code class="d">D</code> Thoughts meander <code class="b">Bm</code>
-like a restless<br />
-<code class="f">F#m</code> wind inside a letterbox<br />
-They <code class="e">Em7</code> tumble blindly<br />
-as they make their <code class="a">A</code> way<br />
+like a restless<br>
+<code class="f">F#m</code> wind inside a letterbox<br>
+They <code class="e">Em7</code> tumble blindly<br>
+as they make their <code class="a">A</code> way<br>
 across the <code class="a">A7</code> universe</p>
-</section>
-<section id="chorus-1" class="slide level2">
+</div></section>
+<section id="chorus-1" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code></p>
-<p><code class="a">A</code> Nothing’s gonna change my world <code
-class="a">A7</code><br />
-<code class="g">G</code> Nothing’s gonna change my world <code
-class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse-3" class="slide level2">
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code></p>
+<p><code class="a">A</code> Nothing’s gonna change my world <code class="a">A7</code><br>
+<code class="g">G</code> Nothing’s gonna change my world <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-3" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="d">D</code> Sounds of laughter, <code
-class="b">Bm</code> shades of life<br />
-are <code class="f">F#m</code> ringing through my opened ears<br />
+<p><code class="d">D</code> Sounds of laughter, <code class="b">Bm</code> shades of life<br>
+are <code class="f">F#m</code> ringing through my opened ears<br>
 In<code class="e">Em7</code>citing and in<code class="g">Gm</code>viting
 me</p>
 <p><code class="d">D</code> Limitless, un<code class="b">Bm</code>dying
-love<br />
-which <code class="f">F#m</code>shines around me like<br />
-a million <code class="e">Em7</code> suns and calls me on and on<br />
-a<code class="a">A</code>cross the universe <code
-class="a">A7</code></p>
-</section>
-<section id="chorus-2" class="slide level2">
+love<br>
+which <code class="f">F#m</code>shines around me like<br>
+a million <code class="e">Em7</code> suns and calls me on and on<br>
+a<code class="a">A</code>cross the universe <code class="a">A7</code></p>
+</div></section>
+<section id="chorus-2" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code></p>
-<p><code class="a">A</code> Nothing’s gonna change my world <code
-class="a">A7</code><br />
-<code class="g">G</code> Nothing’s gonna change my world <code
-class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="outro" class="slide level2">
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code></p>
+<p><code class="a">A</code> Nothing’s gonna change my world <code class="a">A7</code><br>
+<code class="g">G</code> Nothing’s gonna change my world <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="outro" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code> <em>(Repeat and fade)</em></p>
-</section>
-<section id="resources" class="slide level2">
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code> <em>(Repeat and fade)</em></p>
+</div></section>
+<section id="resources" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=90M60PzmxEE">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/the-beatles/across-the-universe-chords-202167">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/the-beatles/across-the-universe-chords-202167">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=CQ1P8IQc8AY">Guitar
 tutorial</a></li>
 <li><a href="https://www.youtube.com/watch?v=RhMEKiIb86I">Interpretation
 by Fiona Apple</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="as-long-as-you-love-me-backstreet-boys"
-class="title-slide slide level1">
+<section id="as-long-as-you-love-me-backstreet-boys" class="title-slide slide level1"><div class="slide-content">
 <h1>As long as you love me (Backstreet Boys)</h1>
 
-</section>
-<section id="intro-1" class="slide level2">
+</div></section>
+<section id="intro-1" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="c">C</code> <code class="g">G</code> <code
-class="e">Em</code> <code class="d">D</code><br />
+<p><code class="c">C</code> <code class="g">G</code> <code class="e">Em</code> <code class="d">D</code><br>
 As long as you love me</p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="verse-1-1" class="slide level2">
+</div></section>
+<section id="verse-1-1" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Although <code class="e">Em</code> loneliness has always been<br />
-a <code class="c">C</code> friend of mine<br />
-I’m <code class="d">D</code> leavin’ my life in your hands <code
-class="g">G</code> <code class="d">D</code><br />
-<code class="e">Em</code> People say I’m crazy and that <code
-class="c">C</code> I am blind<br />
-<code class="d">D</code> Risking it all in a glance <code
-class="g">G</code> <code class="d">D</code></p>
-<p>And <code class="e">Em</code> how you got me blind is still a <code
-class="c">C</code> mystery<br />
-I <code class="d">D</code> can’t get you out of my head <code
-class="g">G</code> <code class="d">D</code><br />
-<code class="e">Em</code> Don’t care what is written in your <code
-class="c">C</code> history<br />
-As <code class="d">D</code> long as you’re here with me <code
-class="g">G</code></p>
-</section>
-<section id="chorus-3" class="slide level2">
+<p>Although <code class="e">Em</code> loneliness has always been<br>
+a <code class="c">C</code> friend of mine<br>
+I’m <code class="d">D</code> leavin’ my life in your hands <code class="g">G</code> <code class="d">D</code><br>
+<code class="e">Em</code> People say I’m crazy and that <code class="c">C</code> I am blind<br>
+<code class="d">D</code> Risking it all in a glance <code class="g">G</code> <code class="d">D</code></p>
+<p>And <code class="e">Em</code> how you got me blind is still a <code class="c">C</code> mystery<br>
+I <code class="d">D</code> can’t get you out of my head <code class="g">G</code> <code class="d">D</code><br>
+<code class="e">Em</code> Don’t care what is written in your <code class="c">C</code> history<br>
+As <code class="d">D</code> long as you’re here with me <code class="g">G</code></p>
+</div></section>
+<section id="chorus-3" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I don’t care who <code class="c">C</code> you are<br />
-Where <code class="g">G</code> you’re from<br />
-What <code class="e">Em</code> you did<br />
+<p>I don’t care who <code class="c">C</code> you are<br>
+Where <code class="g">G</code> you’re from<br>
+What <code class="e">Em</code> you did<br>
 As long <code class="d">D</code> as you love me</p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="verse-2-1" class="slide level2">
+</div></section>
+<section id="verse-2-1" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="e">Em</code> Every little thing that you have <code
-class="c">C</code> said and done<br />
-Feels <code class="d">D</code> like it’s deep within me <code
-class="g">G</code> <code class="d">D</code><br />
-<code class="e">Em</code> Doesn’t really matter if you’re <code
-class="c">C</code> on the run<br />
+<p><code class="e">Em</code> Every little thing that you have <code class="c">C</code> said and done<br>
+Feels <code class="d">D</code> like it’s deep within me <code class="g">G</code> <code class="d">D</code><br>
+<code class="e">Em</code> Doesn’t really matter if you’re <code class="c">C</code> on the run<br>
 It <code class="d">D</code> seems like we’re <code class="g">G</code>
 meant to be <code class="d">D</code></p>
-</section>
-<section id="chorus-4" class="slide level2">
+</div></section>
+<section id="chorus-4" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I don’t care who <code class="c">C</code> you are<br />
-Where <code class="g">G</code> you’re from<br />
-What <code class="e">Em</code> you did<br />
+<p>I don’t care who <code class="c">C</code> you are<br>
+Where <code class="g">G</code> you’re from<br>
+What <code class="e">Em</code> you did<br>
 As long <code class="d">D</code> as you love me (yeah)</p>
 <p><em>(Repeat)</em></p>
-<p><code class="c">C</code> <code class="g">G</code> <code
-class="e">Em</code> <code class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="bridge" class="slide level2">
+<p><code class="c">C</code> <code class="g">G</code> <code class="e">Em</code> <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="bridge" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p><code class="e">Em</code> I’ve tried to hide it so that <code
-class="g">G</code> no one knows<br />
-But I <code class="c">C</code> guess it shows<br />
-When you <code class="c">C</code> look into my eyes <code
-class="d">D</code></p>
-<p><code class="e">Em</code> What you did and where you’re <code
-class="g">G</code> comin from<br />
+<p><code class="e">Em</code> I’ve tried to hide it so that <code class="g">G</code> no one knows<br>
+But I <code class="c">C</code> guess it shows<br>
+When you <code class="c">C</code> look into my eyes <code class="d">D</code></p>
+<p><code class="e">Em</code> What you did and where you’re <code class="g">G</code> comin from<br>
 I don’t <code class="d">D</code> care, <code class="c">C</code> as long
 <code class="d">D</code> as you <code class="c">C</code> love me,
-baby<br />
-<code class="g">G</code> <code class="d">D</code> <code
-class="e">Em</code> <code class="c">C</code> <code
-class="d">D</code></p>
-</section>
-<section id="chorus-5" class="slide level2">
+baby<br>
+<code class="g">G</code> <code class="d">D</code> <code class="e">Em</code> <code class="c">C</code> <code class="d">D</code></p>
+</div></section>
+<section id="chorus-5" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I don’t care who <code class="c">C</code> you are<br />
-Where <code class="g">G</code> you’re from<br />
-What <code class="e">Em</code> you did<br />
+<p>I don’t care who <code class="c">C</code> you are<br>
+Where <code class="g">G</code> you’re from<br>
+What <code class="e">Em</code> you did<br>
 As long <code class="d">D</code> as you love me</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
-<section id="resources-1" class="slide level2">
+</div></section>
+<section id="resources-1" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=960wzRtcl-Y">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/backstreet-boys/as-long-as-you-love-me-chords-263108">Source
+<li>
+<a href="https://tabs.ultimate-guitar.com/tab/backstreet-boys/as-long-as-you-love-me-chords-263108">Source
 tab</a> (transposed +7)</li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="baby-one-more-time-britney-spears"
-class="title-slide slide level1">
+<section id="baby-one-more-time-britney-spears" class="title-slide slide level1"><div class="slide-content">
 <h1>Baby one more time (Britney Spears)</h1>
 
-</section>
-<section id="intro-2" class="slide level2">
+</div></section>
+<section id="intro-2" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><code class="a">Am</code> Oh baby, baby <em>(x2)</em></p>
-</section>
-<section id="verse-1-2" class="slide level2">
+</div></section>
+<section id="verse-1-2" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="a">Am</code> Oh baby, baby<br />
-How <code class="e">E</code> was I supposed to know <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby, baby<br>
+How <code class="e">E</code> was I supposed to know <code class="c">C</code><br>
 That <code class="d">Dm</code> something wasn’t <code class="e">E</code>
 right here</p>
-<p><code class="a">Am</code> Oh baby baby<br />
-I <code class="e">E</code> shouldn’t have let you go <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby baby<br>
+I <code class="e">E</code> shouldn’t have let you go <code class="c">C</code><br>
 And <code class="d">Dm</code> now you’re out of <code class="e">E</code>
 sight, yeah</p>
-</section>
-<section id="pre-chorus" class="slide level2">
+</div></section>
+<section id="pre-chorus" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
-<p><code class="a">Am</code> Show me, how you want it <code
-class="e">E</code> to be<br />
-Tell me <code class="c">C</code> baby<br />
-’Cause I need to <code class="d">Dm</code> know now<br />
+<p><code class="a">Am</code> Show me, how you want it <code class="e">E</code> to be<br>
+Tell me <code class="c">C</code> baby<br>
+’Cause I need to <code class="d">Dm</code> know now<br>
 what we’ve got <code class="e">E</code></p>
-</section>
-<section id="chorus-6" class="slide level2">
+</div></section>
+<section id="chorus-6" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
-killing me<br />
+killing me<br>
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe<br />
+still believe<br>
 <code class="e">E</code> (still believe)</p>
-<p><code class="a">Am</code> When I’m not with you I lose <code
-class="e">E</code> my mind<br />
-<code class="g">G</code> Give me a sign <code class="c">C</code><br />
+<p><code class="a">Am</code> When I’m not with you I lose <code class="e">E</code> my mind<br>
+<code class="g">G</code> Give me a sign <code class="c">C</code><br>
 <code class="d">Dm</code> Hit me baby <code class="e">E</code> one more
 time</p>
-</section>
-<section id="verse-2-2" class="slide level2">
+</div></section>
+<section id="verse-2-2" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> Oh baby, baby<br />
-The <code class="e">E</code> reason I breathe is you <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby, baby<br>
+The <code class="e">E</code> reason I breathe is you <code class="c">C</code><br>
 <code class="d">Dm</code> Boy you’ve got me <code class="e">E</code>
 flying</p>
-<p><code class="a">Am</code> Oh pretty baby<br />
-There’s <code class="e">E</code> nothing that I woul<code
-class="c">C</code>dn’t do<br />
+<p><code class="a">Am</code> Oh pretty baby<br>
+There’s <code class="e">E</code> nothing that I woul<code class="c">C</code>dn’t do<br>
 It’s <code class="d">Dm</code> not the way I <code class="e">E</code>
 planned it</p>
-</section>
-<section id="pre-chorus-1" class="slide level2">
+</div></section>
+<section id="pre-chorus-1" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
-<p><code class="a">Am</code> Show me, how you want it <code
-class="e">E</code> to be<br />
-Tell me <code class="c">C</code> baby<br />
-’Cause I need to <code class="d">Dm</code> know now<br />
+<p><code class="a">Am</code> Show me, how you want it <code class="e">E</code> to be<br>
+Tell me <code class="c">C</code> baby<br>
+’Cause I need to <code class="d">Dm</code> know now<br>
 what we’ve got <code class="e">E</code></p>
-</section>
-<section id="chorus-7" class="slide level2">
+</div></section>
+<section id="chorus-7" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
-killing me (and I)<br />
+killing me (and I)<br>
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe<br />
+still believe<br>
 <code class="e">E</code> (still believe)</p>
-<p><code class="a">Am</code> When I’m not with you I lose <code
-class="e">E</code> my mind<br />
-<code class="g">G</code> Give me a sign <code class="c">C</code><br />
+<p><code class="a">Am</code> When I’m not with you I lose <code class="e">E</code> my mind<br>
+<code class="g">G</code> Give me a sign <code class="c">C</code><br>
 <code class="d">Dm</code> Hit me baby <code class="e">E</code> one more
 time</p>
-</section>
-<section id="interlude" class="slide level2">
+</div></section>
+<section id="interlude" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><code class="a">Am</code> Oh baby, baby <em>(x2)</em></p>
-<p><code class="a">Am</code> Oh baby, baby<br />
-How <code class="e">E</code> was I supposed to know <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby, baby<br>
+How <code class="e">E</code> was I supposed to know <code class="c">C</code><br>
 <code class="d">Dm</code> <code class="e">E</code></p>
-<p><code class="f">F</code> Oh pretty baby<br />
-I <code class="g">G</code> shouldn’t have let you go <code
-class="d">Dm</code> <code class="f">F</code> <code
-class="g">G</code></p>
-</section>
-<section id="bridge-1" class="slide level2">
+<p><code class="f">F</code> Oh pretty baby<br>
+I <code class="g">G</code> shouldn’t have let you go <code class="d">Dm</code> <code class="f">F</code> <code class="g">G</code></p>
+</div></section>
+<section id="bridge-1" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>I must confess <code class="a">Am</code> that my loneliness <code
-class="e">E</code><br />
-Is killing me now <code class="c">C</code><br />
+<p>I must confess <code class="a">Am</code> that my loneliness <code class="e">E</code><br>
+Is killing me now <code class="c">C</code><br>
 don’t you <code class="d">Dm</code> know I <code class="e">E</code>
-still believe <code class="f">F</code><br />
-That you will be here <code class="g">G</code><br />
+still believe <code class="f">F</code><br>
+That you will be here <code class="g">G</code><br>
 Now give me a sign <code class="f">F</code></p>
-<p><code class="d">Dm</code> Hit me baby<br />
-<code class="g">G</code> one <code class="g">G#m</code> more <code
-class="a">Am</code> time <em>(use barre and move up)</em></p>
-</section>
-<section id="chorus-8" class="slide level2">
+<p><code class="d">Dm</code> Hit me baby<br>
+<code class="g">G</code> one <code class="g">G#m</code> more <code class="a">Am</code> time <em>(use barre and move up)</em></p>
+</div></section>
+<section id="chorus-8" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
-killing me (and I)<br />
+killing me (and I)<br>
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe<br />
+still believe<br>
 <code class="e">E</code> (still believe)</p>
-<p><code class="a">Am</code> When I’m not with you I lose <code
-class="e">E</code> my mind<br />
-<code class="g">G</code> Give me a sign <code class="c">C</code><br />
+<p><code class="a">Am</code> When I’m not with you I lose <code class="e">E</code> my mind<br>
+<code class="g">G</code> Give me a sign <code class="c">C</code><br>
 <code class="d">Dm</code> Hit me baby <code class="e">E</code> <del>one
 more time</del> <strong>I must confess…</strong></p>
-<p><em>(Repeat and add 2nd voice)</em> <strong>…that my loneliness<br />
-is killing me now, don’t you know I still believe<br />
+<p><em>(Repeat and add 2nd voice)</em> <strong>…that my loneliness<br>
+is killing me now, don’t you know I still believe<br>
 that you would be here and give me a sign</strong></p>
-<p><em>(Together)</em> Hit me baby one more time! <code
-class="a">Am</code></p>
-</section>
-<section id="resources-2" class="slide level2">
+<p><em>(Together)</em> Hit me baby one more time! <code class="a">Am</code></p>
+</div></section>
+<section id="resources-2" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=C-u5WLJ9Yk4">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/britney-spears/baby-one-more-time-chords-1512732">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/britney-spears/baby-one-more-time-chords-1512732">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=jn4ydR1m96E">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="bella-ciao-traditional" class="title-slide slide level1">
+<section id="bella-ciao-traditional" class="title-slide slide level1"><div class="slide-content">
 <h1>Bella ciao (Traditional)</h1>
 
-</section>
-<section id="verse-1-3" class="slide level2">
+</div></section>
+<section id="verse-1-3" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>Una mat<code class="a">Am</code>tina mi son svegliato</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>Una mat<code class="d">Dm</code>tina mi son sveg<code
-class="a">Am</code>liato<br />
-e ho tro<code class="e">E7</code>vato l’inva<code
-class="a">Am</code>sor</p>
-</section>
-<section id="verse-2-3" class="slide level2">
+<p>Una mat<code class="d">Dm</code>tina mi son sveg<code class="a">Am</code>liato<br>
+e ho tro<code class="e">E7</code>vato l’inva<code class="a">Am</code>sor</p>
+</div></section>
+<section id="verse-2-3" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>O parti<code class="a">Am</code>giano, portami via</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>O parti<code class="d">Dm</code>giano, portami Am via<br />
-ché mi <code class="e">E7</code> sento di mo<code
-class="a">Am</code>rir</p>
-</section>
-<section id="verse-3-1" class="slide level2">
+<p>O parti<code class="d">Dm</code>giano, portami Am via<br>
+ché mi <code class="e">E7</code> sento di mo<code class="a">Am</code>rir</p>
+</div></section>
+<section id="verse-3-1" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p>E se io <code class="a">Am</code> muoio da partigiano</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>E se io <code class="d">Dm</code> muoio da parti<code
-class="a">Am</code>giano<br />
-tu mi <code class="e">E7</code> devi seppel<code
-class="a">Am</code>lir</p>
-</section>
-<section id="verse-4" class="slide level2">
+<p>E se io <code class="d">Dm</code> muoio da parti<code class="a">Am</code>giano<br>
+tu mi <code class="e">E7</code> devi seppel<code class="a">Am</code>lir</p>
+</div></section>
+<section id="verse-4" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
 <p>E seppel<code class="a">Am</code>lire lassù in montagna</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>E seppel<code class="d">Dm</code>lire lassù in mon<code
-class="a">Am</code>tagna<br />
-Sotto <code class="e">E7</code> l’ombra di un bel <code
-class="a">Am</code> fior</p>
-</section>
-<section id="verse-5" class="slide level2">
+<p>E seppel<code class="d">Dm</code>lire lassù in mon<code class="a">Am</code>tagna<br>
+Sotto <code class="e">E7</code> l’ombra di un bel <code class="a">Am</code> fior</p>
+</div></section>
+<section id="verse-5" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p>Tutte le <code class="a">Am</code> genti che passeranno</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>Tutte le <code class="d">Dm</code> genti che passe<code
-class="a">Am</code>ranno<br />
+<p>Tutte le <code class="d">Dm</code> genti che passe<code class="a">Am</code>ranno<br>
 Ti di<code class="e">E7</code>ranno “Che bel <code class="a">Am</code>
 fior!”</p>
-</section>
-<section id="verse-6" class="slide level2">
+</div></section>
+<section id="verse-6" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
 <p>“È questo il <code class="a">Am</code> fiore del partigiano”</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>“È questo il <code class="d">Dm</code> fiore del parti<code
-class="a">Am</code>giano<br />
-morto <code class="e">E7</code> per la liber<code
-class="a">Am</code>tà!” <em>(Repeat and fade)</em></p>
-</section>
-<section id="resources-3" class="slide level2">
+<p>“È questo il <code class="d">Dm</code> fiore del parti<code class="a">Am</code>giano<br>
+morto <code class="e">E7</code> per la liber<code class="a">Am</code>tà!” <em>(Repeat and fade)</em></p>
+</div></section>
+<section id="resources-3" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=4CI3lhyNKfo">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/misc-traditional/bella-ciao-chords-1839756">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/misc-traditional/bella-ciao-chords-1839756">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=2iCOH6GOmRA">Guitar
 interpretation</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="dont-worry-be-happy-bobby-mcferrin"
-class="title-slide slide level1">
+<section id="dont-worry-be-happy-bobby-mcferrin" class="title-slide slide level1"><div class="slide-content">
 <h1>Don’t worry be happy (Bobby McFerrin)</h1>
 
-</section>
-<section id="intro-3" class="slide level2">
+</div></section>
+<section id="intro-3" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="verse-1-4" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-1-4" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="g">G</code> Here’s a little song I wrote<br />
-You <code class="a">Am</code> might want to sing it note for note<br />
+<p><code class="g">G</code> Here’s a little song I wrote<br>
+You <code class="a">Am</code> might want to sing it note for note<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-<p>In <code class="g">G</code> every life we have some trouble<br />
-<code class="a">Am</code> When you worry you make it double<br />
+<p>In <code class="g">G</code> every life we have some trouble<br>
+<code class="a">Am</code> When you worry you make it double<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-</section>
-<section id="chorus-9" class="slide level2">
+</div></section>
+<section id="chorus-9" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
-</section>
-<section id="verse-2-4" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
+</div></section>
+<section id="verse-2-4" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="g">G</code> Ain’t got no place to lay your head<br />
-<code class="a">Am</code> Somebody came and took your bed<br />
+<p><code class="g">G</code> Ain’t got no place to lay your head<br>
+<code class="a">Am</code> Somebody came and took your bed<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-<p>The <code class="g">G</code> landlord say your rent is late<br />
-<code class="a">Am</code> He may have to litigate<br />
+<p>The <code class="g">G</code> landlord say your rent is late<br>
+<code class="a">Am</code> He may have to litigate<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-</section>
-<section id="chorus-10" class="slide level2">
+</div></section>
+<section id="chorus-10" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
-</section>
-<section id="verse-3-2" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
+</div></section>
+<section id="verse-3-2" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="g">G</code> Ain’t got no cash, ain’t got no style<br />
-<code class="a">Am</code> Ain’t got no girl to make you smile<br />
-<strong>But</strong> don’t <code class="c">C</code> worry, be <code
-class="g">G</code> happy</p>
+<p><code class="g">G</code> Ain’t got no cash, ain’t got no style<br>
+<code class="a">Am</code> Ain’t got no girl to make you smile<br>
+<strong>But</strong> don’t <code class="c">C</code> worry, be <code class="g">G</code> happy</p>
 <p>Cause <code class="g">G</code> when you worry, your face will
-frown<br />
-<code class="a">Am</code> And that will bring everybody down<br />
-<strong>So</strong> don’t <code class="c">C</code> worry, be <code
-class="g">G</code> happy</p>
-</section>
-<section id="chorus-11" class="slide level2">
+frown<br>
+<code class="a">Am</code> And that will bring everybody down<br>
+<strong>So</strong> don’t <code class="c">C</code> worry, be <code class="g">G</code> happy</p>
+</div></section>
+<section id="chorus-11" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
-</section>
-<section id="verse-4-1" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
+</div></section>
+<section id="verse-4-1" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p><code class="g">G</code> There is this little song I wrote<br />
-<code class="a">Am</code> I hope you learn it note for note<br />
+<p><code class="g">G</code> There is this little song I wrote<br>
+<code class="a">Am</code> I hope you learn it note for note<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
 <p>(Listen to what I say!)</p>
-<p><code class="g">G</code> In your life expect some trouble<br />
-<code class="a">Am</code> But when you worry, you make it double<br />
+<p><code class="g">G</code> In your life expect some trouble<br>
+<code class="a">Am</code> But when you worry, you make it double<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-</section>
-<section id="chorus-12" class="slide level2">
+</div></section>
+<section id="chorus-12" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
-<section id="resources-4" class="slide level2">
+</div></section>
+<section id="resources-4" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=d-diB65scQU">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/bobby-mcferrin/dont-worry-be-happy-chords-484289">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/bobby-mcferrin/dont-worry-be-happy-chords-484289">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=vJfE-WNl_z8">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="dr-eskimo-mani-matter" class="title-slide slide level1">
+<section id="dr-eskimo-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dr Eskimo (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-5" class="slide level2">
+</div></section>
+<section id="verse-1-5" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="a">Am</code> Kenned ihr das Gschichtli scho<br />
+<p><code class="a">Am</code> Kenned ihr das Gschichtli scho<br>
 <code class="e">E</code> Vu dem arme <code class="a">Am</code>
-Eskimo<br />
-<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code
-class="e">Em</code> einisch <code class="a">Am</code> so<br />
+Eskimo<br>
+<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code class="e">Em</code> einisch <code class="a">Am</code> so<br>
 <code class="e">Em</code> Truurig <code class="a">Am</code> isch ums
 <code class="e">Em</code> Lebe <code class="a">Am</code> cho.</p>
-</section>
-<section id="verse-2-5" class="slide level2">
+</div></section>
+<section id="verse-2-5" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> Er hät dank em Radio<br />
+<p><code class="a">Am</code> Er hät dank em Radio<br>
 <code class="e">E</code> Freud ar Musig <code class="a">Am</code>
-übercho<br />
+übercho<br>
 <code class="e">Em</code> Und het <code class="a">Am</code> denkt das
-<code class="e">Em</code> chan i <code class="a">Am</code> o<br />
-<code class="e">Em</code> So isch <code class="a">Am</code> er is <code
-class="e">Em</code> unglück <code class="a">Am</code> cho.</p>
-</section>
-<section id="verse-3-3" class="slide level2">
+<code class="e">Em</code> chan i <code class="a">Am</code> o<br>
+<code class="e">Em</code> So isch <code class="a">Am</code> er is <code class="e">Em</code> unglück <code class="a">Am</code> cho.</p>
+</div></section>
+<section id="verse-3-3" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> Nämlich hät er sich für zwo<br />
+<p><code class="a">Am</code> Nämlich hät er sich für zwo<br>
 <code class="e">E</code> Fläsche Leber<code class="a">Am</code>tran es
-no<br />
-<code class="e">Em</code> Guet er<code class="a">Am</code>haltnigs <code
-class="e">Em</code> Cemba<code class="a">Am</code>lo<br />
+no<br>
+<code class="e">Em</code> Guet er<code class="a">Am</code>haltnigs <code class="e">Em</code> Cemba<code class="a">Am</code>lo<br>
 <code class="e">Em</code> Kouft und <code class="a">Am</code> hets i d
 <code class="e">Em</code> Höhli <code class="a">Am</code> gno.</p>
-</section>
-<section id="verse-4-2" class="slide level2">
+</div></section>
+<section id="verse-4-2" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p><code class="a">Am</code> Doch won er fortissimo<br />
+<p><code class="a">Am</code> Doch won er fortissimo<br>
 <code class="e">E</code> Gspilt het uf sim <code class="a">Am</code>
-Cembalo<br />
-<code class="e">Em</code> Isch en <code class="a">Am</code> Iisbär <code
-class="e">Em</code> ine <code class="e">Em</code> cho und<br />
+Cembalo<br>
+<code class="e">Em</code> Isch en <code class="a">Am</code> Iisbär <code class="e">Em</code> ine <code class="e">Em</code> cho und<br>
 <code class="a">Am</code> Hetne <code class="a">Am</code> zwüsche
 d’<code class="e">Em</code>Chralle <code class="a">Am</code> gno.</p>
-</section>
-<section id="verse-5-1" class="slide level2">
+</div></section>
+<section id="verse-5-1" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p><code class="a">Am</code> D’Kunst isch geng es Risiko<br />
+<p><code class="a">Am</code> D’Kunst isch geng es Risiko<br>
 <code class="e">E</code> So isch er ums <code class="a">Am</code> Lebe
-cho<br />
+cho<br>
 <code class="e">Em</code> Und ihr <code class="a">Am</code> gsänd
-d’Mo<code class="e">Em</code>ral der<code class="a">Am</code>vo<br />
-<code class="e">Em</code> Choufed <code class="a">Am</code> nie es <code
-class="e">Em</code> Cemba<code class="a">Am</code>lo<br />
+d’Mo<code class="e">Em</code>ral der<code class="a">Am</code>vo<br>
+<code class="e">Em</code> Choufed <code class="a">Am</code> nie es <code class="e">Em</code> Cemba<code class="a">Am</code>lo<br>
 <code class="e">Em</code> Süscht geits <code class="a">Am</code> euch
-grad <code class="e">Em</code> äbe<code class="a">Am</code>so<br />
-<code class="e">Em</code> Wie dem <code class="a">Am</code> arme <code
-class="e">Em</code> Eski<code class="a">Am</code>mo<br />
-<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code
-class="e">Em</code> einisch <code class="a">Am</code> so<br />
+grad <code class="e">Em</code> äbe<code class="a">Am</code>so<br>
+<code class="e">Em</code> Wie dem <code class="a">Am</code> arme <code class="e">Em</code> Eski<code class="a">Am</code>mo<br>
+<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code class="e">Em</code> einisch <code class="a">Am</code> so<br>
 <code class="e">Em</code> Truurig <code class="a">Am</code> isch ums
 <code class="e">Em</code> Lebe <code class="a">Am</code> cho.</p>
-</section>
-<section id="resources-5" class="slide level2">
+</div></section>
+<section id="resources-5" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/mani-matter/dr-eskimo-chords-2146513">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/mani-matter/dr-eskimo-chords-2146513">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="dr-sidi-abdel-assar-mani-matter"
-class="title-slide slide level1">
+<section id="dr-sidi-abdel-assar-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dr Sidi Abdel Assar (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-6" class="slide level2">
+</div></section>
+<section id="verse-1-6" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Dr <code class="a">Am</code> Sidi Abdel Assar vo El Hama<br />
-Het <code class="a">Am</code> mal am Morge früe no im Pijama<br />
-Ir <code class="d">Dm</code> Strass vor dr Moschee<br />
-Zwöi <code class="a">Am</code> schöni Ouge gseh<br />
-Das <code class="e">E</code> isch dr Afang worde vo sim <code
-class="a">Am</code> Drama</p>
-</section>
-<section id="verse-2-6" class="slide level2">
+<p>Dr <code class="a">Am</code> Sidi Abdel Assar vo El Hama<br>
+Het <code class="a">Am</code> mal am Morge früe no im Pijama<br>
+Ir <code class="d">Dm</code> Strass vor dr Moschee<br>
+Zwöi <code class="a">Am</code> schöni Ouge gseh<br>
+Das <code class="e">E</code> isch dr Afang worde vo sim <code class="a">Am</code> Drama</p>
+</div></section>
+<section id="verse-2-6" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>S isch <code class="a">Am</code> Tochter gsy vom Mohamed
-Mustafa<br />
-Dr <code class="a">Am</code> Abdel Assar het nümm choenne schlafa<br />
-Bis <code class="d">Dm</code> er bim Mohamed<br />
-Um <code class="a">Am</code> d’Hand aghalte hed<br />
-Und <code class="e">E</code> gseit: I biete hundertfüfzig <code
-class="a">Am</code> Schaf a</p>
-</section>
-<section id="verse-3-4" class="slide level2">
+Mustafa<br>
+Dr <code class="a">Am</code> Abdel Assar het nümm choenne schlafa<br>
+Bis <code class="d">Dm</code> er bim Mohamed<br>
+Um <code class="a">Am</code> d’Hand aghalte hed<br>
+Und <code class="e">E</code> gseit: I biete hundertfüfzig <code class="a">Am</code> Schaf a</p>
+</div></section>
+<section id="verse-3-4" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Dr <code class="a">Am</code> Mohamed het gantwortet: Bi Allah<br />
+<p>Dr <code class="a">Am</code> Mohamed het gantwortet: Bi Allah<br>
 Es <code class="a">Am</code> froeit mi, dass mi Tochter dir het
-gfalla<br />
-Doch <code class="d">Dm</code> wärt isch si, mi Seel<br />
-Zwöi<code class="a">Am</code>hundertzwänzg Kamel<br />
-Und <code class="e">E</code> drunder chan i dir sen uf ke <code
-class="a">Am</code> Fall la</p>
-</section>
-<section id="verse-4-3" class="slide level2">
+gfalla<br>
+Doch <code class="d">Dm</code> wärt isch si, mi Seel<br>
+Zwöi<code class="a">Am</code>hundertzwänzg Kamel<br>
+Und <code class="e">E</code> drunder chan i dir sen uf ke <code class="a">Am</code> Fall la</p>
+</div></section>
+<section id="verse-4-3" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>Da <code class="a">Am</code> het dr Abdel Assar gseit: O Sidi<br />
-Uf <code class="a">Am</code> sone türe Handel gang i nid y<br />
-Isch <code class="d">Dm</code> furt, het gly druf scho<br />
-E <code class="a">Am</code> billigeri gno<br />
-Wo <code class="e">E</code> nid so schoen isch gsy, defuer e <code
-class="a">Am</code> gschydi</p>
-</section>
-<section id="verse-5-2" class="slide level2">
+<p>Da <code class="a">Am</code> het dr Abdel Assar gseit: O Sidi<br>
+Uf <code class="a">Am</code> sone türe Handel gang i nid y<br>
+Isch <code class="d">Dm</code> furt, het gly druf scho<br>
+E <code class="a">Am</code> billigeri gno<br>
+Wo <code class="e">E</code> nid so schoen isch gsy, defuer e <code class="a">Am</code> gschydi</p>
+</div></section>
+<section id="verse-5-2" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p><em>(Langsam)</em></p>
 <p>Doch <code class="a">Am</code> wenn es Nacht wird ueber der
-Sahara<br />
+Sahara<br>
 Luegt <code class="a">Am</code> er dr Mond am Himmel hell und klar
-a<br />
-Und <code class="d">Dm</code> truret hie und da<br />
+a<br>
+Und <code class="d">Dm</code> truret hie und da<br>
 De <code class="a">Am</code> schoene Ouge na -</p>
 <p><em>(Schnell)</em></p>
-<p>Und <code class="e">E</code> daenkt: Haett i doch frueecher afa <code
-class="a">Am</code> spara!</p>
-</section>
-<section id="resources-6" class="slide level2">
+<p>Und <code class="e">E</code> daenkt: Haett i doch frueecher afa <code class="a">Am</code> spara!</p>
+</div></section>
+<section id="resources-6" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=O9tzZ3CE-rM">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/mani-matter/dr-sidi-abdel-assar-chords-1693629">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/mani-matter/dr-sidi-abdel-assar-chords-1693629">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="dr-wilhelm-täll-mani-matter"
-class="title-slide slide level1">
+<section id="dr-wilhelm-täll-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dr Wilhelm Täll (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-7" class="slide level2">
+</div></section>
+<section id="verse-1-7" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br />
-Im <code class="g">G7</code> Löie z’Nottis<code
-class="c">C</code>wil<br />
-Da <code class="c">C</code> bruchts viel Volk, gwüss z’halbe Dorf<br />
+<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br>
+Im <code class="g">G7</code> Löie z’Nottis<code class="c">C</code>wil<br>
+Da <code class="c">C</code> bruchts viel Volk, gwüss z’halbe Dorf<br>
 Hett <code class="g">G7</code> mitgmacht i däm <code class="c">C</code>
 Schpil</p>
 <p>Die <code class="e">E7</code> andri Hälfti <code class="a">Am</code>
-isch im Saal gsy<br />
+isch im Saal gsy<br>
 <code class="g">G7</code> Bim’ne grosse <code class="c">C</code>
-Bier<br />
+Bier<br>
 Als <code class="f">F</code> publikum, het <code class="c">C</code>
-zuegluegt<br />
-Und isch <code class="g">G7</code> gschpannt gsy, was pas<code
-class="c">C</code>sier</p>
-</section>
-<section id="verse-2-7" class="slide level2">
+zuegluegt<br>
+Und isch <code class="g">G7</code> gschpannt gsy, was pas<code class="c">C</code>sier</p>
+</div></section>
+<section id="verse-2-7" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Am <code class="c">C</code> Aafang isch es schön gsy<br />
-Do het <code class="g">G7</code> als Schtouffache<code
-class="c">C</code>rin<br />
-D’Frou <code class="c">C</code> Pfarrer mit dem Schnyder gret<br />
+<p>Am <code class="c">C</code> Aafang isch es schön gsy<br>
+Do het <code class="g">G7</code> als Schtouffache<code class="c">C</code>rin<br>
+D’Frou <code class="c">C</code> Pfarrer mit dem Schnyder gret<br>
 I <code class="g">G7</code> Wort vo tiefem <code class="c">C</code>
 Sinn</p>
-<p>Und <code class="e">E7</code> alls isch grüert gsy, <code
-class="a">Am</code> sy het dasmal<br />
-<code class="g">G7</code> Nid gseit, s’Chleid sig z’<code
-class="c">C</code>tüür<br />
-Und <code class="f">F</code> är het guet uf<code
-class="c">C</code>passt<br />
-Das är der <code class="g">G7</code> Fade nid ver<code
-class="c">C</code>lüür</p>
-</section>
-<section id="verse-3-5" class="slide level2">
+<p>Und <code class="e">E7</code> alls isch grüert gsy, <code class="a">Am</code> sy het dasmal<br>
+<code class="g">G7</code> Nid gseit, s’Chleid sig z’<code class="c">C</code>tüür<br>
+Und <code class="f">F</code> är het guet uf<code class="c">C</code>passt<br>
+Das är der <code class="g">G7</code> Fade nid ver<code class="c">C</code>lüür</p>
+</div></section>
+<section id="verse-3-5" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Uf <code class="c">C</code> z’Mal, churz vor em Öpfelschuss<br />
+<p>Uf <code class="c">C</code> z’Mal, churz vor em Öpfelschuss<br>
 Dr <code class="g">G7</code> Lehrer chunnt als <code class="c">C</code>
-Täll<br />
-Sy <code class="c">C</code> Sohn, dä fragt’ne dis und äis<br />
+Täll<br>
+Sy <code class="c">C</code> Sohn, dä fragt’ne dis und äis<br>
 Do <code class="g">G7</code> rüeft dert eine <code class="c">C</code>
 schnäll</p>
-<p>Wo <code class="e">E7</code> und’rem Huet als <code
-class="a">Am</code> Wach isch gschtande<br />
+<p>Wo <code class="e">E7</code> und’rem Huet als <code class="a">Am</code> Wach isch gschtande<br>
 <code class="g">G7</code> So dass’ jede <code class="c">C</code>
-ghört<br />
+ghört<br>
 Wi<code class="f">F</code>so fragt dä so <code class="c">C</code>
-dumm<br />
-Het dä ir <code class="g">G7</code> Schuel de nüt rächts <code
-class="c">C</code> glehrt</p>
-</section>
-<section id="verse-4-4" class="slide level2">
+dumm<br>
+Het dä ir <code class="g">G7</code> Schuel de nüt rächts <code class="c">C</code> glehrt</p>
+</div></section>
+<section id="verse-4-4" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>E <code class="c">C</code> Fründ vom Täll, e Maa us Altdorf<br />
+<p>E <code class="c">C</code> Fründ vom Täll, e Maa us Altdorf<br>
 <code class="g">G7</code> Zwickt em eis uf ds <code class="c">C</code>
-Muul<br />
-Und <code class="c">C</code> dise wo dr Huet bewacht<br />
+Muul<br>
+Und <code class="c">C</code> dise wo dr Huet bewacht<br>
 Git <code class="g">G7</code> ume, gar nid <code class="c">C</code>
 fuul</p>
-<p>Und <code class="e">E7</code> stosst ihm mit syr <code
-class="a">Am</code> Helebarde<br />
+<p>Und <code class="e">E7</code> stosst ihm mit syr <code class="a">Am</code> Helebarde<br>
 <code class="g">G7</code> Eine z’Mitzt i <code class="c">C</code>
-Buuch<br />
-Da <code class="f">F</code> chunnt scho s’Volk vo <code
-class="c">C</code> Uri z’springe<br />
+Buuch<br>
+Da <code class="f">F</code> chunnt scho s’Volk vo <code class="c">C</code> Uri z’springe<br>
 <code class="g">G7</code> Donner jetzt geits <code class="c">C</code>
 ruuch</p>
-</section>
-<section id="verse-5-3" class="slide level2">
+</div></section>
+<section id="verse-5-3" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p>Die <code class="c">C</code> einte, die vo Öschterrich<br />
-<code class="g">G7</code> Die näh für d’Wach Par<code
-class="c">C</code>tei<br />
-Die <code class="c">C</code> andre, die vo Altdorf<br />
-Füre <code class="g">G7</code> Täll - ei Schläge<code
-class="c">C</code>rei</p>
+<p>Die <code class="c">C</code> einte, die vo Öschterrich<br>
+<code class="g">G7</code> Die näh für d’Wach Par<code class="c">C</code>tei<br>
+Die <code class="c">C</code> andre, die vo Altdorf<br>
+Füre <code class="g">G7</code> Täll - ei Schläge<code class="c">C</code>rei</p>
 <p>Mit <code class="e">E7</code> Helebarde, <code class="a">Am</code>
-Kartonschwärt<br />
+Kartonschwärt<br>
 <code class="g">G7</code> Kulisse schlöh sy <code class="c">C</code>
-dry<br />
+dry<br>
 <code class="f">F</code> Der Täll liit und’rem <code class="c">C</code>
-Gessler scho<br />
-Da <code class="g">G7</code> mischt der Saal sech <code
-class="c">C</code> y</p>
-</section>
-<section id="verse-6-1" class="slide level2">
+Gessler scho<br>
+Da <code class="g">G7</code> mischt der Saal sech <code class="c">C</code> y</p>
+</div></section>
+<section id="verse-6-1" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
-<p>Jitz <code class="c">C</code> chöme Gläser z’flüge<br />
-Jede <code class="g">G7</code> stillt sy gheimi Wuet <code
-class="c">C</code><br />
-Es <code class="c">C</code> chrose Tisch, u bänk und’s Bier<br />
+<p>Jitz <code class="c">C</code> chöme Gläser z’flüge<br>
+Jede <code class="g">G7</code> stillt sy gheimi Wuet <code class="c">C</code><br>
+Es <code class="c">C</code> chrose Tisch, u bänk und’s Bier<br>
 Ver<code class="g">G7</code>mischt sech mit em <code class="c">C</code>
 Bluet</p>
-<p>Dr <code class="e">E7</code> Wirt rouft sech sys <code
-class="a">Am</code> Haar<br />
-D’Frou schinet <code class="g">G7</code> brochni glider y <code
-class="c">C</code><br />
-Zwo <code class="f">F</code> Stund lang het das duu<code
-class="c">C</code>ret<br />
-Do isch <code class="g">G7</code> Öschtrich gschlage <code
-class="c">C</code> gsy</p>
-</section>
-<section id="verse-7" class="slide level2">
+<p>Dr <code class="e">E7</code> Wirt rouft sech sys <code class="a">Am</code> Haar<br>
+D’Frou schinet <code class="g">G7</code> brochni glider y <code class="c">C</code><br>
+Zwo <code class="f">F</code> Stund lang het das duu<code class="c">C</code>ret<br>
+Do isch <code class="g">G7</code> Öschtrich gschlage <code class="c">C</code> gsy</p>
+</div></section>
+<section id="verse-7" class="slide level2"><div class="slide-content">
 <h2>Verse 7</h2>
-<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br />
-Im <code class="g">G7</code> Löie z’Nottis<code
-class="c">C</code>wil<br />
-Und <code class="c">C</code> gwüss no niene i<br />
+<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br>
+Im <code class="g">G7</code> Löie z’Nottis<code class="c">C</code>wil<br>
+Und <code class="c">C</code> gwüss no niene i<br>
 natura<code class="g">G7</code>listischerem <code class="c">C</code>
 Stil</p>
 <p>D’Ver<code class="e">E7</code>sicherig het <code class="a">Am</code>
-zahlt<br />
-Hingäge <code class="g">G7</code> eis weiss ig sit<code
-class="c">C</code>här:</p>
+zahlt<br>
+Hingäge <code class="g">G7</code> eis weiss ig sit<code class="c">C</code>här:</p>
 <p>Sy <code class="f">F</code> würde d’Freiheit <code class="c">C</code>
-gwinne<br />
-Wenn sy <code class="g">G7</code> dä Wäg z’gwinne <code
-class="c">C</code> wär <em>(x2)</em></p>
-</section>
-<section id="resources-7" class="slide level2">
+gwinne<br>
+Wenn sy <code class="g">G7</code> dä Wäg z’gwinne <code class="c">C</code> wär <em>(x2)</em></p>
+</div></section>
+<section id="resources-7" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=-Qtp0EC2P4M">Song</a></li>
 <li><a href="https://tabs.ultimate-guitar.com/tab/1911563">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="dynamit-mani-matter" class="title-slide slide level1">
+<section id="dynamit-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dynamit (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-8" class="slide level2">
+</div></section>
+<section id="verse-1-8" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="a">Am</code> Einisch ir Nacht won i spät no bi <code
-class="e">E7</code> gloffe<br />
-<code class="a">Am</code> D’Bundesterrasse z’düruf gäge <code
-class="g">G</code> hei<br />
-<code class="a">Am</code> Han i e bärtige Kärli a<code
-class="e">E7</code>troffe<br />
+<p><code class="a">Am</code> Einisch ir Nacht won i spät no bi <code class="e">E7</code> gloffe<br>
+<code class="a">Am</code> D’Bundesterrasse z’düruf gäge <code class="g">G</code> hei<br>
+<code class="a">Am</code> Han i e bärtige Kärli a<code class="e">E7</code>troffe<br>
 <code class="a">Am</code> Und gseh grad, dass dä sech dert, jemers nei
-<code class="g">G7</code><br />
-<code class="c">C</code> Dass dä sech dert zu nachtschlafener <code
-class="e">E</code> Zyt<br />
-<code class="a">Am</code> Am Bundeshus z’schaffe macht <code
-class="e">E7</code> mit Dyna<code class="a">Am</code>mit</p>
-</section>
-<section id="verse-2-8" class="slide level2">
+<code class="g">G7</code><br>
+<code class="c">C</code> Dass dä sech dert zu nachtschlafener <code class="e">E</code> Zyt<br>
+<code class="a">Am</code> Am Bundeshus z’schaffe macht <code class="e">E7</code> mit Dyna<code class="a">Am</code>mit</p>
+</div></section>
+<section id="verse-2-8" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> I bi erchlüpft und ha zuen ihm gseit: <code
-class="e">E7</code> Säget<br />
-<code class="a">Am</code> Exgüse, aber es gseht fasch so <code
-class="g">G</code> us<br />
-<code class="a">Am</code> Wi dass dir da jitze würklech er<code
-class="e">E7</code>wäget<br />
-<code class="a">Am</code> Das grad id Luft welle z’spränge das <code
-class="g">G7</code> Hus<br />
-<code class="c">C</code> Ja, seit dä Ma mir mit Füür, es mues <code
-class="e">E</code> sy<br />
-<code class="a">Am</code> Furt mit däm Ghütt, i bi <code
-class="e">E7</code> für d’Anar<code class="a">Am</code>chie</p>
-</section>
-<section id="verse-3-6" class="slide level2">
+<p><code class="a">Am</code> I bi erchlüpft und ha zuen ihm gseit: <code class="e">E7</code> Säget<br>
+<code class="a">Am</code> Exgüse, aber es gseht fasch so <code class="g">G</code> us<br>
+<code class="a">Am</code> Wi dass dir da jitze würklech er<code class="e">E7</code>wäget<br>
+<code class="a">Am</code> Das grad id Luft welle z’spränge das <code class="g">G7</code> Hus<br>
+<code class="c">C</code> Ja, seit dä Ma mir mit Füür, es mues <code class="e">E</code> sy<br>
+<code class="a">Am</code> Furt mit däm Ghütt, i bi <code class="e">E7</code> für d’Anar<code class="a">Am</code>chie</p>
+</div></section>
+<section id="verse-3-6" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> Was isch als Bürger mir da übrig<code
-class="e">E7</code>blybe<br />
-<code class="a">Am</code> Als ihm’s probiere uszrede, i <code
-class="g">G</code> ha<br />
-<code class="a">Am</code> Ihm afa d’Vorteile alli be<code
-class="e">E7</code>schrybe<br />
-<code class="a">Am</code> Vo üsem Staat, eso guet dass i <code
-class="g">G7</code> cha<br />
-<code class="c">C</code> Ds Rütli und d’Freiheit und d’Demokra<code
-class="e">E</code>tie<br />
+<p><code class="a">Am</code> Was isch als Bürger mir da übrig<code class="e">E7</code>blybe<br>
+<code class="a">Am</code> Als ihm’s probiere uszrede, i <code class="g">G</code> ha<br>
+<code class="a">Am</code> Ihm afa d’Vorteile alli be<code class="e">E7</code>schrybe<br>
+<code class="a">Am</code> Vo üsem Staat, eso guet dass i <code class="g">G7</code> cha<br>
+<code class="c">C</code> Ds Rütli und d’Freiheit und d’Demokra<code class="e">E</code>tie<br>
 <code class="a">Am</code> Han i beschworen, är <code class="e">E7</code>
 sölls doch la <code class="a">Am</code> sy</p>
-</section>
-<section id="verse-4-5" class="slide level2">
+</div></section>
+<section id="verse-4-5" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p><code class="a">Am</code> D’Angscht het mys Rednertalänt la ent<code
-class="e">E7</code>falte<br />
-<code class="a">Am</code> Chüel het dr Wind um üs gwäit i dr <code
-class="g">G</code> Nacht<br />
-<code class="a">Am</code> Während ig ihm en Ouguschtred ha <code
-class="e">E7</code> ghalte<br />
-<code class="a">Am</code> Dass es es Ross patriotisch hätt <code
-class="g">G7</code> gmacht<br />
-<code class="c">C</code> Z’letscht hei dä Ma mini Wort so be<code
-class="e">E</code>rückt<br />
+<p><code class="a">Am</code> D’Angscht het mys Rednertalänt la ent<code class="e">E7</code>falte<br>
+<code class="a">Am</code> Chüel het dr Wind um üs gwäit i dr <code class="g">G</code> Nacht<br>
+<code class="a">Am</code> Während ig ihm en Ouguschtred ha <code class="e">E7</code> ghalte<br>
+<code class="a">Am</code> Dass es es Ross patriotisch hätt <code class="g">G7</code> gmacht<br>
+<code class="c">C</code> Z’letscht hei dä Ma mini Wort so be<code class="e">E</code>rückt<br>
 <code class="a">Am</code> Dass är e Träne im <code class="e">E7</code>
 Oug het ver<code class="a">Am</code>drückt</p>
-</section>
-<section id="verse-5-4" class="slide level2">
+</div></section>
+<section id="verse-5-4" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p><code class="a">Am</code> So han i schliesslech dr Staat chönne <code
-class="e">E7</code> rette<br />
-<code class="a">Am</code> Är isch mit sym Dynamit wieder <code
-class="g">G</code> hei<br />
-<code class="a">Am</code> Und i ha mir a däm Abe im <code
-class="e">E7</code> Bett en<br />
-<code class="a">Am</code> Orde zuegsproche für my ganz al<code
-class="g">G7</code>lei<br />
+<p><code class="a">Am</code> So han i schliesslech dr Staat chönne <code class="e">E7</code> rette<br>
+<code class="a">Am</code> Är isch mit sym Dynamit wieder <code class="g">G</code> hei<br>
+<code class="a">Am</code> Und i ha mir a däm Abe im <code class="e">E7</code> Bett en<br>
+<code class="a">Am</code> Orde zuegsproche für my ganz al<code class="g">G7</code>lei<br>
 <code class="c">C</code> Glunge isch nume, dass
-zmonderischt<sup>_*_</sup> <code class="e">E</code> scho<br />
+zmonderischt<sup>_*_</sup> <code class="e">E</code> scho<br>
 <code class="a">Am</code> Über mi Red mir du <code class="e">E7</code>
 Zwyfel si <code class="a">Am</code> cho</p>
 <p><em><sup>*</sup> Zmonderischt: Ein Tag, welcher nach einem
-schon<br />
-vergangenen Tag gekommen ist. (<a
-href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)</em></p>
-</section>
-<section id="verse-6-2" class="slide level2">
+schon<br>
+vergangenen Tag gekommen ist. (<a href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)</em></p>
+</div></section>
+<section id="verse-6-2" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
-<p><code class="a">Am</code> Han ig ihm d’Schwyz o mit Rächt eso <code
-class="e">E7</code> prise?<br />
-<code class="a">Am</code> Fragen i mi no bis hüt hinde<code
-class="g">G</code>dry<br />
-<code class="a">Am</code> Und no uf eis het dä Ma mi hi<code
-class="e">E7</code>gwise<br />
-<code class="a">Am</code> Louf i am Bundeshus sider ver<code
-class="g">G7</code>by<br />
-<code class="c">C</code> Mues i gäng dänke, s’steit numen uf <code
-class="e">E</code> Zyt<br />
-<code class="a">Am</code> S’länge fürs z’Spränge paar <code
-class="e">E7</code> Seck Dyna<code class="a">Am</code>mit!</p>
+<p><code class="a">Am</code> Han ig ihm d’Schwyz o mit Rächt eso <code class="e">E7</code> prise?<br>
+<code class="a">Am</code> Fragen i mi no bis hüt hinde<code class="g">G</code>dry<br>
+<code class="a">Am</code> Und no uf eis het dä Ma mi hi<code class="e">E7</code>gwise<br>
+<code class="a">Am</code> Louf i am Bundeshus sider ver<code class="g">G7</code>by<br>
+<code class="c">C</code> Mues i gäng dänke, s’steit numen uf <code class="e">E</code> Zyt<br>
+<code class="a">Am</code> S’länge fürs z’Spränge paar <code class="e">E7</code> Seck Dyna<code class="a">Am</code>mit!</p>
 <p><code class="e">E7</code> <code class="a">Am</code></p>
-</section>
-<section id="resources-8" class="slide level2">
+</div></section>
+<section id="resources-8" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=qaeVSV0fRDo">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/mani-matter/dynamit-chords-2553321">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/mani-matter/dynamit-chords-2553321">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="father-and-son-cat-stevens"
-class="title-slide slide level1">
+<section id="father-and-son-cat-stevens" class="title-slide slide level1"><div class="slide-content">
 <h1>Father and son (Cat Stevens)</h1>
 
-</section>
-<section id="instructions-1" class="slide level2">
+</div></section>
+<section id="instructions-1" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>     |E A D G B e|
      |-----------|
@@ -1574,745 +1424,610 @@ G |0--0-0-0-0--5--5-|
 D |0--0-0-0-0-------|
 A |x--x-x-x-x-------| Mute with finger on E string
 E |3--3-3-3-3-------|</code></pre>
-</section>
-<section id="intro-4" class="slide level2">
+</div></section>
+<section id="intro-4" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Riff x4)</em></p>
-</section>
-<section id="verse-1---father" class="slide level2">
+</div></section>
+<section id="verse-1---father" class="slide level2"><div class="slide-content">
 <h2>Verse 1 - Father</h2>
-<p>It’s not <code class="g">G</code> time to make a change <code
-class="d">D/F#</code><br />
-just relax <code class="c">C</code> and take it ea<code
-class="a">Am7</code>sy<br />
-You’re still <code class="g">G</code> young, that’s your fault <code
-class="e">Em</code><br />
-there’s so <code class="a">Am</code> much you have to know <code
-class="d">D</code></p>
-<p>Find a <code class="g">G</code> girl, settle down <code
-class="d">D/F#</code><br />
-if you want <code class="c">C</code>, you can mar<code
-class="a">Am7</code>ry<br />
-Look at me <code class="g">G</code>, I am old <code
-class="e">Em</code><br />
+<p>It’s not <code class="g">G</code> time to make a change <code class="d">D/F#</code><br>
+just relax <code class="c">C</code> and take it ea<code class="a">Am7</code>sy<br>
+You’re still <code class="g">G</code> young, that’s your fault <code class="e">Em</code><br>
+there’s so <code class="a">Am</code> much you have to know <code class="d">D</code></p>
+<p>Find a <code class="g">G</code> girl, settle down <code class="d">D/F#</code><br>
+if you want <code class="c">C</code>, you can mar<code class="a">Am7</code>ry<br>
+Look at me <code class="g">G</code>, I am old <code class="e">Em</code><br>
 but I’m <code class="a">Am</code> happy <code class="d">D</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I was <code class="g">G</code> once like you are now <code
-class="d">D</code><br />
-and I know <code class="c">C</code> that it’s not ea<code
-class="a">Am7</code>sy<br />
-To be <code class="g">G</code> calm when you’ve found <code
-class="e">Em</code><br />
-something <code class="a">Am</code> going on <code
-class="d">D</code></p>
-<p>But take your time <code class="g">G</code>, think a lot <code
-class="d">D</code><br />
-why think of ev<code class="c">C</code>erything you’ve got <code
-class="a">Am7</code><br />
-For you will <code class="g">G</code> still be here tomorrow <code
-class="e">Em</code><br />
+<p>I was <code class="g">G</code> once like you are now <code class="d">D</code><br>
+and I know <code class="c">C</code> that it’s not ea<code class="a">Am7</code>sy<br>
+To be <code class="g">G</code> calm when you’ve found <code class="e">Em</code><br>
+something <code class="a">Am</code> going on <code class="d">D</code></p>
+<p>But take your time <code class="g">G</code>, think a lot <code class="d">D</code><br>
+why think of ev<code class="c">C</code>erything you’ve got <code class="a">Am7</code><br>
+For you will <code class="g">G</code> still be here tomorrow <code class="e">Em</code><br>
 but your <code class="a">Am</code> dreams <code class="d">D</code> may
 <code class="g">G</code> not</p>
 <p><em>(Riff x2)</em></p>
-</section>
-<section id="verse-2---son" class="slide level2">
+</div></section>
+<section id="verse-2---son" class="slide level2"><div class="slide-content">
 <h2>Verse 2 - Son</h2>
-<p>How can I <code class="g">G</code> try to explain? <code
-class="b">Bm</code><br />
-’cause when I <code class="c">C</code> do he turns a<code
-class="a">Am7</code>way again<br />
-It’s al<code class="g">G</code>ways been the same <code
-class="e">Em</code><br />
+<p>How can I <code class="g">G</code> try to explain? <code class="b">Bm</code><br>
+’cause when I <code class="c">C</code> do he turns a<code class="a">Am7</code>way again<br>
+It’s al<code class="g">G</code>ways been the same <code class="e">Em</code><br>
 same old <code class="a">Am</code> story <code class="d">D</code></p>
-<p>From the mo<code class="g">G</code>ment I could talk <code
-class="b">Bm</code><br />
-I was or<code class="c">C</code>dered to lis<code
-class="a">Am7</code>ten<br />
-Now there’s a way <code class="g">G</code>, and I know <code
-class="e">Em</code> that I <code class="d">D</code> have to go away
-<code class="g">G</code><br />
-I <code class="d">D</code> know I <code class="c">C</code> have to <code
-class="g">G</code> go</p>
+<p>From the mo<code class="g">G</code>ment I could talk <code class="b">Bm</code><br>
+I was or<code class="c">C</code>dered to lis<code class="a">Am7</code>ten<br>
+Now there’s a way <code class="g">G</code>, and I know <code class="e">Em</code> that I <code class="d">D</code> have to go away
+<code class="g">G</code><br>
+I <code class="d">D</code> know I <code class="c">C</code> have to <code class="g">G</code> go</p>
 <p><em>(Riff x2)</em></p>
-</section>
-<section id="interlude-1" class="slide level2">
+</div></section>
+<section id="interlude-1" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="g">G</code> <code class="d">D</code> <code
-class="c">C</code> <code class="a">Am7</code><br />
-<code class="g">G</code> <code class="e">Em</code> <code
-class="a">Am</code> <code class="c">C</code> <code
-class="d">D</code><br />
-<code class="g">G</code> <code class="d">D</code> <code
-class="c">C</code> <code class="a">Am7</code><br />
-<code class="g">G</code> <code class="e">Em</code> <code
-class="d">D</code> <code class="g">G</code><br />
-<code class="d">D</code> <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-3---father" class="slide level2">
+<p><code class="g">G</code> <code class="d">D</code> <code class="c">C</code> <code class="a">Am7</code><br>
+<code class="g">G</code> <code class="e">Em</code> <code class="a">Am</code> <code class="c">C</code> <code class="d">D</code><br>
+<code class="g">G</code> <code class="d">D</code> <code class="c">C</code> <code class="a">Am7</code><br>
+<code class="g">G</code> <code class="e">Em</code> <code class="d">D</code> <code class="g">G</code><br>
+<code class="d">D</code> <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-3---father" class="slide level2"><div class="slide-content">
 <h2>Verse 3 - Father</h2>
-<p>It’s not <code class="g">G</code> time to make a change <code
-class="d">D/F#</code><br />
+<p>It’s not <code class="g">G</code> time to make a change <code class="d">D/F#</code><br>
 just <del>relax</del> <strong>sit down</strong> <code class="c">C</code>
-and take it <del>easy</del> <strong>slow<code
-class="a">Am7</code>ly</strong><br />
-You’re still <code class="g">G</code> young, that’s your fault <code
-class="e">Em</code><br />
+and take it <del>easy</del> <strong>slow<code class="a">Am7</code>ly</strong><br>
+You’re still <code class="g">G</code> young, that’s your fault <code class="e">Em</code><br>
 there’s so <code class="a">Am</code> much you have to <del>know</del>
 <strong>go through</strong> <code class="d">D</code></p>
-<p>Find a <code class="g">G</code> girl, settle down <code
-class="d">D/F#</code><br />
-if you want <code class="c">C</code>, you can mar<code
-class="a">Am7</code>ry<br />
-Look at me <code class="g">G</code>, I am old <code
-class="e">Em</code><br />
+<p>Find a <code class="g">G</code> girl, settle down <code class="d">D/F#</code><br>
+if you want <code class="c">C</code>, you can mar<code class="a">Am7</code>ry<br>
+Look at me <code class="g">G</code>, I am old <code class="e">Em</code><br>
 but I’m <code class="a">Am</code> happy <code class="d">D</code></p>
-</section>
-<section id="verse-4---son" class="slide level2">
+</div></section>
+<section id="verse-4---son" class="slide level2"><div class="slide-content">
 <h2>Verse 4 - Son</h2>
-<p>All the times <code class="g">G</code> that I’ve cried <code
-class="b">Bm</code><br />
-keeping all <code class="c">C</code> the things I knew <code
-class="a">Am7</code> inside<br />
-It’s hard <code class="g">G</code><br />
-but it’s har<code class="e">Em</code>der to ig<code
-class="a">Am</code>nore it <code class="d">D</code></p>
-<p>If they were right <code class="g">G</code>, I’d agree <code
-class="b">Bm</code> <em>(I love this one!)</em><br />
-but it’s them <code class="c">C</code> they know, not me <code
-class="a">Am7</code><br />
-Now there’s a way <code class="g">G</code>, and I know <code
-class="e">Em</code><br />
-that I <code class="d">D</code> have to go away <code
-class="g">G</code></p>
+<p>All the times <code class="g">G</code> that I’ve cried <code class="b">Bm</code><br>
+keeping all <code class="c">C</code> the things I knew <code class="a">Am7</code> inside<br>
+It’s hard <code class="g">G</code><br>
+but it’s har<code class="e">Em</code>der to ig<code class="a">Am</code>nore it <code class="d">D</code></p>
+<p>If they were right <code class="g">G</code>, I’d agree <code class="b">Bm</code> <em>(I love this one!)</em><br>
+but it’s them <code class="c">C</code> they know, not me <code class="a">Am7</code><br>
+Now there’s a way <code class="g">G</code>, and I know <code class="e">Em</code><br>
+that I <code class="d">D</code> have to go away <code class="g">G</code></p>
 <p>I <code class="d">D</code> know I <code class="c">C</code> have to
 <code class="g">G</code> go</p>
-</section>
-<section id="resources-9" class="slide level2">
+</div></section>
+<section id="resources-9" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=P6zaCV4niKk">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/cat-stevens/father-and-son-chords-84491">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/cat-stevens/father-and-son-chords-84491">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=fP7VC-2J_Ok">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="feel-robbie-williams" class="title-slide slide level1">
+<section id="feel-robbie-williams" class="title-slide slide level1"><div class="slide-content">
 <h1>Feel (Robbie Williams)</h1>
 
-</section>
-<section id="intro-5" class="slide level2">
+</div></section>
+<section id="intro-5" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code> <em>(2x)</em></p>
-</section>
-<section id="verse-1-9" class="slide level2">
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code> <em>(2x)</em></p>
+</div></section>
+<section id="verse-1-9" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Come on and hold my <code class="d">Dm</code> hand<br />
-<code class="a">Am</code> I wanna contact the living <code
-class="a">A</code> <code class="a">A7</code><br />
-Not sure I under<code class="g">Gm</code>stand<br />
-<code class="d">Dm</code> This role I’ve been gi<code
-class="a">A</code>ven <code class="a">A7</code></p>
-</section>
-<section class="slide level2">
+<p>Come on and hold my <code class="d">Dm</code> hand<br>
+<code class="a">Am</code> I wanna contact the living <code class="a">A</code> <code class="a">A7</code><br>
+Not sure I under<code class="g">Gm</code>stand<br>
+<code class="d">Dm</code> This role I’ve been gi<code class="a">A</code>ven <code class="a">A7</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I sit and talk to <code class="d">Dm</code> God<br />
-<code class="a">Am</code> and he just laughs at my <code
-class="a">A</code> plans <code class="a">A7</code><br />
-My head speaks a <code class="g">Gm</code> language<br />
+<p>I sit and talk to <code class="d">Dm</code> God<br>
+<code class="a">Am</code> and he just laughs at my <code class="a">A</code> plans <code class="a">A7</code><br>
+My head speaks a <code class="g">Gm</code> language<br>
 <code class="d">Dm</code> I don’t understand <code class="a">A</code>
 <code class="a">A7</code></p>
-</section>
-<section id="chorus-1-1" class="slide level2">
+</div></section>
+<section id="chorus-1-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p>I just wanna <code class="b">Bb</code> feel real lo<code
-class="f">F</code>ve<br />
-Fill the home that I li<code class="c">C</code>ve in<br />
-Cause I got too much li<code class="b">Bb</code>fe<br />
-Running through my ve<code class="f">F</code>igns<br />
+<p>I just wanna <code class="b">Bb</code> feel real lo<code class="f">F</code>ve<br>
+Fill the home that I li<code class="c">C</code>ve in<br>
+Cause I got too much li<code class="b">Bb</code>fe<br>
+Running through my ve<code class="f">F</code>igns<br>
 Going to waste <code class="c">C</code></p>
-</section>
-<section id="verse-2-9" class="slide level2">
+</div></section>
+<section id="verse-2-9" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>I dont wanna <code class="d">Dm</code> die<br />
-<code class="a">Am</code> But I ain’t keen on living ei<code
-class="a">A</code>ther <code class="a">A7</code><br />
-Before I fall in <code class="g">Gm</code> love<br />
+<p>I dont wanna <code class="d">Dm</code> die<br>
+<code class="a">Am</code> But I ain’t keen on living ei<code class="a">A</code>ther <code class="a">A7</code><br>
+Before I fall in <code class="g">Gm</code> love<br>
 <code class="d">Dm</code> I’m preparing to le<code class="a">A</code>ave
 her <code class="a">A7</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I scare myself to de<code class="d">Dm</code>ath<br />
-<code class="a">Am</code> That’s why I keep on run<code
-class="a">A</code>ning <code class="a">A7</code><br />
-Before I’ve ar<code class="g">Gm</code>rived<br />
-<code class="d">Dm</code> I can see myself co<code
-class="a">A</code>ming <code class="a">A7</code></p>
-</section>
-<section id="chorus-2-1" class="slide level2">
+<p>I scare myself to de<code class="d">Dm</code>ath<br>
+<code class="a">Am</code> That’s why I keep on run<code class="a">A</code>ning <code class="a">A7</code><br>
+Before I’ve ar<code class="g">Gm</code>rived<br>
+<code class="d">Dm</code> I can see myself co<code class="a">A</code>ming <code class="a">A7</code></p>
+</div></section>
+<section id="chorus-2-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p>I just wanna <code class="b">Bb</code> feel real lo<code
-class="f">F</code>ve<br />
-Fill the home that I li<code class="c">C</code>ve in<br />
-Cause I got too much li<code class="b">Bb</code>fe<br />
-Running through my ve<code class="f">F</code>igns<br />
+<p>I just wanna <code class="b">Bb</code> feel real lo<code class="f">F</code>ve<br>
+Fill the home that I li<code class="c">C</code>ve in<br>
+Cause I got too much li<code class="b">Bb</code>fe<br>
+Running through my ve<code class="f">F</code>igns<br>
 Going to waste <code class="c">C</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I just wanna feel <code class="b">Bb</code> real lo<code
-class="f">F</code>ve<br />
-And the life ever af<code class="c">C</code>ter<br />
+<p>I just wanna feel <code class="b">Bb</code> real lo<code class="f">F</code>ve<br>
+And the life ever af<code class="c">C</code>ter<br>
 I cannot get enough</p>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code> <em>(3x)</em></p>
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code> <em>(3x)</em></p>
 <p><code class="d">Dm</code> <code class="a">Am</code>
 <em>(Pause)</em></p>
-</section>
-<section id="chorus-2-2" class="slide level2">
+</div></section>
+<section id="chorus-2-2" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p>I just wanna <code class="b">Bb</code> feel real lo<code
-class="f">F</code>ve<br />
-Fill the home that I li<code class="c">C</code>ve in<br />
-Cause I got too much li<code class="b">Bb</code>fe<br />
-Running through my ve<code class="f">F</code>igns<br />
+<p>I just wanna <code class="b">Bb</code> feel real lo<code class="f">F</code>ve<br>
+Fill the home that I li<code class="c">C</code>ve in<br>
+Cause I got too much li<code class="b">Bb</code>fe<br>
+Running through my ve<code class="f">F</code>igns<br>
 Going to <code class="c">C</code> waste</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I just wanna feel <code class="b">Bb</code> real lo<code
-class="f">F</code>ve<br />
-And the life ever af<code class="c">C</code>ter<br />
-There’s a hole in my soul <code class="b">Bb</code><br />
-you can see it in my face <code class="f">F</code><br />
+<p>I just wanna feel <code class="b">Bb</code> real lo<code class="f">F</code>ve<br>
+And the life ever af<code class="c">C</code>ter<br>
+There’s a hole in my soul <code class="b">Bb</code><br>
+you can see it in my face <code class="f">F</code><br>
 it’s a real big place <code class="c">C</code></p>
-</section>
-<section id="bridge-2" class="slide level2">
+</div></section>
+<section id="bridge-2" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><code class="d">Dm</code> <code class="a">Am</code> <em>(2x)</em></p>
-<p>Come on and hold my <code class="d">Dm</code> hand<br />
-<code class="a">Am</code> I wanna contact the li<code
-class="d">Dm</code>ving<br />
-<code class="a">Am</code> Not sure I under<code
-class="d">Dm</code>stand<br />
-<code class="a">Am</code> This role I’ve been gi<code
-class="d">Dm</code>ven</p>
-<p><code class="a">Am</code> Not sure I under<code
-class="d">Dm</code>stand <em>(4x)</em></p>
-</section>
-<section id="resources-10" class="slide level2">
+<p>Come on and hold my <code class="d">Dm</code> hand<br>
+<code class="a">Am</code> I wanna contact the li<code class="d">Dm</code>ving<br>
+<code class="a">Am</code> Not sure I under<code class="d">Dm</code>stand<br>
+<code class="a">Am</code> This role I’ve been gi<code class="d">Dm</code>ven</p>
+<p><code class="a">Am</code> Not sure I under<code class="d">Dm</code>stand <em>(4x)</em></p>
+</div></section>
+<section id="resources-10" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=iy4mXZN1Zzk">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/robbie-williams/feel-chords-133140">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/robbie-williams/feel-chords-133140">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=LVGNZyeff7">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="further-on-up-the-road-johnny-cash"
-class="title-slide slide level1">
+<section id="further-on-up-the-road-johnny-cash" class="title-slide slide level1"><div class="slide-content">
 <h1>Further on up the road (Johnny Cash)</h1>
 
-</section>
-<section id="intro-6" class="slide level2">
+</div></section>
+<section id="intro-6" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="c">C</code> <code
-class="a">Am</code> <code class="e">E7</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-1-10" class="slide level2">
+<p><code class="a">Am</code> <code class="c">C</code> <code class="a">Am</code> <code class="e">E7</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-1-10" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Where the road is <code class="a">Am</code> dark<br />
-And the seed is <code class="c">C</code> sowed<br />
-Where the gun is <code class="a">Am</code> cocked<br />
+<p>Where the road is <code class="a">Am</code> dark<br>
+And the seed is <code class="c">C</code> sowed<br>
+Where the gun is <code class="a">Am</code> cocked<br>
 As the bullet’s <code class="c">C</code> cold</p>
-<p>Where the miles are <code class="a">Am</code> marked<br />
+<p>Where the miles are <code class="a">Am</code> marked<br>
 <code class="g">G</code> In the blood and the <code class="a">Am</code>
-gold<br />
+gold<br>
 <code class="g">G</code> I’ll <code class="f">F</code> meet you further
 <code class="g">G</code> on up the road <code class="a">Am</code></p>
-</section>
-<section id="verse-2-10" class="slide level2">
+</div></section>
+<section id="verse-2-10" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Got on my dead man <code class="a">Am</code> suit<br />
-And my smilin’ skull <code class="c">C</code> ring<br />
-My lucky graveyard <code class="a">Am</code> boots<br />
+<p>Got on my dead man <code class="a">Am</code> suit<br>
+And my smilin’ skull <code class="c">C</code> ring<br>
+My lucky graveyard <code class="a">Am</code> boots<br>
 And a song to <code class="c">C</code> sing</p>
-<p>I got a song to <code class="a">Am</code> sing<br />
-<code class="g">G</code> That keeps me out of the <code
-class="a">Am</code> cold<br />
+<p>I got a song to <code class="a">Am</code> sing<br>
+<code class="g">G</code> That keeps me out of the <code class="a">Am</code> cold<br>
 <code class="g">G</code> And I’ll <code class="f">F</code> meet
-you<br />
+you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road</p>
-</section>
-<section id="chorus-1-2" class="slide level2">
+</div></section>
+<section id="chorus-1-2" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p>Further on up the <code class="c">C</code> road<br />
-Further on up the <code class="a">Am</code> road<br />
-Where the way is <code class="c">C</code> dark<br />
+<p>Further on up the <code class="c">C</code> road<br>
+Further on up the <code class="a">Am</code> road<br>
+Where the way is <code class="c">C</code> dark<br>
 And the night is <code class="e">E7</code> cold</p>
-<p>One sunny <code class="a">Am</code> mornin’<br />
+<p>One sunny <code class="a">Am</code> mornin’<br>
 <code class="g">G</code> We’ll rise I <code class="a">Am</code>
-know<br />
+know<br>
 <code class="g">G</code> And I’ll <code class="f">F</code> meet
-you<br />
+you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road</p>
-</section>
-<section id="instrumental" class="slide level2">
+</div></section>
+<section id="instrumental" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="a">Am</code> <code class="c">C</code> <code
-class="a">Am</code> <code class="e">E7</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-3-7" class="slide level2">
+<p><code class="a">Am</code> <code class="c">C</code> <code class="a">Am</code> <code class="e">E7</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-3-7" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Now I’ve been out in the <code class="a">Am</code> desert<br />
-Just don’t my <code class="c">C</code> time<br />
-Searchin’ through the <code class="a">Am</code> dust<br />
+<p>Now I’ve been out in the <code class="a">Am</code> desert<br>
+Just don’t my <code class="c">C</code> time<br>
+Searchin’ through the <code class="a">Am</code> dust<br>
 Lookin’ for a <code class="c">C</code> sign</p>
-<p>If there’s a light up a<code class="g">G</code>head<br />
-Well, brother I don’t <code class="a">Am</code> know<br />
-<code class="g">G</code> But I’ve <code class="f">F</code> got<br />
-this fever <code class="g">G</code> burnin’ in my soul <code
-class="a">Am</code></p>
-</section>
-<section id="chours-2" class="slide level2">
+<p>If there’s a light up a<code class="g">G</code>head<br>
+Well, brother I don’t <code class="a">Am</code> know<br>
+<code class="g">G</code> But I’ve <code class="f">F</code> got<br>
+this fever <code class="g">G</code> burnin’ in my soul <code class="a">Am</code></p>
+</div></section>
+<section id="chours-2" class="slide level2"><div class="slide-content">
 <h2>Chours 2</h2>
-<p>Further on up the <code class="c">C</code> road<br />
-Further on up the <code class="a">Am</code> road<br />
-Further on up the <code class="c">C</code> road<br />
+<p>Further on up the <code class="c">C</code> road<br>
+Further on up the <code class="a">Am</code> road<br>
+Further on up the <code class="c">C</code> road<br>
 Further on up the <code class="e">E7</code> road</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>One sunny <code class="a">Am</code> mornin’ <code
-class="g">G</code><br />
+<p>One sunny <code class="a">Am</code> mornin’ <code class="g">G</code><br>
 We’ll rise I <code class="a">Am</code> know <code class="g">G</code></p>
-<p>And I’ll <code class="f">F</code> meet you<br />
+<p>And I’ll <code class="f">F</code> meet you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road <code class="g">G</code> <em>(2x)</em></p>
-<p>And I’ll <code class="f">F</code> meet you<br />
+<p>And I’ll <code class="f">F</code> meet you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road</p>
-</section>
-<section id="resources-11" class="slide level2">
+</div></section>
+<section id="resources-11" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=HMCQgWtST5c">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/johnny-cash/further-on-up-the-road-chords-520573">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/johnny-cash/further-on-up-the-road-chords-520573">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="griechischer-wein-udo-jürgens"
-class="title-slide slide level1">
+<section id="griechischer-wein-udo-jürgens" class="title-slide slide level1"><div class="slide-content">
 <h1>Griechischer Wein (Udo Jürgens)</h1>
 
-</section>
-<section id="intro-7" class="slide level2">
+</div></section>
+<section id="intro-7" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code><br />
-<code class="c">C</code> <code class="e">E</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-1-11" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dm</code> <code class="f">F</code> <code class="g">G</code><br>
+<code class="c">C</code> <code class="e">E</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-1-11" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Es war schon <code class="a">Am</code> dunkel, als ich durch<br />
-Vorstadtstrassen <code class="f">F</code> heim<code
-class="g">G</code>wärts <code class="c">C</code> ging<br />
-Da war ein Wirtshaus, aus dem das<br />
-Licht noch auf den Geh<code class="f">F</code>steig <code
-class="g">G</code> schien</p>
-<p>Ich hatte <code class="a">Am</code> Zeit und mir war <code
-class="e">E</code> kalt<br />
+<p>Es war schon <code class="a">Am</code> dunkel, als ich durch<br>
+Vorstadtstrassen <code class="f">F</code> heim<code class="g">G</code>wärts <code class="c">C</code> ging<br>
+Da war ein Wirtshaus, aus dem das<br>
+Licht noch auf den Geh<code class="f">F</code>steig <code class="g">G</code> schien</p>
+<p>Ich hatte <code class="a">Am</code> Zeit und mir war <code class="e">E</code> kalt<br>
 drum trat ich <code class="a">Am</code> ein</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Da sassen <code class="a">Am</code> Männer mit braunen Augen<br />
-und mit <code class="f">F</code> schwar<code class="g">G</code>zem <code
-class="c">C</code> Haar<br />
-Und aus der Jukebox erklang Musik<br />
+<p>Da sassen <code class="a">Am</code> Männer mit braunen Augen<br>
+und mit <code class="f">F</code> schwar<code class="g">G</code>zem <code class="c">C</code> Haar<br>
+Und aus der Jukebox erklang Musik<br>
 die fremd und süd<code class="f">F</code>lich <code class="g">G</code>
 war</p>
-<p>Als man mich sah <code class="a">Am</code>, stand einer auf <code
-class="e">E</code><br />
+<p>Als man mich sah <code class="a">Am</code>, stand einer auf <code class="e">E</code><br>
 und lud mich ein <code class="a">Am</code></p>
-</section>
-<section id="chorus-1-3" class="slide level2">
+</div></section>
+<section id="chorus-1-3" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
 <p><code class="f">F</code> Griechischer Wein ist so wie das Blut der
-Erde<br />
-<code class="c">C</code> Komm schenk dir ein<br />
+Erde<br>
+<code class="c">C</code> Komm schenk dir ein<br>
 Und wenn ich dann traurig werde, <code class="g">G</code> liegt es
-daran<br />
+daran<br>
 Dass ich immer träume von da<code class="c">C</code>heim</p>
 <p>Du musst ver<code class="e">E</code>zeihen!</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="f">F</code> Griechischer Wein und die alt vertrauten
-Lieder<br />
-<code class="c">C</code> Schenk nochmal ein<br />
+Lieder<br>
+<code class="c">C</code> Schenk nochmal ein<br>
 Denn ich fühl die Sehnsucht wieder</p>
-<p><code class="g">G</code> In dieser Stadt<br />
-werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br />
+<p><code class="g">G</code> In dieser Stadt<br>
+werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br>
 <code class="e">E</code> und al<code class="a">Am</code>lein</p>
-</section>
-<section id="verse-2-11" class="slide level2">
+</div></section>
+<section id="verse-2-11" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>Und dann er<code class="a">Am</code>zählten sie mir von grünen
-Hügeln<br />
-<code class="f">F</code> Meer <code class="g">G</code> und <code
-class="c">C</code> Wind<br />
+Hügeln<br>
+<code class="f">F</code> Meer <code class="g">G</code> und <code class="c">C</code> Wind<br>
 Von alten Häusern und jungen Frauen, die allei<code class="f">F</code>ne
 <code class="g">G</code> sind</p>
-<p>Und von dem <code class="a">Am</code> Kind<br />
-das seinen <code class="e">E</code> Vater noch nie <code
-class="a">Am</code> sah</p>
-</section>
-<section class="slide level2">
+<p>Und von dem <code class="a">Am</code> Kind<br>
+das seinen <code class="e">E</code> Vater noch nie <code class="a">Am</code> sah</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Sie sagten <code class="a">Am</code> sich immer wieder<br />
+<p>Sie sagten <code class="a">Am</code> sich immer wieder<br>
 irgendwann geht <code class="f">F</code> es <code class="g">G</code>
-zu<code class="c">C</code>rück<br />
-Und das Ersparte genügt zu Hause<br />
+zu<code class="c">C</code>rück<br>
+Und das Ersparte genügt zu Hause<br>
 für ein klei<code class="f">F</code>nes <code class="g">G</code>
 Glück</p>
-<p>Und bald denkt <code class="a">Am</code> keiner mehr da<code
-class="e">E</code>ran<br />
+<p>Und bald denkt <code class="a">Am</code> keiner mehr da<code class="e">E</code>ran<br>
 wie es hier <code class="a">Am</code> war</p>
-</section>
-<section id="chorus-2-3" class="slide level2">
+</div></section>
+<section id="chorus-2-3" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
 <p><code class="f">F</code> Griechischer Wein ist so wie das Blut der
-Erde<br />
-<code class="c">C</code> Komm schenk dir ein<br />
+Erde<br>
+<code class="c">C</code> Komm schenk dir ein<br>
 Und wenn ich dann traurig werde, <code class="g">G</code> liegt es
-daran<br />
+daran<br>
 Dass ich immer träume von da<code class="c">C</code>heim</p>
 <p>Du musst ver<code class="e">E</code>zeihen!</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="f">F</code> Griechischer Wein und die alt vertrauten
-Lieder<br />
-<code class="c">C</code> Schenk nochmal ein<br />
+Lieder<br>
+<code class="c">C</code> Schenk nochmal ein<br>
 Denn ich fühl die Sehnsucht wieder</p>
-<p><code class="g">G</code> in dieser Stadt<br />
-Werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br />
+<p><code class="g">G</code> in dieser Stadt<br>
+Werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br>
 <code class="e">E</code> und al<code class="a">Am</code>lein</p>
-</section>
-<section id="outro-1" class="slide level2">
+</div></section>
+<section id="outro-1" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code><br />
-<code class="c">C</code> <code class="e">E</code> <code
-class="a">Am</code></p>
-</section>
-<section id="resources-12" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dm</code> <code class="f">F</code> <code class="g">G</code><br>
+<code class="c">C</code> <code class="e">E</code> <code class="a">Am</code></p>
+</div></section>
+<section id="resources-12" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=6Ucp1IxujUg">Song</a></li>
 <li><a href="https://tabs.ultimate-guitar.com/tab/1018193">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="hallelujah-leonard-cohen" class="title-slide slide level1">
+<section id="hallelujah-leonard-cohen" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ Hallelujah (Leonard Cohen)</h1>
 
-</section>
-<section id="intro-8" class="slide level2">
+</div></section>
+<section id="intro-8" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><code class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="verse-1-12" class="slide level2">
+</div></section>
+<section id="verse-1-12" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Now I’ve <code class="c">C</code> heard there was a <code
-class="a">Am</code> secret chord<br />
-That <code class="c">C</code> David played, and it <code
-class="a">Am</code> pleased the Lord<br />
+<p>Now I’ve <code class="c">C</code> heard there was a <code class="a">Am</code> secret chord<br>
+That <code class="c">C</code> David played, and it <code class="a">Am</code> pleased the Lord<br>
 But <code class="f">F</code> you don’t really <code class="g">G</code>
-care for music, <code class="c">C</code> do you? <code
-class="g">G</code></p>
-<p>It <code class="c">C</code> goes like this, the <code
-class="f">F</code> fourth, the <code class="g">G</code> fifth<br />
+care for music, <code class="c">C</code> do you? <code class="g">G</code></p>
+<p>It <code class="c">C</code> goes like this, the <code class="f">F</code> fourth, the <code class="g">G</code> fifth<br>
 The <code class="a">Am</code> minor fall, the <code class="f">F</code>
-major lift<br />
+major lift<br>
 The <code class="g">G</code> baffled king <code class="e">E</code>
 composing, halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-13" class="slide level2">
+</div></section>
+<section id="chorus-13" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-2-12" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-2-12" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Your <code class="c">C</code> faith was strong, but you <code
-class="a">Am</code> needed proof<br />
+<p>Your <code class="c">C</code> faith was strong, but you <code class="a">Am</code> needed proof<br>
 You <code class="c">C</code> saw her bathing <code class="a">Am</code>
-on the roof<br />
+on the roof<br>
 Her <code class="f">F</code> beauty and the <code class="g">G</code>
-moonlight over<code class="c">C</code>threw ya <code
-class="g">G</code></p>
+moonlight over<code class="c">C</code>threw ya <code class="g">G</code></p>
 <p>She <code class="c">C</code> tied you to a <code class="f">F</code>
-kitchen <code class="g">G</code> chair<br />
-She <code class="a">Am</code> broke your throne, and she <code
-class="f">F</code> cut your hair<br />
+kitchen <code class="g">G</code> chair<br>
+She <code class="a">Am</code> broke your throne, and she <code class="f">F</code> cut your hair<br>
 And <code class="g">G</code> from your lips she <code class="e">E</code>
 drew the <code class="a">Am</code> hallelujah</p>
-</section>
-<section id="chorus-14" class="slide level2">
+</div></section>
+<section id="chorus-14" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-3-8" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-3-8" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p><code class="c">C</code> Baby, I’ve been <code class="a">Am</code>
-here before<br />
-I <code class="c">C</code> know this room, I’ve <code
-class="a">Am</code> walked this floor<br />
+here before<br>
+I <code class="c">C</code> know this room, I’ve <code class="a">Am</code> walked this floor<br>
 I <code class="f">F</code>used to live a<code class="g">G</code>lone
 before I <code class="c">C</code> knew you <code class="g">G</code></p>
-<p>I’ve <code class="c">C</code> seen your flag on the <code
-class="f">F</code> marble <code class="g">G</code> arch<br />
+<p>I’ve <code class="c">C</code> seen your flag on the <code class="f">F</code> marble <code class="g">G</code> arch<br>
 <code class="a">Am</code>Love is not a <code class="f">F</code> victory
-march<br />
-It’s a <code class="g">G</code> cold, and it’s a <code
-class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-15" class="slide level2">
+march<br>
+It’s a <code class="g">G</code> cold, and it’s a <code class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
+</div></section>
+<section id="chorus-15" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-4-6" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-4-6" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>There <code class="c">C</code> was a time when you <code
-class="a">Am</code> let me know<br />
+<p>There <code class="c">C</code> was a time when you <code class="a">Am</code> let me know<br>
 What’s <code class="c">C</code> really going <code class="a">Am</code>
-on below<br />
+on below<br>
 But <code class="f">F</code> now you never <code class="g">G</code> show
 it to me, <code class="c">C</code> do you? <code class="g">G</code></p>
 <p>And re<code class="c">C</code>member when I <code class="f">F</code>
-moved in <code class="g">G</code> you<br />
+moved in <code class="g">G</code> you<br>
 The <code class="a">Am</code> holy dove was <code class="f">F</code>
-moving too<br />
+moving too<br>
 And <code class="g">G</code> every breath we <code class="e">E</code>
 drew was halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-16" class="slide level2">
+</div></section>
+<section id="chorus-16" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-5-5" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-5-5" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p><code class="c">C</code> Maybe there’s a <code class="a">Am</code>
-God above<br />
+God above<br>
 And <code class="c">C</code> all I ever <code class="a">Am</code>
-learned from love<br />
+learned from love<br>
 Was <code class="f">F</code> how to shoot at <code class="g">G</code>
-someone who out<code class="c">C</code>drew you <code
-class="g">G</code></p>
-<p>It’s <code class="c">C</code> not a cry you can <code
-class="f">F</code> hear at <code class="g">G</code> night<br />
-It’s <code class="a">Am</code> not somebody who has <code
-class="f">F</code> seen the light<br />
-It’s a <code class="g">G</code> cold, and it’s a <code
-class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-17" class="slide level2">
+someone who out<code class="c">C</code>drew you <code class="g">G</code></p>
+<p>It’s <code class="c">C</code> not a cry you can <code class="f">F</code> hear at <code class="g">G</code> night<br>
+It’s <code class="a">Am</code> not somebody who has <code class="f">F</code> seen the light<br>
+It’s a <code class="g">G</code> cold, and it’s a <code class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
+</div></section>
+<section id="chorus-17" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-6-3" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-6-3" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
 <p>You <code class="c">C</code> say I took the <code class="a">Am</code>
-name in vain<br />
+name in vain<br>
 Though <code class="c">C</code> I don’t even <code class="a">Am</code>
-know the name<br />
+know the name<br>
 But <code class="f">F</code> if I did, well <code class="g">G</code>
-really, what’s it <code class="c">C</code> to ya? <code
-class="g">G</code></p>
-<p>There’s a <code class="c">C</code> blaze of light in <code
-class="f">F</code> every <code class="g">G</code> word<br />
+really, what’s it <code class="c">C</code> to ya? <code class="g">G</code></p>
+<p>There’s a <code class="c">C</code> blaze of light in <code class="f">F</code> every <code class="g">G</code> word<br>
 It <code class="a">Am</code> doesn’t matter <code class="f">F</code>
-which you heard<br />
+which you heard<br>
 The <code class="g">G</code> holy or the <code class="e">E</code> broken
 halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-18" class="slide level2">
+</div></section>
+<section id="chorus-18" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-7-1" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-7-1" class="slide level2"><div class="slide-content">
 <h2>Verse 7</h2>
 <p>I <code class="c">C</code> did my best, it <code class="a">Am</code>
-wasn’t much<br />
+wasn’t much<br>
 I <code class="c">C</code> couldn’t feel, so I <code class="a">Am</code>
-tried to touch<br />
+tried to touch<br>
 I’ve <code class="f">F</code> told the truth, I <code class="g">G</code>
-didn’t come to <code class="c">C</code> fool ya <code
-class="g">G</code></p>
+didn’t come to <code class="c">C</code> fool ya <code class="g">G</code></p>
 <p>And <code class="c">C</code> even though it <code class="f">F</code>
-all went <code class="g">G</code> wrong<br />
+all went <code class="g">G</code> wrong<br>
 I’ll <code class="a">Am</code> stand before the <code class="f">F</code>
-Lord of Song<br />
+Lord of Song<br>
 With <code class="g">G</code> nothing on my <code class="e">E</code>
 tongue but halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-19" class="slide level2">
+</div></section>
+<section id="chorus-19" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
 <p><em>(4x)</em></p>
-</section>
-<section id="resources-13" class="slide level2">
+</div></section>
+<section id="resources-13" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=ttEMYvpoR-k">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/leonard-cohen/hallelujah-chords-629185">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/leonard-cohen/hallelujah-chords-629185">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=Mzm1enk7W4Y">Guitar
 tutorial</a></li>
 <li><a href="https://www.youtube.com/watch?v=uKDXIl52j1E">Sing in
 harmony tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="hemmige-mani-matter" class="title-slide slide level1">
+<section id="hemmige-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Hemmige (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-13" class="slide level2">
+</div></section>
+<section id="verse-1-13" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>S’git <code class="a">Am</code> Lüt, die würden alletwäge <code
-class="d">Dm</code> nie<br />
-Es <code class="g">G</code> Lied vorsinge, so win ig jitz <code
-class="c">C</code> hie<br />
-Eis singe <code class="c">C</code> - um kei Pris, nei bhüetis <code
-class="e">E7</code> nei!<br />
+<p>S’git <code class="a">Am</code> Lüt, die würden alletwäge <code class="d">Dm</code> nie<br>
+Es <code class="g">G</code> Lied vorsinge, so win ig jitz <code class="c">C</code> hie<br>
+Eis singe <code class="c">C</code> - um kei Pris, nei bhüetis <code class="e">E7</code> nei!<br>
 Will si <code class="a">Am</code> hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-2-13" class="slide level2">
+</div></section>
+<section id="verse-2-13" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Si <code class="a">Am</code> wäre vilicht gärn im Grund gno <code
-class="d">Dm</code> fräch<br />
-Und <code class="g">G</code> dänke, das syg ires grosse <code
-class="c">C</code> Päch<br />
-Und <code class="c">C</code> s’laschtet uf ne wine schwäre <code
-class="e">E7</code> Stei<br />
+<p>Si <code class="a">Am</code> wäre vilicht gärn im Grund gno <code class="d">Dm</code> fräch<br>
+Und <code class="g">G</code> dänke, das syg ires grosse <code class="c">C</code> Päch<br>
+Und <code class="c">C</code> s’laschtet uf ne wine schwäre <code class="e">E7</code> Stei<br>
 dass si <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-3-9" class="slide level2">
+</div></section>
+<section id="verse-3-9" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>I <code class="a">Am</code> weis, das macht eim heiss,<br />
-erschlat eim <code class="d">Dm</code> d’Stimm<br />
-Doch <code class="g">G</code> dünkt eim mängisch o<br />
-s’syg nüt so <code class="c">C</code> schlimm<br />
-S’isch <code class="c">C</code> glych es Glück, o we mirs gar nid <code
-class="e">E7</code> wei<br />
+<p>I <code class="a">Am</code> weis, das macht eim heiss,<br>
+erschlat eim <code class="d">Dm</code> d’Stimm<br>
+Doch <code class="g">G</code> dünkt eim mängisch o<br>
+s’syg nüt so <code class="c">C</code> schlimm<br>
+S’isch <code class="c">C</code> glych es Glück, o we mirs gar nid <code class="e">E7</code> wei<br>
 Dass mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-4-7" class="slide level2">
+</div></section>
+<section id="verse-4-7" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>Was <code class="a">Am</code> unterscheidet d’Mönsche vom schim<code
-class="d">Dm</code>pans?<br />
-S’isch <code class="g">G</code> nid die glatti Huut, dr fählend <code
-class="c">C</code> Schwanz<br />
-Nid <code class="c">C</code> dass mir schlächter d’Böim ufchöme, <code
-class="e">E7</code> nei<br />
+<p>Was <code class="a">Am</code> unterscheidet d’Mönsche vom schim<code class="d">Dm</code>pans?<br>
+S’isch <code class="g">G</code> nid die glatti Huut, dr fählend <code class="c">C</code> Schwanz<br>
+Nid <code class="c">C</code> dass mir schlächter d’Böim ufchöme, <code class="e">E7</code> nei<br>
 Dass mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-5-6" class="slide level2">
+</div></section>
+<section id="verse-5-6" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p><em>(Interlude in Stephan Eicher’s Version)</em></p>
 <p>Me <code class="a">Am</code> stell sech d’Manne vor, wenns anders
-<code class="d">Dm</code> wär<br />
-Und <code class="g">G</code> s’chäm es hübsches Meiteli der<code
-class="c">C</code>här<br />
-Jitz <code class="c">C</code> luege mir doch höchstens chly uf d’<code
-class="e">E7</code>Bei<br />
+<code class="d">Dm</code> wär<br>
+Und <code class="g">G</code> s’chäm es hübsches Meiteli der<code class="c">C</code>här<br>
+Jitz <code class="c">C</code> luege mir doch höchstens chly uf d’<code class="e">E7</code>Bei<br>
 Will mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-6-4" class="slide level2">
+</div></section>
+<section id="verse-6-4" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
 <p>Und <code class="a">Am</code> we me gseht, was hütt dr Mönschheit
-<code class="d">Dm</code> droht<br />
-So <code class="g">G</code> gseht me würklech schwarz, nid nume <code
-class="c">C</code> rot<br />
-Und <code class="c">C</code> was me no cha hoffen isch a<code
-class="e">E7</code>lei<br />
-Dass si <code class="a">Am</code> Hemm<code class="e">E7</code>ige <code
-class="a">Am</code> hei</p>
-</section>
-<section id="resources-14" class="slide level2">
+<code class="d">Dm</code> droht<br>
+So <code class="g">G</code> gseht me würklech schwarz, nid nume <code class="c">C</code> rot<br>
+Und <code class="c">C</code> was me no cha hoffen isch a<code class="e">E7</code>lei<br>
+Dass si <code class="a">Am</code> Hemm<code class="e">E7</code>ige <code class="a">Am</code> hei</p>
+</div></section>
+<section id="resources-14" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
-<li><a href="https://www.youtube.com/watch?v=L0OydDmfwAo">Song</a>
+<li>
+<a href="https://www.youtube.com/watch?v=L0OydDmfwAo">Song</a>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=pxjNh3sq66U">Super
 Interpretation vomStephan Eicher</a></li>
-</ul></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/stephan-eicher/hemmige-chords-1716428">Source
+</ul>
+</li>
+<li><a href="https://tabs.ultimate-guitar.com/tab/stephan-eicher/hemmige-chords-1716428">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="hurt-johnny-cash" class="title-slide slide level1">
+<section id="hurt-johnny-cash" class="title-slide slide level1"><div class="slide-content">
 <h1>Hurt (Johnny Cash)</h1>
 
-</section>
-<section id="instructions-2" class="slide level2">
+</div></section>
+<section id="instructions-2" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>Chorus chord variations:
 
@@ -2323,143 +2038,116 @@ C/E(2) |0 3 2 0 1 3|
 Fadd9  |1 0 3 2 1 3| Thumb on E string
 
 Just keep pinky on 3rd fret of e string</code></pre>
-</section>
-<section id="intro-9" class="slide level2">
+</div></section>
+<section id="intro-9" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-1-14" class="slide level2">
+<p><code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-1-14" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>I <code class="c">C</code> hurt myself <code class="d">D</code> today
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 to see <code class="c">C</code> if I <code class="d">D</code> still feel
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 I <code class="c">C</code> focus <code class="d">D</code> on the pain
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 the <code class="c">C</code> only thing <code class="d">D</code> that’s
 real <code class="a">Am</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>The <code class="c">C</code> needle <code class="d">D</code> tears a
-hole <code class="a">Am</code><br />
+hole <code class="a">Am</code><br>
 the <code class="c">C</code> old fa<code class="d">D</code>miliar sting
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 Try to <code class="c">C</code> kill it <code class="d">D</code> all
-away <code class="a">Am</code><br />
+away <code class="a">Am</code><br>
 but I re<code class="c">C</code>member <code class="d">D</code>
 everything <code class="g">G</code></p>
-</section>
-<section id="chorus-1-4" class="slide level2">
+</div></section>
+<section id="chorus-1-4" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p><code class="a">Am7</code> What have I become? <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My sweetest friend <code
-class="g">G</code><br />
-<code class="a">Am7</code> Everyone I know <code
-class="f">Fadd9</code><br />
-goes away <code class="c">C/E</code> in the end <code
-class="g">G</code></p>
-</section>
-<section class="slide level2">
+<p><code class="a">Am7</code> What have I become? <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My sweetest friend <code class="g">G</code><br>
+<code class="a">Am7</code> Everyone I know <code class="f">Fadd9</code><br>
+goes away <code class="c">C/E</code> in the end <code class="g">G</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>And <code class="a">Am7</code> you could have it all <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My empire of dirt <code
-class="g">G</code><br />
-<code class="a">Am7</code> I will let you down <code
-class="f">Fadd9</code><br />
-<code class="g">G</code> I will make you hurt <code
-class="a">Am</code></p>
-</section>
-<section id="transition" class="slide level2">
+<p>And <code class="a">Am7</code> you could have it all <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My empire of dirt <code class="g">G</code><br>
+<code class="a">Am7</code> I will let you down <code class="f">Fadd9</code><br>
+<code class="g">G</code> I will make you hurt <code class="a">Am</code></p>
+</div></section>
+<section id="transition" class="slide level2"><div class="slide-content">
 <h2>Transition</h2>
-<p><code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-2-14" class="slide level2">
+<p><code class="c">C</code> <code class="d">D</code> <code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-2-14" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>I <code class="c">C</code> wear this crown <code class="d">D</code>
-of thorns <code class="a">Am</code><br />
+of thorns <code class="a">Am</code><br>
 u<code class="c">C</code>pon my li<code class="d">D</code>ar’s chair
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 <code class="c">C</code> Full of bro<code class="d">D</code>ken thoughts
-<code class="a">Am</code><br />
-<code class="c">C</code>I cannot <code class="d">D</code> re<code
-class="a">Am</code>pair</p>
-</section>
-<section class="slide level2">
+<code class="a">Am</code><br>
+<code class="c">C</code>I cannot <code class="d">D</code> re<code class="a">Am</code>pair</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>Be<code class="c">C</code>neath the stains <code class="d">D</code>
-of <code class="a">Am</code> time<br />
+of <code class="a">Am</code> time<br>
 the <code class="c">C</code> feelings <code class="d">D</code> disappear
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 <code class="c">C</code> You are some<code class="d">D</code>one else
-<code class="a">Am</code><br />
-<code class="c">C</code> I am still <code class="d">D</code> right <code
-class="g">G</code> here</p>
+<code class="a">Am</code><br>
+<code class="c">C</code> I am still <code class="d">D</code> right <code class="g">G</code> here</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="chorus-2-4" class="slide level2">
+</div></section>
+<section id="chorus-2-4" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p><code class="a">Am7</code> What have I become? <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My sweetest friend <code
-class="g">G</code><br />
-<code class="a">Am7</code> Everyone I know <code
-class="f">Fadd9</code><br />
-goes away <code class="c">C/E</code> in the end <code
-class="g">G</code></p>
-</section>
-<section class="slide level2">
+<p><code class="a">Am7</code> What have I become? <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My sweetest friend <code class="g">G</code><br>
+<code class="a">Am7</code> Everyone I know <code class="f">Fadd9</code><br>
+goes away <code class="c">C/E</code> in the end <code class="g">G</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>And <code class="a">Am7</code> you could have it all <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My empire of dirt <code
-class="g">G</code><br />
-<code class="a">Am7</code> I will let you down <code
-class="f">Fadd9</code><br />
+<p>And <code class="a">Am7</code> you could have it all <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My empire of dirt <code class="g">G</code><br>
+<code class="a">Am7</code> I will let you down <code class="f">Fadd9</code><br>
 <code class="g">G</code> I will make you hurt <code class="g">G</code>
 <em>(remain on G)</em></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>If I <code class="a">Am7</code> could start again <code
-class="f">Fadd9</code><br />
-a <code class="c">C/E</code> million miles a<code
-class="g">G</code>way<br />
-<code class="a">Am7</code> I would keep myself <code
-class="f">Fadd9</code><br />
+<p>If I <code class="a">Am7</code> could start again <code class="f">Fadd9</code><br>
+a <code class="c">C/E</code> million miles a<code class="g">G</code>way<br>
+<code class="a">Am7</code> I would keep myself <code class="f">Fadd9</code><br>
 <code class="g">G</code> I would find a way</p>
-<p><code class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code></p>
-</section>
-<section id="resources-15" class="slide level2">
+<p><code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code></p>
+</div></section>
+<section id="resources-15" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=8AHCfZTRGiI">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/johnny-cash/hurt-chords-89849">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/johnny-cash/hurt-chords-89849">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=hEKexrWq5RU">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="i-am-sailing-rod-stewart" class="title-slide slide level1">
+<section id="i-am-sailing-rod-stewart" class="title-slide slide level1"><div class="slide-content">
 <h1>I am sailing (Rod Stewart)</h1>
 
-</section>
-<section id="instructions-3" class="slide level2">
+</div></section>
+<section id="instructions-3" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <p>Capo on 3rd fret</p>
 <pre><code>   Riff:
@@ -2470,287 +2158,269 @@ D |----|----|0-------|----|----|0---0-2|
 A |----|----|--------|----|----|-------|
 E |----|----|--------|----|----|-------|
      x4   x2            x4   x2</code></pre>
-</section>
-<section id="intro-10" class="slide level2">
+</div></section>
+<section id="intro-10" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Riff)</em></p>
-</section>
-<section id="verse-1-15" class="slide level2">
+</div></section>
+<section id="verse-1-15" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>I am <code class="g">G</code> sailing, I am <code class="e">Em</code>
-sailing<br />
+sailing<br>
 home a<code class="c">C</code>gain ’cross the <code class="g">G</code>
 sea.</p>
-<p>I am <code class="a">Am</code> sailing stormy <code
-class="e">Em</code> waters<br />
+<p>I am <code class="a">Am</code> sailing stormy <code class="e">Em</code> waters<br>
 to be <code class="a">Am</code> near you, to be <code class="g">G</code>
 free. <code class="d">D</code></p>
-</section>
-<section id="verse-2-15" class="slide level2">
+</div></section>
+<section id="verse-2-15" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>I am <code class="g">G</code> flying, I am <code class="e">Em</code>
-flying<br />
+flying<br>
 like a <code class="c">C</code> bird ’cross the <code class="g">G</code>
 sea.</p>
-<p>I am <code class="a">Am</code> flying passing <code
-class="e">Em</code> high clouds<br />
+<p>I am <code class="a">Am</code> flying passing <code class="e">Em</code> high clouds<br>
 to be <code class="a">Am</code> near you, to be <code class="g">G</code>
 free. <code class="d">D</code></p>
-</section>
-<section id="chorus-20" class="slide level2">
+</div></section>
+<section id="chorus-20" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Can you <code class="g">G</code> hear me, can you <code
-class="e">Em</code> hear me<br />
-thru the <code class="c">C</code> dark night far a<code
-class="g">G</code>way?</p>
-<p>I am <code class="a">Am</code> dying, forever <code
-class="e">Em</code> trying<br />
-to be <code class="a">Am</code> with you, who can <code
-class="g">G</code> say? <code class="d">D</code></p>
-</section>
-<section id="verse-3-10" class="slide level2">
+<p>Can you <code class="g">G</code> hear me, can you <code class="e">Em</code> hear me<br>
+thru the <code class="c">C</code> dark night far a<code class="g">G</code>way?</p>
+<p>I am <code class="a">Am</code> dying, forever <code class="e">Em</code> trying<br>
+to be <code class="a">Am</code> with you, who can <code class="g">G</code> say? <code class="d">D</code></p>
+</div></section>
+<section id="verse-3-10" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>We are <code class="g">G</code> sailing, we are <code
-class="e">Em</code> sailing<br />
+<p>We are <code class="g">G</code> sailing, we are <code class="e">Em</code> sailing<br>
 home a<code class="c">C</code>gain ’cross the <code class="g">G</code>
 sea.</p>
-<p>We are <code class="a">Am</code> sailing stormy <code
-class="e">Em</code> waters<br />
+<p>We are <code class="a">Am</code> sailing stormy <code class="e">Em</code> waters<br>
 to be <code class="a">Am</code> near you, to be <code class="g">G</code>
 free. <code class="d">D</code> Oh Lord</p>
-</section>
-<section id="outro-2" class="slide level2">
+</div></section>
+<section id="outro-2" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p>To be <code class="a">Am</code> near you, to be <code
-class="g">G</code> free.<br />
-Oh Lord, to be <code class="a">Am</code> near you, to be free. <code
-class="g">G</code></p>
-</section>
-<section id="resources-16" class="slide level2">
+<p>To be <code class="a">Am</code> near you, to be <code class="g">G</code> free.<br>
+Oh Lord, to be <code class="a">Am</code> near you, to be free. <code class="g">G</code></p>
+</div></section>
+<section id="resources-16" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=P6zaCV4niKk">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/rod-stewart/sailing-chords-380559">Source
+<li>
+<a href="https://tabs.ultimate-guitar.com/tab/rod-stewart/sailing-chords-380559">Source
 tab</a> (transpose by -5 to start with G instead of B)</li>
-<li><a href="https://www.youtube.com/watch?v=m4KTNKZSFVs">Guitar
+<li>
+<a href="https://www.youtube.com/watch?v=m4KTNKZSFVs">Guitar
 tutorial</a>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=JmiW9-kpGck">Another guitar
 tutorial with additional inspirations</a></li>
-</ul></li>
 </ul>
-</section></section>
+</li>
+</ul>
+</div></section></section>
 <section>
-<section id="jolene-dolly-parton" class="title-slide slide level1">
+<section id="jolene-dolly-parton" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ Jolene (Dolly Parton)</h1>
 
-</section>
-<section id="intro-11" class="slide level2">
+</div></section>
+<section id="intro-11" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><code class="a">Am</code> <em>(x4)</em></p>
-</section>
-<section id="chorus-21" class="slide level2">
+</div></section>
+<section id="chorus-21" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-I’m <code class="g">G</code> begging of you<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+I’m <code class="g">G</code> begging of you<br>
 please don’t take my <code class="a">Am</code> man</p>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-<code class="g">G</code> Please don’t take him<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+<code class="g">G</code> Please don’t take him<br>
 <code class="e">Em</code> just because you <code class="a">Am</code>
 can</p>
-</section>
-<section id="verse-1-16" class="slide level2">
+</div></section>
+<section id="verse-1-16" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Your <code class="a">Am</code> beauty is be<code
-class="c">C</code>yond compare<br />
+<p>Your <code class="a">Am</code> beauty is be<code class="c">C</code>yond compare<br>
 With <code class="g">G</code> flaming locks of <code class="a">Am</code>
-auburn hair<br />
-With <code class="g">G</code> ivory skin<br />
+auburn hair<br>
+With <code class="g">G</code> ivory skin<br>
 and <code class="e">Em</code> eyes of emerald <code class="a">Am</code>
 green</p>
-<p>Your <code class="a">Am</code> smile is like a <code
-class="c">C</code> breath of spring<br />
-Your <code class="g">G</code> voice is soft like <code
-class="a">Am</code> summer rain<br />
+<p>Your <code class="a">Am</code> smile is like a <code class="c">C</code> breath of spring<br>
+Your <code class="g">G</code> voice is soft like <code class="a">Am</code> summer rain<br>
 And <code class="g">G</code> I cannot com<code class="e">Em</code>pete
-with you<br />
+with you<br>
 <code class="a">Am</code> Jolene</p>
-</section>
-<section id="verse-2-16" class="slide level2">
+</div></section>
+<section id="verse-2-16" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>He <code class="a">Am</code> talks about you <code class="c">C</code>
-in his sleep<br />
+in his sleep<br>
 There’s <code class="g">G</code> nothing I can <code class="a">Am</code>
-do to keep<br />
+do to keep<br>
 From <code class="g">G</code> crying when he <code class="e">Em</code>
-calls your name<br />
+calls your name<br>
 Jo<code class="a">Am</code>lene</p>
 <p>And <code class="a">Am</code> I can easily <code class="c">C</code>
-understand<br />
+understand<br>
 How <code class="g">G</code> you could easily <code class="a">Am</code>
-take my man<br />
-But you <code class="g">G</code> don’t know what he <code
-class="e">Em</code> means to me<br />
+take my man<br>
+But you <code class="g">G</code> don’t know what he <code class="e">Em</code> means to me<br>
 Jo<code class="a">Am</code>lene</p>
-</section>
-<section id="chorus-22" class="slide level2">
+</div></section>
+<section id="chorus-22" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-I’m <code class="g">G</code> begging of you<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+I’m <code class="g">G</code> begging of you<br>
 please don’t take my <code class="a">Am</code> man</p>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-<code class="g">G</code> Please don’t take him<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+<code class="g">G</code> Please don’t take him<br>
 <code class="e">Em</code> just because you <code class="a">Am</code>
 can</p>
-</section>
-<section id="verse-3-11" class="slide level2">
+</div></section>
+<section id="verse-3-11" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> You could have your <code
-class="c">C</code> choice of men<br />
+<p><code class="a">Am</code> You could have your <code class="c">C</code> choice of men<br>
 But <code class="g">G</code> I could never <code class="a">Am</code>
-love again<br />
+love again<br>
 <code class="g">G</code> He’s the only <code class="e">Em</code> one for
-me<br />
+me<br>
 Jo<code class="a">Am</code>lene</p>
 <p>I <code class="a">Am</code> had to have this <code class="c">C</code>
-talk with you<br />
+talk with you<br>
 My <code class="g">G</code> happiness de<code class="a">Am</code>pends
-on you<br />
+on you<br>
 What<code class="g">G</code>ever you de<code class="e">Em</code>cide to
-do<br />
+do<br>
 Jo<code class="a">Am</code>lene</p>
-</section>
-<section id="chorus-23" class="slide level2">
+</div></section>
+<section id="chorus-23" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-I’m <code class="g">G</code> begging of you<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+I’m <code class="g">G</code> begging of you<br>
 please don’t take my <code class="a">Am</code> man</p>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-<code class="g">G</code> Please don’t take him<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+<code class="g">G</code> Please don’t take him<br>
 <code class="e">Em</code> <del>just because</del> <strong>even
 though</strong> you <code class="a">Am</code> can</p>
-</section>
-<section id="resources-17" class="slide level2">
+</div></section>
+<section id="resources-17" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=Ixrje2rXLMA">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/dolly-parton/jolene-chords-183019">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/dolly-parton/jolene-chords-183019">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=O2j6cZlT2LI">Guitar
 tutorial</a></li>
 <li><a href="https://www.youtube.com/watch?v=viQx4KDivPY">Interpretation
 by The Petersens</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="junge-die-ärzte" class="title-slide slide level1">
+<section id="junge-die-ärzte" class="title-slide slide level1"><div class="slide-content">
 <h1>Junge (Die Ärzte)</h1>
 
-</section>
-<section id="intro-12" class="slide level2">
+</div></section>
+<section id="intro-12" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="a">Am</code> <code class="a">Am</code> <em>(x2)</em></p>
-</section>
-<section id="verse-1-17" class="slide level2">
+<p><code class="f">F</code> <code class="g">G</code> <code class="a">Am</code> <code class="a">Am</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-1-17" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><em>(Picking)</em></p>
 <p><code class="f">F</code> Junge, warum <code class="g">G</code> hast
-Du nichts gelernt? <code class="a">Am</code><br />
-Guck Dir den <code class="f">F</code> Dieter an:<br />
+Du nichts gelernt? <code class="a">Am</code><br>
+Guck Dir den <code class="f">F</code> Dieter an:<br>
 <code class="g">G</code> der hat sogar ein <code class="a">Am</code>
 Auto! <code class="e">Em</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Warum <code class="f">F</code> gehst Du nicht zu<br />
-Onkel Werner in die Werk<code class="g">G</code>statt?<br />
-Der gibt Dir ’ne <code class="a">Am</code> Festanstellung<br />
+<p>Warum <code class="f">F</code> gehst Du nicht zu<br>
+Onkel Werner in die Werk<code class="g">G</code>statt?<br>
+Der gibt Dir ’ne <code class="a">Am</code> Festanstellung<br>
 wenn Du ihn darum bittest</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
-</section>
-<section id="chorus-1-5" class="slide level2">
+</div></section>
+<section id="chorus-1-5" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
 <p><em>(Strumming)</em></p>
-<p>…und wie du wieder aus<code class="f">F</code>siehst<br />
-Löcher in der Ho<code class="d">Dm</code>se<br />
-und ständig dieser Lärm <code class="a">Am</code><br />
+<p>…und wie du wieder aus<code class="f">F</code>siehst<br>
+Löcher in der Ho<code class="d">Dm</code>se<br>
+und ständig dieser Lärm <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Und dann noch deine Ha<code class="f">F</code>are<br />
-da fehlen mir die Wor<code class="d">Dm</code>te<br />
-musst du die denn färb’n? <code class="a">Am</code><br />
+<p>Und dann noch deine Ha<code class="f">F</code>are<br>
+da fehlen mir die Wor<code class="d">Dm</code>te<br>
+musst du die denn färb’n? <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>Nie kommst du nach Hau<code class="f">F</code>se<br />
+<p>Nie kommst du nach Hau<code class="f">F</code>se<br>
 wir wissen nicht mehr wei<code class="d">Dm</code>ter</p>
-</section>
-<section id="verse-2-17" class="slide level2">
+</div></section>
+<section id="verse-2-17" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p><em>(Picking)</em></p>
 <p><code class="f">F</code> Junge, <code class="g">G</code> brich deiner
-Mutter nicht das Herz <code class="a">Am</code><br />
-es ist noch <code class="f">F</code> nicht zu spät <code
-class="g">G</code><br />
+Mutter nicht das Herz <code class="a">Am</code><br>
+es ist noch <code class="f">F</code> nicht zu spät <code class="g">G</code><br>
 dich an der Uni einzu<code class="a">Am</code>schreiben</p>
-<p>du hast dich doch <code class="f">F</code> früher so<br />
-für Tiere interessiert <code class="g">G</code><br />
+<p>du hast dich doch <code class="f">F</code> früher so<br>
+für Tiere interessiert <code class="g">G</code><br>
 wäre das nichts für <code class="a">Am</code> dich: eine eigene
 Praxis?</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
-</section>
-<section id="chorus-2-5" class="slide level2">
+</div></section>
+<section id="chorus-2-5" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
 <p><em>(Strumming)</em></p>
-<p>…und wie du wieder aus<code class="f">F</code>siehst<br />
-Löcher in der Ho<code class="d">Dm</code>se<br />
-und ständig dieser Lärm <code class="a">Am</code><br />
+<p>…und wie du wieder aus<code class="f">F</code>siehst<br>
+Löcher in der Ho<code class="d">Dm</code>se<br>
+und ständig dieser Lärm <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>Elektrische Gi<code class="f">F</code>tarren<br />
-und immer diese Tex<code class="d">Dm</code>te<br />
-das will doch keiner hör’n <code class="a">Am</code><br />
+<p>Elektrische Gi<code class="f">F</code>tarren<br>
+und immer diese Tex<code class="d">Dm</code>te<br>
+das will doch keiner hör’n <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Nie kommst du nach Hau<code class="f">F</code>se<br />
-so viel schlechter Um<code class="d">Dm</code>gang<br />
-wir werden dich enterb’n <code class="a">Am</code><br />
+<p>Nie kommst du nach Hau<code class="f">F</code>se<br>
+so viel schlechter Um<code class="d">Dm</code>gang<br>
+wir werden dich enterb’n <code class="a">Am</code><br>
 (was soll das Finanz<code class="c">C</code>amt sagen?)</p>
-<p>wo soll das alles en<code class="f">F</code>den?<br />
+<p>wo soll das alles en<code class="f">F</code>den?<br>
 Wir machen uns doch Sor<code class="d">Dm</code>gen</p>
-</section>
-<section id="bridge-3" class="slide level2">
+</div></section>
+<section id="bridge-3" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><em>(Very fast strumming)</em></p>
 <p><code class="f">F</code> und du warst <code class="d">Dm</code> so
-ein süsses <code class="a">Am</code> Kind<br />
-und du warst <code class="c">C</code> so ein süsses <code
-class="f">F</code> Kind<br />
-und du warst <code class="d">Dm</code> so ein süsses <code
-class="a">Am</code> Kind<br />
+ein süsses <code class="a">Am</code> Kind<br>
+und du warst <code class="c">C</code> so ein süsses <code class="f">F</code> Kind<br>
+und du warst <code class="d">Dm</code> so ein süsses <code class="a">Am</code> Kind<br>
 du warst so <code class="c">C</code> süss</p>
-</section>
-<section id="chorus-24" class="slide level2">
+</div></section>
+<section id="chorus-24" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Und immer deine Freun<code class="f">F</code>de<br />
-ihr nehmt doch alle Dro<code class="d">Dm</code>gen<br />
-und ständig dieser Lärm <code class="a">Am</code><br />
+<p>Und immer deine Freun<code class="f">F</code>de<br>
+ihr nehmt doch alle Dro<code class="d">Dm</code>gen<br>
+und ständig dieser Lärm <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>denk’ an deine Zu<code class="f">F</code>kunft<br />
+<p>denk’ an deine Zu<code class="f">F</code>kunft<br>
 denk’ an deine El<code class="d">Dm</code>tern…</p>
 <p>…willst du, dass wir <code class="a">Am</code> sterb’n?</p>
-</section>
-<section id="resources-18" class="slide level2">
+</div></section>
+<section id="resources-18" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=iK-1oGphELM">Song</a></li>
@@ -2759,289 +2429,241 @@ tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=YycHXyyI4fI">Acoustic
 guitar interpretation</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="keep-on-the-sunny-side-carter-family"
-class="title-slide slide level1">
+<section id="keep-on-the-sunny-side-carter-family" class="title-slide slide level1"><div class="slide-content">
 <h1>Keep on the sunny side (Carter Family)</h1>
 
-</section>
-<section id="intro-13" class="slide level2">
+</div></section>
+<section id="intro-13" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code><br />
-<code class="c">C</code> <code class="g">G</code><br />
-<code class="g">G7</code> <code class="c">C</code><br />
+<p><code class="c">C</code> <code class="f">F</code> <code class="c">C</code><br>
+<code class="c">C</code> <code class="g">G</code><br>
+<code class="g">G7</code> <code class="c">C</code><br>
 <code class="g">G</code> <code class="c">C</code></p>
-</section>
-<section id="verse-1-18" class="slide level2">
+</div></section>
+<section id="verse-1-18" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>There’s a <code class="c">C</code> dark and a <code
-class="f">F</code> troubled side of <code class="c">C</code> life<br />
-There’s a <code class="c">C</code> bright, there’s a sunny side <code
-class="g">G</code> too<br />
-Tho’ we <code class="g">G7</code> meet with the darkness and <code
-class="c">C</code> strife<br />
-The <code class="g">G</code> sunny side we also may <code
-class="c">C</code> view</p>
-</section>
-<section id="chorus-25" class="slide level2">
+<p>There’s a <code class="c">C</code> dark and a <code class="f">F</code> troubled side of <code class="c">C</code> life<br>
+There’s a <code class="c">C</code> bright, there’s a sunny side <code class="g">G</code> too<br>
+Tho’ we <code class="g">G7</code> meet with the darkness and <code class="c">C</code> strife<br>
+The <code class="g">G</code> sunny side we also may <code class="c">C</code> view</p>
+</div></section>
+<section id="chorus-25" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Keep on the sunny side <code
-class="f">F</code><br />
-always on the <code class="c">C</code> sunny side<br />
-Keep on the sunny side of <code class="g">G</code> life<br />
-<code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+<p><code class="c">C</code> Keep on the sunny side <code class="f">F</code><br>
+always on the <code class="c">C</code> sunny side<br>
+Keep on the sunny side of <code class="g">G</code> life<br>
+<code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
-</section>
-<section id="verse-2-18" class="slide level2">
+</div></section>
+<section id="verse-2-18" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Well the <code class="c">C</code> storm and its <code
-class="f">F</code> fury broke to<code class="c">C</code>day<br />
-Crushing <code class="c">C</code> hopes that we cherish so <code
-class="g">G</code> dear<br />
-Clouds and <code class="g">G7</code> storms will, in time, pass a<code
-class="c">C</code>way<br />
-The <code class="g">G7</code> sun again will shine bright and <code
-class="c">C</code> clear</p>
-</section>
-<section id="chorus-26" class="slide level2">
+<p>Well the <code class="c">C</code> storm and its <code class="f">F</code> fury broke to<code class="c">C</code>day<br>
+Crushing <code class="c">C</code> hopes that we cherish so <code class="g">G</code> dear<br>
+Clouds and <code class="g">G7</code> storms will, in time, pass a<code class="c">C</code>way<br>
+The <code class="g">G7</code> sun again will shine bright and <code class="c">C</code> clear</p>
+</div></section>
+<section id="chorus-26" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Keep on the sunny side<br />
+<p><code class="c">C</code> Keep on the sunny side<br>
 <code class="f">F</code> always on the <code class="c">C</code> sunny
-side<br />
-Keep on the sunny side of <code class="g">G</code> life<br />
-<code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+side<br>
+Keep on the sunny side of <code class="g">G</code> life<br>
+<code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
-</section>
-<section id="interlude-2" class="slide level2">
+</div></section>
+<section id="interlude-2" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code><br />
-<code class="c">C</code> <code class="g">G</code><br />
-<code class="g">G7</code> <code class="c">C</code><br />
+<p><code class="c">C</code> <code class="f">F</code> <code class="c">C</code><br>
+<code class="c">C</code> <code class="g">G</code><br>
+<code class="g">G7</code> <code class="c">C</code><br>
 <code class="g">G</code> <code class="c">C</code></p>
-</section>
-<section id="verse-3-12" class="slide level2">
+</div></section>
+<section id="verse-3-12" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p>Let us <code class="c">C</code> greet with a <code class="f">F</code>
-song of hope each <code class="c">C</code> day<br />
-Thou the <code class="c">C</code> moment be cloudy or <code
-class="g">G</code> fair<br />
-Let us <code class="g">G7</code> trust in our Saviour al<code
-class="c">C</code>ways<br />
-Who <code class="g">G7</code> keepeth everyone in His <code
-class="c">C</code> care</p>
-</section>
-<section id="chorus-27" class="slide level2">
+song of hope each <code class="c">C</code> day<br>
+Thou the <code class="c">C</code> moment be cloudy or <code class="g">G</code> fair<br>
+Let us <code class="g">G7</code> trust in our Saviour al<code class="c">C</code>ways<br>
+Who <code class="g">G7</code> keepeth everyone in His <code class="c">C</code> care</p>
+</div></section>
+<section id="chorus-27" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Keep on the sunny side<br />
+<p><code class="c">C</code> Keep on the sunny side<br>
 <code class="f">F</code> always on the <code class="c">C</code> sunny
-side<br />
-Keep on the sunny side of <code class="g">G</code> life<br />
-<code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+side<br>
+Keep on the sunny side of <code class="g">G</code> life<br>
+<code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
 <p><em>(Repeat)</em></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><em>(Fade out</em></p>
-<p><code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+<p><code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
-</section>
-<section id="resources-19" class="slide level2">
+</div></section>
+<section id="resources-19" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=ZbmQQ4RfzVE">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/the-carter-family/keep-on-the-sunny-side-chords-1431252">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/the-carter-family/keep-on-the-sunny-side-chords-1431252">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=O2j6cZlT2LI">Guitar
 tutorial</a></li>
 <li><a href="https://www.youtube.com/watch?v=8joVnqleS9Q">Interpretation
 by The Whites</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="lemon-tree-fools-garden" class="title-slide slide level1">
+<section id="lemon-tree-fools-garden" class="title-slide slide level1"><div class="slide-content">
 <h1>Lemon tree (Fool’s Garden)</h1>
 
-</section>
-<section id="instructions-4" class="slide level2">
+</div></section>
+<section id="instructions-4" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <p>Capo on 2nd fret</p>
 <pre><code>    |E A D G B e|
     |-----------|
 Bb  |x 1 3 3 3 1|</code></pre>
-</section>
-<section id="intro-14" class="slide level2">
+</div></section>
+<section id="intro-14" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Barre chords)</em></p>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code><br />
-<code class="g">Gm</code> <code class="a">Am</code> <code
-class="d">Dm</code></p>
-</section>
-<section id="verse-1-19" class="slide level2">
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code><br>
+<code class="g">Gm</code> <code class="a">Am</code> <code class="d">Dm</code></p>
+</div></section>
+<section id="verse-1-19" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> sitting here in a <code
-class="a">Am</code> boring room<br />
-It’s <code class="d">Dm</code> just another rainy sunday <code
-class="a">Am</code> afternoon<br />
-I’m <code class="d">Dm</code> wasting my time I got <code
-class="a">Am</code> nothing to do<br />
-I’m <code class="g">Gm</code> hanging around I’m <code
-class="a">Am</code> waiting for you</p>
-<p>But <code class="g">Gm</code> nothing ever happens <code
-class="a">Am</code><br />
+<p>I’m <code class="d">Dm</code> sitting here in a <code class="a">Am</code> boring room<br>
+It’s <code class="d">Dm</code> just another rainy sunday <code class="a">Am</code> afternoon<br>
+I’m <code class="d">Dm</code> wasting my time I got <code class="a">Am</code> nothing to do<br>
+I’m <code class="g">Gm</code> hanging around I’m <code class="a">Am</code> waiting for you</p>
+<p>But <code class="g">Gm</code> nothing ever happens <code class="a">Am</code><br>
 and I won<code class="d">Dm</code>der</p>
-</section>
-<section id="verse-2-19" class="slide level2">
+</div></section>
+<section id="verse-2-19" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> driving around <code
-class="a">Am</code> in my car<br />
-I’m <code class="d">Dm</code> driving too fast I’m <code
-class="a">Am</code> driving too far<br />
-I’d <code class="d">Dm</code> like to change my <code
-class="a">Am</code> point of view<br />
+<p>I’m <code class="d">Dm</code> driving around <code class="a">Am</code> in my car<br>
+I’m <code class="d">Dm</code> driving too fast I’m <code class="a">Am</code> driving too far<br>
+I’d <code class="d">Dm</code> like to change my <code class="a">Am</code> point of view<br>
 I <code class="g">Gm</code> feel so lonely I’m <code class="a">Am</code>
 waiting for you</p>
-<p>But <code class="g">Gm</code> nothing ever happens <code
-class="a">Am</code><br />
+<p>But <code class="g">Gm</code> nothing ever happens <code class="a">Am</code><br>
 and I won<code class="d">Dm</code>der</p>
-</section>
-<section id="chorus-28" class="slide level2">
+</div></section>
+<section id="chorus-28" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><em>(Open chords)</em></p>
 <p>I <code class="f">F</code> wonder how I <code class="c">C</code>
-wonder why<br />
-<code class="d">Dm</code> Yesterday you told me<br />
+wonder why<br>
+<code class="d">Dm</code> Yesterday you told me<br>
 ’bout the <code class="a">Am</code> blue blue sky</p>
-<p>And all <code class="b">Bb</code> that I can see <code
-class="c">C</code><br />
-Is just a yellow <code class="f">F</code> lemon tree <code
-class="c">C</code></p>
-</section>
-<section class="slide level2">
+<p>And all <code class="b">Bb</code> that I can see <code class="c">C</code><br>
+Is just a yellow <code class="f">F</code> lemon tree <code class="c">C</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>I’m <code class="f">F</code> turning my head <code class="c">C</code>
-up and down<br />
-I’m <code class="d">Dm</code> turning turning turning<br />
+up and down<br>
+I’m <code class="d">Dm</code> turning turning turning<br>
 turning <code class="a">Am</code> turning around</p>
-<p>And <code class="b">Bb</code> all that I can <code
-class="g">G7</code><br />
+<p>And <code class="b">Bb</code> all that I can <code class="g">G7</code><br>
 see is just a yellow <code class="c">C</code> lemon tree</p>
-</section>
-<section id="bridge-1-1" class="slide level2">
+</div></section>
+<section id="bridge-1-1" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
 <p><em>(Barre chords)</em></p>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code><br />
-<code class="g">Gm</code> <code class="a">Am</code> <code
-class="d">Dm</code><br />
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code><br>
+<code class="g">Gm</code> <code class="a">Am</code> <code class="d">Dm</code><br>
 Da da da…</p>
-</section>
-<section id="verse-3-13" class="slide level2">
+</div></section>
+<section id="verse-3-13" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> sitting here I <code
-class="a">Am</code> miss the power<br />
+<p>I’m <code class="d">Dm</code> sitting here I <code class="a">Am</code> miss the power<br>
 I’d <code class="d">Dm</code> like to go out <code class="a">Am</code>
-taking a shower<br />
-But <code class="d">Dm</code> there’s a heavy cloud in<code
-class="a">Am</code>side my head<br />
-I <code class="g">Gm</code> feel so tired put my<code
-class="a">Am</code>self into bed</p>
-<p>Where <code class="g">Gm</code> nothing ever happens <code
-class="a">Am</code><br />
+taking a shower<br>
+But <code class="d">Dm</code> there’s a heavy cloud in<code class="a">Am</code>side my head<br>
+I <code class="g">Gm</code> feel so tired put my<code class="a">Am</code>self into bed</p>
+<p>Where <code class="g">Gm</code> nothing ever happens <code class="a">Am</code><br>
 and I won<code class="d">Dm</code>der</p>
-</section>
-<section id="bridge-2-1" class="slide level2">
+</div></section>
+<section id="bridge-2-1" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
 <p><em>(Open chords)</em></p>
 <p><code class="a">A7</code> Isolation <code class="d">Dm</code> is not
-good for me<br />
+good for me<br>
 <code class="c">C7</code> Isolation - <code class="f">F</code> I don’t
-want to<br />
+want to<br>
 <code class="a">A7</code> sit on a lemon tree</p>
-</section>
-<section id="verse-4-8" class="slide level2">
+</div></section>
+<section id="verse-4-8" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> steppin’ around in a <code
-class="a">Am</code> desert of joy<br />
-<code class="d">Dm</code> Baby anyhow I’ll get an<code
-class="a">Am</code>other toy</p>
-<p>And <code class="g">Gm</code> everything will happen<br />
+<p>I’m <code class="d">Dm</code> steppin’ around in a <code class="a">Am</code> desert of joy<br>
+<code class="d">Dm</code> Baby anyhow I’ll get an<code class="a">Am</code>other toy</p>
+<p>And <code class="g">Gm</code> everything will happen<br>
 <code class="a">Am</code> and you’ll won<code class="d">Dm</code>der</p>
-</section>
-<section id="chorus-29" class="slide level2">
+</div></section>
+<section id="chorus-29" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><em>(Open chords)</em></p>
 <p>I <code class="f">F</code> wonder how I <code class="c">C</code>
-wonder why<br />
-<code class="d">Dm</code> Yesterday you told me<br />
+wonder why<br>
+<code class="d">Dm</code> Yesterday you told me<br>
 ’bout the <code class="a">Am</code> blue blue sky</p>
-<p>And all <code class="b">Bb</code> that I can see <code
-class="c">C</code><br />
-Is just a yellow <code class="f">F</code> lemon tree <code
-class="c">C</code></p>
-</section>
-<section class="slide level2">
+<p>And all <code class="b">Bb</code> that I can see <code class="c">C</code><br>
+Is just a yellow <code class="f">F</code> lemon tree <code class="c">C</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>I’m <code class="f">F</code> turning my head <code class="c">C</code>
-up and down<br />
-I’m <code class="d">Dm</code> turning turning turning<br />
+up and down<br>
+I’m <code class="d">Dm</code> turning turning turning<br>
 turning <code class="a">Am</code> turning around</p>
-<p>And <code class="b">Bb</code> all that I can <code
-class="g">G7</code><br />
+<p>And <code class="b">Bb</code> all that I can <code class="g">G7</code><br>
 see is just a yellow <code class="c">C</code> lemon tree</p>
 <p>And I wonder I wonder</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>I <code class="f">F</code> wonder how I <code class="c">C</code>
-wonder why<br />
-<code class="d">Dm</code> Yesterday you told me<br />
+wonder why<br>
+<code class="d">Dm</code> Yesterday you told me<br>
 ’bout the <code class="a">Am</code> blue blue sky</p>
-<p>And all <code class="b">Bb</code> that I can see <code
-class="c">C</code> <em>(3x)</em><br />
+<p>And all <code class="b">Bb</code> that I can see <code class="c">C</code> <em>(3x)</em><br>
 Is just a yellow <code class="f">F</code> lemon tree</p>
-</section>
-<section id="resources-20" class="slide level2">
+</div></section>
+<section id="resources-20" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=wCQfkEkePx8">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/user/tab/view?h=_5ECoKMMKHZmcTbZHfp9P2JQ&amp;tab_id=27297698">Source
+<li><a href="https://tabs.ultimate-guitar.com/user/tab/view?h=_5ECoKMMKHZmcTbZHfp9P2JQ&amp;tab_id=27297698">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=Yv-AsMzWaV0">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="morning-has-broken-cat-stevens"
-class="title-slide slide level1">
+<section id="morning-has-broken-cat-stevens" class="title-slide slide level1"><div class="slide-content">
 <h1>Morning has broken (Cat Stevens)</h1>
 
-</section>
-<section id="instructions-5" class="slide level2">
+</div></section>
+<section id="instructions-5" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>       |E A D G B e|
        |-----------|
@@ -3050,607 +2672,524 @@ D7sus4 |x x 0 2 1 3|
 F#     |2=4=4=3=2=2|
 F#m    |2=4=4=2=2=2|
 G7sus4 |x x 0 0 1 1|</code></pre>
-</section>
-<section id="intro-15" class="slide level2">
+</div></section>
+<section id="intro-15" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="d">D</code> <code class="g">G</code> <code
-class="a">A</code> <code class="f">F#</code> <code
-class="b">Bm</code><br />
-<code class="g">G7</code> <code class="c">C</code> <code
-class="f">F</code> <code class="c">C</code></p>
-</section>
-<section id="verse-1-20" class="slide level2">
+<p><code class="d">D</code> <code class="g">G</code> <code class="a">A</code> <code class="f">F#</code> <code class="b">Bm</code><br>
+<code class="g">G7</code> <code class="c">C</code> <code class="f">F</code> <code class="c">C</code></p>
+</div></section>
+<section id="verse-1-20" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Morning has <code class="c">C</code>brok<code
-class="d">Dm</code>en<br />
+<p>Morning has <code class="c">C</code>brok<code class="d">Dm</code>en<br>
 <code class="g">G</code> like the first <code class="f">F</code>
-morn<code class="c">C</code>ing<br />
+morn<code class="c">C</code>ing<br>
 <code class="c">C</code> Blackbird has <code class="e">Em</code>
-spok<code class="a">Am</code>en<br />
+spok<code class="a">Am</code>en<br>
 <code class="d">D7sus4</code> like the first <code class="g">G</code>
 bird</p>
 <p><code class="c">C</code> Praise for the <code class="f">F</code>
-singing<br />
+singing<br>
 <code class="c">C</code> praise for the <code class="a">Am</code>
-morn<code class="d">D</code>ing<br />
+morn<code class="d">D</code>ing<br>
 <code class="g">G</code> Praise for them <code class="c">C</code>
-spring<code class="f">F</code>ing<br />
+spring<code class="f">F</code>ing<br>
 <code class="g">G7</code> fresh from the <code class="c">C</code>
 world</p>
-</section>
-<section id="instrumental-1" class="slide level2">
+</div></section>
+<section id="instrumental-1" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="e">E</code> <code class="a">Am</code><br />
-<code class="g">G7</code> <code class="c">C</code> <code
-class="g">G7sus4</code></p>
-</section>
-<section id="verse-2-20" class="slide level2">
+<p><code class="f">F</code> <code class="g">G</code> <code class="e">E</code> <code class="a">Am</code><br>
+<code class="g">G7</code> <code class="c">C</code> <code class="g">G7sus4</code></p>
+</div></section>
+<section id="verse-2-20" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Sweet the rain’s <code class="c">C</code> new <code
-class="d">Dm</code> fall<br />
-<code class="g">G</code> sunlit from <code class="f">F</code> heav<code
-class="c">C</code>en<br />
+<p>Sweet the rain’s <code class="c">C</code> new <code class="d">Dm</code> fall<br>
+<code class="g">G</code> sunlit from <code class="f">F</code> heav<code class="c">C</code>en<br>
 <code class="c">C</code> Like the first <code class="e">Em</code> dew
-<code class="a">Am</code> fall<br />
+<code class="a">Am</code> fall<br>
 <code class="d">D7sus4</code> on the first <code class="g">G</code>
 grass</p>
 <p><code class="c">C</code> Praise for the <code class="f">F</code>
-sweetness<br />
-<code class="c">C</code> of the wet <code class="a">Am</code> gard<code
-class="d">D</code>en<br />
-<code class="g">G</code> Sprung in comp<code class="c">C</code>lete<code
-class="f">F</code>ness<br />
+sweetness<br>
+<code class="c">C</code> of the wet <code class="a">Am</code> gard<code class="d">D</code>en<br>
+<code class="g">G</code> Sprung in comp<code class="c">C</code>lete<code class="f">F</code>ness<br>
 <code class="g">G7</code> where his feet <code class="c">C</code>
 pass</p>
-</section>
-<section id="instrumental-2" class="slide level2">
+</div></section>
+<section id="instrumental-2" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="e">E</code> <code class="a">Am</code><br />
-<code class="f">F#</code> <code class="b">Bm</code> <code
-class="g">G</code> <code class="d">D</code><br />
+<p><code class="f">F</code> <code class="g">G</code> <code class="e">E</code> <code class="a">Am</code><br>
+<code class="f">F#</code> <code class="b">Bm</code> <code class="g">G</code> <code class="d">D</code><br>
 <code class="a">A7/D</code> <code class="d">D</code></p>
-</section>
-<section id="verse-3-14" class="slide level2">
+</div></section>
+<section id="verse-3-14" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Mine is the <code class="d">D</code> sun<code
-class="e">Em</code>light<br />
-<code class="a">A</code> mine is the <code class="g">G</code> morn<code
-class="d">D</code>ing<br />
+<p>Mine is the <code class="d">D</code> sun<code class="e">Em</code>light<br>
+<code class="a">A</code> mine is the <code class="g">G</code> morn<code class="d">D</code>ing<br>
 Born of the <code class="f">F#m</code> one <code class="b">Bm</code>
-light<br />
-<code class="e">E7</code> Eden saw <code class="a">A</code> play <code
-class="a">A7</code></p>
-<p><code class="d">D</code> Praise with el<code
-class="g">G</code>ation<br />
+light<br>
+<code class="e">E7</code> Eden saw <code class="a">A</code> play <code class="a">A7</code></p>
+<p><code class="d">D</code> Praise with el<code class="g">G</code>ation<br>
 <code class="d">D</code> praise every <code class="b">Bm</code>
-morn<code class="e">E</code>ing<br />
-<code class="a">A</code> God’s recre<code class="d">D</code>a<code
-class="g">G</code>tion<br />
+morn<code class="e">E</code>ing<br>
+<code class="a">A</code> God’s recre<code class="d">D</code>a<code class="g">G</code>tion<br>
 <code class="a">A7</code> of the new <code class="d">D</code> day</p>
-</section>
-<section id="instrumental-3" class="slide level2">
+</div></section>
+<section id="instrumental-3" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="g">G</code> <code class="a">A</code> <code
-class="f">F#</code> <code class="b">Bm</code><br />
-<code class="g">G7</code> <code class="c">C</code> <code
-class="f">F</code> <code class="c">C</code></p>
-</section>
-<section id="verse-1-21" class="slide level2">
+<p><code class="g">G</code> <code class="a">A</code> <code class="f">F#</code> <code class="b">Bm</code><br>
+<code class="g">G7</code> <code class="c">C</code> <code class="f">F</code> <code class="c">C</code></p>
+</div></section>
+<section id="verse-1-21" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Morning has <code class="c">C</code>brok<code
-class="d">Dm</code>en<br />
+<p>Morning has <code class="c">C</code>brok<code class="d">Dm</code>en<br>
 <code class="g">G</code> like the first <code class="f">F</code>
-morn<code class="c">C</code>ing<br />
+morn<code class="c">C</code>ing<br>
 <code class="c">C</code> Blackbird has <code class="e">Em</code>
-spok<code class="a">Am</code>en<br />
+spok<code class="a">Am</code>en<br>
 <code class="d">D7sus4</code> like the first <code class="g">G</code>
 bird</p>
 <p><code class="c">C</code> Praise for the <code class="f">F</code>
-singing<br />
+singing<br>
 <code class="c">C</code> praise for the <code class="a">Am</code>
-morn<code class="d">D</code>ing<br />
+morn<code class="d">D</code>ing<br>
 <code class="g">G</code> Praise for them <code class="c">C</code>
-spring<code class="f">F</code>ing<br />
+spring<code class="f">F</code>ing<br>
 <code class="g">G7</code> fresh from the <code class="c">C</code>
 world</p>
-</section>
-<section id="outro-3" class="slide level2">
+</div></section>
+<section id="outro-3" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="e">E</code> <code class="a">Am</code><br />
-<code class="f">F#</code> <code class="b">Bm</code> <code
-class="g">G</code> <code class="d">D</code><br />
+<p><code class="f">F</code> <code class="g">G</code> <code class="e">E</code> <code class="a">Am</code><br>
+<code class="f">F#</code> <code class="b">Bm</code> <code class="g">G</code> <code class="d">D</code><br>
 <code class="a">A7/D</code> <code class="d">D</code></p>
-</section>
-<section id="resources-21" class="slide level2">
+</div></section>
+<section id="resources-21" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=uZAsfB1Np-8">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/cat-stevens/morning-has-broken-chords-84520">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/cat-stevens/morning-has-broken-chords-84520">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=eyRVPNenXlg">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="männer-sind-schweine-die-ärzte"
-class="title-slide slide level1">
+<section id="männer-sind-schweine-die-ärzte" class="title-slide slide level1"><div class="slide-content">
 <h1>Männer sind Schweine (Die Ärzte)</h1>
 
-</section>
-<section id="verse-1-22" class="slide level2">
+</div></section>
+<section id="verse-1-22" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Hal<code class="g">G</code>lo, mein Schatz, ich liebe Dich,<br />
-Du <code class="e">Em</code> bist die einzige für mich.<br />
-Die <code class="c">C</code> andern find’ ich alle doof,<br />
+<p>Hal<code class="g">G</code>lo, mein Schatz, ich liebe Dich,<br>
+Du <code class="e">Em</code> bist die einzige für mich.<br>
+Die <code class="c">C</code> andern find’ ich alle doof,<br>
 Des<code class="d">D</code>wegen mach ich Dir den Hof.</p>
-<p>Du <code class="g">G</code> bist so anders, ganz speziell,<br />
-Ich <code class="e">Em</code> merke sowas immer schnell.<br />
-Jetzt <code class="c">C</code> zieh Dich aus und leg Dich hin,<br />
+<p>Du <code class="g">G</code> bist so anders, ganz speziell,<br>
+Ich <code class="e">Em</code> merke sowas immer schnell.<br>
+Jetzt <code class="c">C</code> zieh Dich aus und leg Dich hin,<br>
 Weil <code class="d">D</code> ich so verliebt in Dich bin.</p>
-</section>
-<section id="bridge-1-2" class="slide level2">
+</div></section>
+<section id="bridge-1-2" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
-<p><code class="c">C</code> Gleich wird es dunkel, <code
-class="b">Bm</code> bald ist es Nacht,<br />
-Da <code class="c">C</code> ist ein Wort der Warnung angebracht! <code
-class="d">D</code></p>
-</section>
-<section id="chorus-1-6" class="slide level2">
+<p><code class="c">C</code> Gleich wird es dunkel, <code class="b">Bm</code> bald ist es Nacht,<br>
+Da <code class="c">C</code> ist ein Wort der Warnung angebracht! <code class="d">D</code></p>
+</div></section>
+<section id="chorus-1-6" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br />
-Sie wollen <code class="a">Am</code> alle das eine!<br />
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br>
+Sie wollen <code class="a">Am</code> alle das eine!<br>
 Weil <code class="c">C</code> Männer nun mal so <code class="d">D</code>
 sind.</p>
-</section>
-<section id="verse-2-21" class="slide level2">
+</div></section>
+<section id="verse-2-21" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>Ein <code class="g">G</code> Mann fühlt sich erst dann als
-Mann,<br />
-Wenn <code class="e">Em</code> er es Dir besorgen kann.<br />
-Er <code class="c">C</code> lügt, dass sich die Balken biegen.<br />
+Mann,<br>
+Wenn <code class="e">Em</code> er es Dir besorgen kann.<br>
+Er <code class="c">C</code> lügt, dass sich die Balken biegen.<br>
 <code class="d">D</code> Nur, um Dich ins Bett zu kriegen.</p>
-<p>Und <code class="g">G</code> dann am nächsten Morgen weiss er<br />
-<code class="e">Em</code> Nicht einmal mehr, wie Du heisst.<br />
-<code class="c">C</code> Rücksichtslos und ungehemmt,<br />
+<p>Und <code class="g">G</code> dann am nächsten Morgen weiss er<br>
+<code class="e">Em</code> Nicht einmal mehr, wie Du heisst.<br>
+<code class="c">C</code> Rücksichtslos und ungehemmt,<br>
 Ge<code class="d">D</code>fühle sind ihm völlig fremd.</p>
-</section>
-<section id="bridge-2-2" class="slide level2">
+</div></section>
+<section id="bridge-2-2" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
-<p><code class="c">C</code> Für ihn ist Liebe gleich <code
-class="b">Bm</code> Samenverlust,<br />
-<code class="c">C</code> Mädchen, sei Dir dessen stets bewusst! <code
-class="d">D</code></p>
-</section>
-<section id="chorus-2-6" class="slide level2">
+<p><code class="c">C</code> Für ihn ist Liebe gleich <code class="b">Bm</code> Samenverlust,<br>
+<code class="c">C</code> Mädchen, sei Dir dessen stets bewusst! <code class="d">D</code></p>
+</div></section>
+<section id="chorus-2-6" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Frage nicht nach <code class="e">Em</code> Sonnenschein.<br />
-Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br />
-In jedem <code class="c">C</code> Mann steckt auch<br />
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Frage nicht nach <code class="e">Em</code> Sonnenschein.<br>
+Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br>
+In jedem <code class="c">C</code> Mann steckt auch<br>
 immer ein <code class="d">D</code> Schwein!</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Säue!<br />
-Glaube ihnen <code class="e">Em</code> nicht ein Wort!<br />
-Sie schwör’n Dir <code class="a">Am</code> ewige Treue<br />
-Und dann am <code class="c">C</code> nächsten Morgen<br />
+<p>Männer sind <code class="g">G</code> Säue!<br>
+Glaube ihnen <code class="e">Em</code> nicht ein Wort!<br>
+Sie schwör’n Dir <code class="a">Am</code> ewige Treue<br>
+Und dann am <code class="c">C</code> nächsten Morgen<br>
 sind sie fort. <code class="d">D</code></p>
-</section>
-<section id="verse-3-15" class="slide level2">
+</div></section>
+<section id="verse-3-15" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Und <code class="g">G</code> falls Du doch den Fehler machst<br />
-Und <code class="e">Em</code> Dir ’nen Ehemann anlachst.<br />
-Mu<code class="c">C</code>tiert dein Rosenkavalier<br />
+<p>Und <code class="g">G</code> falls Du doch den Fehler machst<br>
+Und <code class="e">Em</code> Dir ’nen Ehemann anlachst.<br>
+Mu<code class="c">C</code>tiert dein Rosenkavalier<br>
 Bald <code class="d">D</code> nach der Hochzeit auch zum Tier.</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Da <code class="g">G</code> zeigt er dann sein wahres Ich,<br />
-Ganz <code class="e">Em</code> unrasiert und widerlich.<br />
+<p>Da <code class="g">G</code> zeigt er dann sein wahres Ich,<br>
+Ganz <code class="e">Em</code> unrasiert und widerlich.<br>
 Trinkt <code class="c">C</code> Bier, sieht fern und wird schnell
-fett.<br />
+fett.<br>
 Und <code class="d">D</code> rülpst und furzt im Ehebett.</p>
-</section>
-<section id="bridge-3-1" class="slide level2">
+</div></section>
+<section id="bridge-3-1" class="slide level2"><div class="slide-content">
 <h2>Bridge 3</h2>
-<p><code class="c">C</code> Dann hast du King Kong <code
-class="b">Bm</code> zum Ehemann!<br />
+<p><code class="c">C</code> Dann hast du King Kong <code class="b">Bm</code> zum Ehemann!<br>
 Drum <code class="c">C</code> sag’ ich Dir - denk bitte stets daran:
 <code class="d">D</code></p>
-</section>
-<section id="chorus-4-1" class="slide level2">
+</div></section>
+<section id="chorus-4-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 4</h2>
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br />
-Sie wollen <code class="a">Am</code> alle das eine!<br />
-Für wahre <code class="c">C</code> Liebe sind sie blind <code
-class="d">D</code>.</p>
-</section>
-<section class="slide level2">
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br>
+Sie wollen <code class="a">Am</code> alle das eine!<br>
+Für wahre <code class="c">C</code> Liebe sind sie blind <code class="d">D</code>.</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Ratten<br />
-Begegne ihnen <code class="e">Em</code> nur mit List<br />
-Sie wollen <code class="a">Am</code> alles begatten<br />
-Was nicht bei <code class="c">C</code> drei auf den Bäumen ist <code
-class="d">D</code></p>
-</section>
-<section class="slide level2">
+<p>Männer sind <code class="g">G</code> Ratten<br>
+Begegne ihnen <code class="e">Em</code> nur mit List<br>
+Sie wollen <code class="a">Am</code> alles begatten<br>
+Was nicht bei <code class="c">C</code> drei auf den Bäumen ist <code class="d">D</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Frage nicht nach <code class="e">Em</code> Sonnenschein.<br />
-Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br />
-In jedem <code class="c">C</code> Mann steckt auch immer ein <code
-class="d">D</code> Schwein!</p>
-</section>
-<section class="slide level2">
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Frage nicht nach <code class="e">Em</code> Sonnenschein.<br>
+Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br>
+In jedem <code class="c">C</code> Mann steckt auch immer ein <code class="d">D</code> Schwein!</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Autos<br />
-Nur ohne Re<code class="e">Em</code>serverad<br />
-Yeah, yeah, yeah, yeaääääää <code class="a">Am</code><br />
+<p>Männer sind <code class="g">G</code> Autos<br>
+Nur ohne Re<code class="e">Em</code>serverad<br>
+Yeah, yeah, yeah, yeaääääää <code class="a">Am</code><br>
 <code class="c">C</code> Uh-hu, uh-hu <code class="d">D</code></p>
-</section>
-<section id="resources-22" class="slide level2">
+</div></section>
+<section id="resources-22" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=404oPn6tudE">Song</a></li>
 <li><a href="https://tabs.ultimate-guitar.com/tab/568214">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="no-woman-no-cry-bob-marley"
-class="title-slide slide level1">
+<section id="no-woman-no-cry-bob-marley" class="title-slide slide level1"><div class="slide-content">
 <h1>No woman no cry (Bob Marley)</h1>
 
-</section>
-<section id="intro-16" class="slide level2">
+</div></section>
+<section id="intro-16" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="g">G/B</code> <code
-class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="chorus-30" class="slide level2">
+<p><code class="c">C</code> <code class="g">G/B</code> <code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> <code class="f">F</code> <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="chorus-30" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> No <code class="g">G/B</code> woman no cry
-<code class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
+<code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="verse-1-23" class="slide level2">
+</div></section>
+<section id="verse-1-23" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Said said<br />
-<code class="c">C</code> said I re<code class="g">G/B</code>member<br />
-<code class="a">Am</code> when we used to sit <code
-class="f">F</code><br />
+<p>Said said<br>
+<code class="c">C</code> said I re<code class="g">G/B</code>member<br>
+<code class="a">Am</code> when we used to sit <code class="f">F</code><br>
 <code class="c">C</code> In the govern<code class="g">G/B</code>ment
-yard<br />
+yard<br>
 in <code class="a">Am</code> trenchtown <code class="f">F</code></p>
 <p><code class="c">C</code> Oba-oba<code class="g">G/B</code>serving the
-<code class="a">Am</code> hypo<code class="f">F</code>crites<br />
-As they would <code class="c">C</code> mingle<br />
-with the good <code class="g">G/B</code> people we meet <code
-class="a">Am</code> <code class="f">F</code></p>
-</section>
-<section class="slide level2">
+<code class="a">Am</code> hypo<code class="f">F</code>crites<br>
+As they would <code class="c">C</code> mingle<br>
+with the good <code class="g">G/B</code> people we meet <code class="a">Am</code> <code class="f">F</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="c">C</code> good friends <code class="g">G/B</code> we
-had oh<br />
-<code class="a">Am</code> good friend we lost <code
-class="f">F</code><br />
-<code class="c">C</code> along <code class="g">G/B</code> the way <code
-class="a">Am</code> <code class="f">F</code></p>
+had oh<br>
+<code class="a">Am</code> good friend we lost <code class="f">F</code><br>
+<code class="c">C</code> along <code class="g">G/B</code> the way <code class="a">Am</code> <code class="f">F</code></p>
 <p><code class="c">C</code> In this bright <code class="g">G/B</code>
-future<br />
-you <code class="a">Am</code> cant forget your past <code
-class="f">F</code><br />
+future<br>
+you <code class="a">Am</code> cant forget your past <code class="f">F</code><br>
 <code class="c">C</code> So dry your tears <code class="g">G/B</code> I
 say <code class="a">Am</code> <code class="f">F</code></p>
-</section>
-<section id="chorus-31" class="slide level2">
+</div></section>
+<section id="chorus-31" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> No <code class="g">G/B</code> woman no cry
-<code class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-<p><del>No woman no cry</del><br />
+<code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+<p><del>No woman no cry</del><br>
 <strong><code class="c">C</code> Here <code class="g">G/B</code> little
-darlin’</strong><br />
+darlin’</strong><br>
 <strong><code class="a">Am</code> don’t shed no <code class="f">F</code>
-tears</strong><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="verse-1-24" class="slide level2">
+tears</strong><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-1-24" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Said said<br />
-<code class="c">C</code> said I re<code class="g">G/B</code>member<br />
-<code class="a">Am</code> when we used to sit <code
-class="f">F</code><br />
+<p>Said said<br>
+<code class="c">C</code> said I re<code class="g">G/B</code>member<br>
+<code class="a">Am</code> when we used to sit <code class="f">F</code><br>
 <code class="c">C</code> In the govern<code class="g">G/B</code>ment
-yard<br />
+yard<br>
 in <code class="a">Am</code> trenchtown <code class="f">F</code></p>
 <p><code class="c">C</code> And then <code class="g">G/B</code>
-Georgie<br />
-would <code class="a">Am</code> make a fire light <code
-class="f">F</code><br />
+Georgie<br>
+would <code class="a">Am</code> make a fire light <code class="f">F</code><br>
 as it was <code class="c">C</code> log wood <code class="g">G/B</code>
-burnin<br />
-through the nights <code class="a">Am</code> <code
-class="f">F</code></p>
-</section>
-<section class="slide level2">
+burnin<br>
+through the nights <code class="a">Am</code> <code class="f">F</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="c">C</code> Then we <code class="g">G/B</code> would
-cook<br />
-corn <code class="a">Am</code> meal porridge <code
-class="f">F</code><br />
+cook<br>
+corn <code class="a">Am</code> meal porridge <code class="f">F</code><br>
 <code class="c">C</code> of which I’ll <code class="g">G/B</code>
-share<br />
+share<br>
 with you <code class="a">Am</code> yeah <code class="f">F</code></p>
 <p><code class="c">C</code> My feet <code class="g">G/B</code> is my
-<code class="a">Am</code> only carriage <code class="f">F</code><br />
+<code class="a">Am</code> only carriage <code class="f">F</code><br>
 <code class="c">C</code> and so I’ve got <code class="g">G/B</code>
-to<br />
-push on through <code class="a">Am</code><br />
+to<br>
+push on through <code class="a">Am</code><br>
 But while I’m <code class="f">F</code> gone</p>
-</section>
-<section id="bridge-4" class="slide level2">
+</div></section>
+<section id="bridge-4" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p><code class="c">C</code> Everything’s gonna <code
-class="g">G/B</code> be alright<br />
+<p><code class="c">C</code> Everything’s gonna <code class="g">G/B</code> be alright<br>
 <code class="a">Am</code> Everything’s gonna <code class="f">F</code> be
 alright</p>
 <p><em>(x4)</em></p>
-</section>
-<section id="chorus-32" class="slide level2">
+</div></section>
+<section id="chorus-32" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> No <code class="g">G/B</code> woman no cry
-<code class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-<p><del>No woman no cry</del><br />
+<code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+<p><del>No woman no cry</del><br>
 <strong><code class="c">C</code> Here <code class="g">G/B</code> little
-darlin’</strong><br />
+darlin’</strong><br>
 <strong><code class="a">Am</code> don’t shed no <code class="f">F</code>
-tears</strong><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="outro-4" class="slide level2">
+tears</strong><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="outro-4" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="g">G/B</code> <code
-class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code> <code class="g">G</code></p>
+<p><code class="c">C</code> <code class="g">G/B</code> <code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> <code class="f">F</code> <code class="c">C</code> <code class="g">G</code></p>
 <p><em>(Repeat and fade)</em></p>
-</section>
-<section id="resources-23" class="slide level2">
+</div></section>
+<section id="resources-23" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=aEtfgfv5iN4">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/bob-marley/no-woman-no-cry-chords-45479">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/bob-marley/no-woman-no-cry-chords-45479">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=7lasK3XSICc">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="one-u2" class="title-slide slide level1">
+<section id="one-u2" class="title-slide slide level1"><div class="slide-content">
 <h1>One (U2)</h1>
 
-</section>
-<section id="intro-17" class="slide level2">
+</div></section>
+<section id="intro-17" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="d">Dsus2</code> <code
-class="f">FM7</code> <code class="g">G</code> <em>(x4)</em></p>
-</section>
-<section id="verse-1-25" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dsus2</code> <code class="f">FM7</code> <code class="g">G</code> <em>(x4)</em></p>
+</div></section>
+<section id="verse-1-25" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><code class="a">Am</code> Is it getting <code class="d">Dsus2</code>
-better?<br />
+better?<br>
 <code class="f">FM7</code> Or do you feel the <code class="g">G</code>
-same?<br />
+same?<br>
 <code class="a">Am</code> Will it make it <code class="d">Dsus2</code>
-easier on you?<br />
-Now <code class="f">FM7</code> you got someone to <code
-class="g">G</code> blame</p>
+easier on you?<br>
+Now <code class="f">FM7</code> you got someone to <code class="g">G</code> blame</p>
 <p>You say</p>
-</section>
-<section id="chorus-1-7" class="slide level2">
+</div></section>
+<section id="chorus-1-7" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
 <p><code class="c">C</code> One love <code class="a">Am</code> One
-life<br />
+life<br>
 <code class="f">FM7</code> When it’s one need <code class="c">C</code>
-in the night<br />
+in the night<br>
 <code class="c">C</code>One love <code class="a">Am</code> We got to
-share it<br />
-<code class="f">FM7</code> It leaves you baby<br />
+share it<br>
+<code class="f">FM7</code> It leaves you baby<br>
 if you <code class="c">C</code> don’t care for it</p>
-<p><code class="a">Am</code> <code class="d">Dsus2</code> <code
-class="f">FM7</code> <code class="g">G</code></p>
-</section>
-<section id="verse-2-22" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dsus2</code> <code class="f">FM7</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-2-22" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> Did I disap<code
-class="d">Dsus2</code>point you?<br />
-<code class="f">FM7</code> Or leave a bad taste in your <code
-class="g">G</code> mouth?<br />
-<code class="a">Am</code> You act like you never <code
-class="d">Dsus2</code> had love<br />
-<code class="f">FM7</code> And you want me to go with<code
-class="g">G</code>out</p>
+<p><code class="a">Am</code> Did I disap<code class="d">Dsus2</code>point you?<br>
+<code class="f">FM7</code> Or leave a bad taste in your <code class="g">G</code> mouth?<br>
+<code class="a">Am</code> You act like you never <code class="d">Dsus2</code> had love<br>
+<code class="f">FM7</code> And you want me to go with<code class="g">G</code>out</p>
 <p>Well it’s</p>
-</section>
-<section id="bridge-1-3" class="slide level2">
+</div></section>
+<section id="bridge-1-3" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
 <p><code class="c">C</code> Too late <code class="a">Am</code>
-Tonight<br />
-<code class="f">FM7</code> To drag the past out in<code
-class="c">C</code>to the light<br />
+Tonight<br>
+<code class="f">FM7</code> To drag the past out in<code class="c">C</code>to the light<br>
 <code class="c">C</code> We’re one, but we’re <code class="a">Am</code>
-not the same<br />
-We got to <code class="f">FM7</code> carry each other<br />
+not the same<br>
+We got to <code class="f">FM7</code> carry each other<br>
 <code class="c">C</code> carry each other</p>
-<p><code class="a">Am</code> <code class="d">Dsus2</code> <code
-class="f">FM7</code> <code class="g">G</code></p>
-</section>
-<section id="verse-3-16" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dsus2</code> <code class="f">FM7</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-3-16" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> Have you come here for for<code
-class="d">Dsus2</code>giveness?<br />
-<code class="f">FM7</code> Have you come to raise <code
-class="g">G</code> the dead?<br />
-<code class="a">Am</code> Have you come here to play <code
-class="d">Dsus2</code> Jesus<br />
-<code class="f">FM7</code> To the lepers in your <code
-class="g">G</code> head?</p>
-</section>
-<section id="bridge-2-3" class="slide level2">
+<p><code class="a">Am</code> Have you come here for for<code class="d">Dsus2</code>giveness?<br>
+<code class="f">FM7</code> Have you come to raise <code class="g">G</code> the dead?<br>
+<code class="a">Am</code> Have you come here to play <code class="d">Dsus2</code> Jesus<br>
+<code class="f">FM7</code> To the lepers in your <code class="g">G</code> head?</p>
+</div></section>
+<section id="bridge-2-3" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
-<p><code class="c">C</code> Did I ask too much? <code
-class="a">Am</code> More than a lot?<br />
-<code class="f">FM7</code> You gave me nothing, now it’s <code
-class="c">C</code> all I got<br />
+<p><code class="c">C</code> Did I ask too much? <code class="a">Am</code> More than a lot?<br>
+<code class="f">FM7</code> You gave me nothing, now it’s <code class="c">C</code> all I got<br>
 <code class="c">C</code> We’re one, but we’re <code class="a">Am</code>
-not the same<br />
-Well we <code class="f">FM7</code> hurt each other<br />
+not the same<br>
+Well we <code class="f">FM7</code> hurt each other<br>
 then we <code class="c">C</code> do it again</p>
 <p>You say</p>
-</section>
-<section id="interlude-3" class="slide level2">
+</div></section>
+<section id="interlude-3" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><code class="c">C</code> Love is a temple <code class="a">Am</code>
-Love’s a higher law<br />
+Love’s a higher law<br>
 <code class="c">C</code> Love is a temple <code class="a">Am</code>
-Love’s the higher law<br />
-You <code class="c">C</code> ask me to enter<br />
+Love’s the higher law<br>
+You <code class="c">C</code> ask me to enter<br>
 but <code class="g">G</code> then you make me crawl</p>
-<p>And <code class="g">G</code> I can’t be holding on <code
-class="f">FM7</code><br />
-To what you got <code class="f">FM7</code><br />
+<p>And <code class="g">G</code> I can’t be holding on <code class="f">FM7</code><br>
+To what you got <code class="f">FM7</code><br>
 When all you got is hurt</p>
-</section>
-<section id="chorus-3-1" class="slide level2">
+</div></section>
+<section id="chorus-3-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 3</h2>
 <p><code class="c">C</code> One love <code class="a">Am</code> One
-<del>life</del> <strong>blood</strong><br />
-<del>When it’s one need in the night</del><br />
-<strong><code class="f">FM7</code> One life, You got to <code
-class="c">C</code> do what you should</strong><br />
-<del>One love, we got to share it</del><br />
+<del>life</del> <strong>blood</strong><br>
+<del>When it’s one need in the night</del><br>
+<strong><code class="f">FM7</code> One life, You got to <code class="c">C</code> do what you should</strong><br>
+<del>One love, we got to share it</del><br>
 <strong><code class="c">C</code> One life <code class="a">Am</code> with
-each other</strong><br />
-<del>It leaves you baby</del><br />
-<code class="f">FM7</code> Sisters<br />
-<del>if you don’t care for it</del><br />
+each other</strong><br>
+<del>It leaves you baby</del><br>
+<code class="f">FM7</code> Sisters<br>
+<del>if you don’t care for it</del><br>
 <strong><code class="c">C</code> Brothers</strong></p>
-</section>
-<section id="outro-5" class="slide level2">
+</div></section>
+<section id="outro-5" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="c">C</code> One life, but we’re <code
-class="a">Am</code> not the same<br />
-We got to <code class="f">FM7</code> carry each other, car<code
-class="c">C</code>ry each other</p>
-<p>One <code class="c">C</code> <code class="a">Am</code> One <code
-class="f">FM7</code> <code class="c">C</code><br />
+<p><code class="c">C</code> One life, but we’re <code class="a">Am</code> not the same<br>
+We got to <code class="f">FM7</code> carry each other, car<code class="c">C</code>ry each other</p>
+<p>One <code class="c">C</code> <code class="a">Am</code> One <code class="f">FM7</code> <code class="c">C</code><br>
 <em>(Repeat several times and fade)</em></p>
-</section>
-<section id="resources-24" class="slide level2">
+</div></section>
+<section id="resources-24" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=ftjEcrrf7r0">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/u2/one-chords-87432">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/u2/one-chords-87432">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=wQZaTaexcbk">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="rivers-of-babylon-boney-m."
-class="title-slide slide level1">
+<section id="rivers-of-babylon-boney-m." class="title-slide slide level1"><div class="slide-content">
 <h1>Rivers of Babylon (Boney M.)</h1>
 
-</section>
-<section id="intro-18" class="slide level2">
+</div></section>
+<section id="intro-18" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Vocals only)</em></p>
 <p>Mmmh <code class="g">G</code> mmmh <code class="g">G</code> mmmh
-<code class="d">D7</code> mmmh <code class="g">G</code><br />
-Uuuh <code class="g">G</code> uuuh <code class="g">G</code> uuuh <code
-class="d">D7</code> uuuh <code class="g">G</code></p>
-</section>
-<section id="chorus-33" class="slide level2">
+<code class="d">D7</code> mmmh <code class="g">G</code><br>
+Uuuh <code class="g">G</code> uuuh <code class="g">G</code> uuuh <code class="d">D7</code> uuuh <code class="g">G</code></p>
+</div></section>
+<section id="chorus-33" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>By the rivers of <code class="g">G</code> Babylon<br />
-there we sat down<br />
-Ye-eah we <code class="d">D7</code> wept<br />
+<p>By the rivers of <code class="g">G</code> Babylon<br>
+there we sat down<br>
+Ye-eah we <code class="d">D7</code> wept<br>
 when we remembered Zi<code class="g">G</code>on</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="verse-1-26" class="slide level2">
+</div></section>
+<section id="verse-1-26" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>(When the wicked)<br />
-<code class="g">G</code> Carried us away in cap<code
-class="g">G7</code>tivity<br />
-Re<code class="c">C</code>quired from us a song <code
-class="g">G</code><br />
-Now how shall we sing the lord’s song<br />
+<p>(When the wicked)<br>
+<code class="g">G</code> Carried us away in cap<code class="g">G7</code>tivity<br>
+Re<code class="c">C</code>quired from us a song <code class="g">G</code><br>
+Now how shall we sing the lord’s song<br>
 in a stra<code class="d">D7</code>nge <code class="g">G</code> land</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="interlude-4" class="slide level2">
+</div></section>
+<section id="interlude-4" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p>Mmmh <code class="g">G</code> mmmh <code class="g">G</code> mmmh
 <code class="d">D7</code> mmmh <code class="g">G</code></p>
-</section>
-<section id="bridge-5" class="slide level2">
+</div></section>
+<section id="bridge-5" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>Let the <code class="g">G</code> words of our <code
-class="d">D7</code> mouth<br />
-and the medi<code class="g">G</code>tations of our heart <code
-class="d">D7</code><br />
-Be acc<code class="g">G</code>eptable in thy sight <code
-class="d">D7</code>here to<code class="g">G</code>night</p>
+<p>Let the <code class="g">G</code> words of our <code class="d">D7</code> mouth<br>
+and the medi<code class="g">G</code>tations of our heart <code class="d">D7</code><br>
+Be acc<code class="g">G</code>eptable in thy sight <code class="d">D7</code>here to<code class="g">G</code>night</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="chorus-34" class="slide level2">
+</div></section>
+<section id="chorus-34" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>By the rivers of <code class="g">G</code> Babylon<br />
-there we sat down<br />
-Ye-eah we <code class="d">D7</code> wept<br />
+<p>By the rivers of <code class="g">G</code> Babylon<br>
+there we sat down<br>
+Ye-eah we <code class="d">D7</code> wept<br>
 when we remembered Zi<code class="g">G</code>on</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
-<section id="resources-25" class="slide level2">
+</div></section>
+<section id="resources-25" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=ta42xU2UXLA">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/boney-m-/rivers-of-babylon-chords-1458631">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/boney-m-/rivers-of-babylon-chords-1458631">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=E9WcazK7eOI">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="road-to-mandalay-robbie-williams"
-class="title-slide slide level1">
+<section id="road-to-mandalay-robbie-williams" class="title-slide slide level1"><div class="slide-content">
 <h1>Road to Mandalay (Robbie Williams)</h1>
 
-</section>
-<section id="instructions-6" class="slide level2">
+</div></section>
+<section id="instructions-6" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <p>Capo on 3rd fret</p>
 <pre><code>       |E A D G B e|
@@ -3663,416 +3202,349 @@ F/A    |x 0 3 2 1 1|
 G7     |3 2 0 0 3 1|
 
 X Stop playing</code></pre>
-</section>
-<section id="verse-1-27" class="slide level2">
+</div></section>
+<section id="verse-1-27" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="d">Dm</code> Save me from drowning in the sea <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> Beat me up on the beach<br />
-<code class="d">Dm</code>What a lovely holiday <code
-class="e">E7(1)</code><br />
-There’s nothing funny left to say <code class="a">Asus</code> <code
-class="a">Am</code></p>
-<p><code class="d">Dm</code> This sombre song would drain the sun <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> But it won’t shine until it’s sung<br />
-<code class="d">Dm</code> No water running in the stream <code
-class="e">E7(2)</code><br />
-The saddest place we’ve ever seen <code class="a">A7sus4</code> <code
-class="a">A7</code></p>
-</section>
-<section id="bridge-1-4" class="slide level2">
+<p><code class="d">Dm</code> Save me from drowning in the sea <code class="d">Dm6</code><br>
+<code class="a">Am</code> Beat me up on the beach<br>
+<code class="d">Dm</code>What a lovely holiday <code class="e">E7(1)</code><br>
+There’s nothing funny left to say <code class="a">Asus</code> <code class="a">Am</code></p>
+<p><code class="d">Dm</code> This sombre song would drain the sun <code class="d">Dm6</code><br>
+<code class="a">Am</code> But it won’t shine until it’s sung<br>
+<code class="d">Dm</code> No water running in the stream <code class="e">E7(2)</code><br>
+The saddest place we’ve ever seen <code class="a">A7sus4</code> <code class="a">A7</code></p>
+</div></section>
+<section id="bridge-1-4" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
-<p><code class="f">F/A</code> Everything I touched was gol<code
-class="g">G7</code>den<br />
-Everything I loved got <code class="c">C</code> broken<br />
+<p><code class="f">F/A</code> Everything I touched was gol<code class="g">G7</code>den<br>
+Everything I loved got <code class="c">C</code> broken<br>
 On the road to Mandalay</p>
-<p><code class="f">F</code> Every mistake I’ve ever made <code
-class="e">Em</code><br />
-Has been rehashed and then re<code class="d">Dm</code>played<br />
+<p><code class="f">F</code> Every mistake I’ve ever made <code class="e">Em</code><br>
+Has been rehashed and then re<code class="d">Dm</code>played<br>
 As I got lost along the way <code class="g">G</code></p>
-</section>
-<section id="chorus-35" class="slide level2">
+</div></section>
+<section id="chorus-35" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="x">X</code> Bum bum bum <code class="d">Dm</code> ba da
-dum bum bum <code class="g">G</code><br />
-Bum bum bum <code class="c">C</code> ba da dum bum bum <code
-class="a">Am</code></p>
-<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code
-class="g">G</code><br />
+dum bum bum <code class="g">G</code><br>
+Bum bum bum <code class="c">C</code> ba da dum bum bum <code class="a">Am</code></p>
+<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code class="g">G</code><br>
 Bum ba dum <code class="a">Am</code></p>
-</section>
-<section id="verse-2-23" class="slide level2">
+</div></section>
+<section id="verse-2-23" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="d">Dm</code> There’s nothing left for you to give <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> The truth is all that you’re left with<br />
-<code class="d">Dm</code> Twenty paces then at dawn <code
-class="e">E7(1)</code><br />
-We will <code class="e">E7</code> die and be reborn <code
-class="a">Asus</code> <code class="a">Am</code></p>
-<p><code class="d">Dm</code> I like to sleep beneath the trees <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> Have the universe at one with me<br />
-<code class="d">Dm</code> Look down the barrel of a gun <code
-class="e">E7(2)</code><br />
-And feel the moon replace the sun <code class="a">A7sus4</code> <code
-class="a">A7</code></p>
-</section>
-<section id="bridge-2-4" class="slide level2">
+<p><code class="d">Dm</code> There’s nothing left for you to give <code class="d">Dm6</code><br>
+<code class="a">Am</code> The truth is all that you’re left with<br>
+<code class="d">Dm</code> Twenty paces then at dawn <code class="e">E7(1)</code><br>
+We will <code class="e">E7</code> die and be reborn <code class="a">Asus</code> <code class="a">Am</code></p>
+<p><code class="d">Dm</code> I like to sleep beneath the trees <code class="d">Dm6</code><br>
+<code class="a">Am</code> Have the universe at one with me<br>
+<code class="d">Dm</code> Look down the barrel of a gun <code class="e">E7(2)</code><br>
+And feel the moon replace the sun <code class="a">A7sus4</code> <code class="a">A7</code></p>
+</div></section>
+<section id="bridge-2-4" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
-<p><code class="f">F/A</code> Everything we’ve ever sto<code
-class="g">G7</code>len<br />
-Has been lost returned or <code class="c">C</code> broken<br />
+<p><code class="f">F/A</code> Everything we’ve ever sto<code class="g">G7</code>len<br>
+Has been lost returned or <code class="c">C</code> broken<br>
 No more dragons left to slay</p>
-<p><code class="f">F</code> Every mistake I’ve ever made <code
-class="e">Em</code><br />
-Has been rehashed and then re<code class="d">Dm</code>played<br />
+<p><code class="f">F</code> Every mistake I’ve ever made <code class="e">Em</code><br>
+Has been rehashed and then re<code class="d">Dm</code>played<br>
 As I got lost along the way <code class="g">G</code></p>
-</section>
-<section id="chorus-36" class="slide level2">
+</div></section>
+<section id="chorus-36" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="x">X</code> Bum bum bum <code class="d">Dm</code> ba da
-dum bum bum <code class="g">G</code><br />
-Bum bum bum <code class="c">C</code> ba da dum bum bum <code
-class="a">Am</code></p>
-<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code
-class="g">G</code><br />
+dum bum bum <code class="g">G</code><br>
+Bum bum bum <code class="c">C</code> ba da dum bum bum <code class="a">Am</code></p>
+<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code class="g">G</code><br>
 Bum ba dum <code class="a">Am</code></p>
 <p><em>(x3)</em></p>
-</section>
-<section id="solo" class="slide level2">
+</div></section>
+<section id="solo" class="slide level2"><div class="slide-content">
 <h2>Solo</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="d">Dm</code> <code class="g">G</code> <code
-class="c">C</code> <code class="a">Am</code> <code class="f">F</code>
+<p><code class="d">Dm</code> <code class="g">G</code> <code class="c">C</code> <code class="a">Am</code> <code class="f">F</code>
 <code class="g">G</code> <code class="a">Am</code></p>
-</section>
-<section id="outro-6" class="slide level2">
+</div></section>
+<section id="outro-6" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="d">Dm</code> Save me from drowning in the sea <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> Beat me up on the beach<br />
-<code class="d">Dm</code>What a lovely holiday <code
-class="e">E7(1)</code><br />
+<p><code class="d">Dm</code> Save me from drowning in the sea <code class="d">Dm6</code><br>
+<code class="a">Am</code> Beat me up on the beach<br>
+<code class="d">Dm</code>What a lovely holiday <code class="e">E7(1)</code><br>
 There’s nothing funny left to say <code class="a">Am</code></p>
-</section>
-<section id="resources-26" class="slide level2">
+</div></section>
+<section id="resources-26" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=KohurXfPb7s">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/robbie-williams/the-road-to-mandalay-chords-303">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/robbie-williams/the-road-to-mandalay-chords-303">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="road-trippin-red-hot-chili-peppers"
-class="title-slide slide level1">
+<section id="road-trippin-red-hot-chili-peppers" class="title-slide slide level1"><div class="slide-content">
 <h1>Road trippin’ (Red Hot Chili Peppers)</h1>
 
-</section>
-<section id="intro-19" class="slide level2">
+</div></section>
+<section id="intro-19" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="e">Em</code> <code class="c">C</code> <code
-class="b">B</code> <em>(x2)</em></p>
-</section>
-<section id="verse-1-28" class="slide level2">
+<p><code class="e">Em</code> <code class="c">C</code> <code class="b">B</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-1-28" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="e">Em</code> Road trippin with my two<br />
-<code class="c">C</code> favorite all<code class="b">B</code>ies<br />
-<code class="e">Em</code> Fully loaded we got<br />
+<p><code class="e">Em</code> Road trippin with my two<br>
+<code class="c">C</code> favorite all<code class="b">B</code>ies<br>
+<code class="e">Em</code> Fully loaded we got<br>
 <code class="c">C</code> snacks and supp<code class="b">B</code>lies</p>
-<p><code class="e">Em</code> It’s time to leave this town<br />
-It’s <code class="c">C</code> time to steal away <code
-class="b">B</code><br />
-<code class="e">Em</code> Let’s go get lost<br />
-any<code class="c">C</code>where in the U.S.A. <code
-class="b">B</code></p>
-</section>
-<section class="slide level2">
+<p><code class="e">Em</code> It’s time to leave this town<br>
+It’s <code class="c">C</code> time to steal away <code class="b">B</code><br>
+<code class="e">Em</code> Let’s go get lost<br>
+any<code class="c">C</code>where in the U.S.A. <code class="b">B</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="e">Em</code> Let’s go get lost<br />
+<p><code class="e">Em</code> Let’s go get lost<br>
 let’s go get <code class="c">C</code> lost <code class="b">B</code></p>
-<p><code class="e">Em</code> Blue you sit so pretty<br />
-<code class="c">C</code> West of the one <code class="b">B</code><br />
-<code class="e">Em</code> Sparkles light with yellow <code
-class="c">C</code> icing<br />
-Just a <code class="b">B</code> mirror for the sun <code
-class="e">Em</code></p>
-</section>
-<section id="chorus-37" class="slide level2">
+<p><code class="e">Em</code> Blue you sit so pretty<br>
+<code class="c">C</code> West of the one <code class="b">B</code><br>
+<code class="e">Em</code> Sparkles light with yellow <code class="c">C</code> icing<br>
+Just a <code class="b">B</code> mirror for the sun <code class="e">Em</code></p>
+</div></section>
+<section id="chorus-37" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> Just a <code class="b">B</code> mirror for
-the <code class="e">Em</code> sun<br />
+the <code class="e">Em</code> sun<br>
 <code class="c">C</code> Just a <code class="b">B</code> mirror for
-the<br />
-<code class="a">Am</code> Sun <code class="g">G/B</code> <code
-class="c">C</code> <code class="d">D</code></p>
+the<br>
+<code class="a">Am</code> Sun <code class="g">G/B</code> <code class="c">C</code> <code class="d">D</code></p>
 <p><code class="a">Am</code> These smiling <code class="g">G/B</code>
-eyes<br />
-are just a <code class="c">C</code> mirror for <code
-class="d">D</code></p>
-</section>
-<section id="verse-2-24" class="slide level2">
+eyes<br>
+are just a <code class="c">C</code> mirror for <code class="d">D</code></p>
+</div></section>
+<section id="verse-2-24" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="e">Em</code> So much has come before<br />
+<p><code class="e">Em</code> So much has come before<br>
 those <code class="c">C</code> battles lost and <code class="b">B</code>
-won<br />
-<code class="e">Em</code> This life is shining<br />
-more for<code class="c">C</code>ever in the sun <code
-class="b">B</code></p>
-<p><code class="e">Em</code> Now let us check our heads<br />
-And <code class="c">C</code> let us check the surf <code
-class="b">B</code><br />
-<code class="e">Em</code> Staying high and dry’s more <code
-class="c">C</code> trouble<br />
-than it’s <code class="b">B</code> worth in the sun <code
-class="e">Em</code></p>
-</section>
-<section id="chorus-38" class="slide level2">
+won<br>
+<code class="e">Em</code> This life is shining<br>
+more for<code class="c">C</code>ever in the sun <code class="b">B</code></p>
+<p><code class="e">Em</code> Now let us check our heads<br>
+And <code class="c">C</code> let us check the surf <code class="b">B</code><br>
+<code class="e">Em</code> Staying high and dry’s more <code class="c">C</code> trouble<br>
+than it’s <code class="b">B</code> worth in the sun <code class="e">Em</code></p>
+</div></section>
+<section id="chorus-38" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> Just a <code class="b">B</code> mirror for
-the <code class="e">Em</code> sun<br />
+the <code class="e">Em</code> sun<br>
 <code class="c">C</code> Just a <code class="b">B</code> mirror for
-the<br />
-<code class="a">Am</code> Sun <code class="g">G/B</code> <code
-class="c">C</code> <code class="d">D</code></p>
+the<br>
+<code class="a">Am</code> Sun <code class="g">G/B</code> <code class="c">C</code> <code class="d">D</code></p>
 <p><code class="a">Am</code> These smiling <code class="g">G/B</code>
-eyes<br />
-are just a <code class="c">C</code> mirror for <code
-class="d">D</code></p>
-</section>
-<section id="interlude-5" class="slide level2">
+eyes<br>
+are just a <code class="c">C</code> mirror for <code class="d">D</code></p>
+</div></section>
+<section id="interlude-5" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="e">Em</code> <code class="a">A</code> <code
-class="c">C</code> <code class="d">D</code> <code class="e">Em</code>
-<code class="a">A</code> <code class="c">C</code> <code
-class="b">Bdim</code> <em>(x2)</em></p>
+<p><code class="e">Em</code> <code class="a">A</code> <code class="c">C</code> <code class="d">D</code> <code class="e">Em</code>
+<code class="a">A</code> <code class="c">C</code> <code class="b">Bdim</code> <em>(x2)</em></p>
 <p><code class="b">Bdim</code> <em>(x4)</em></p>
-</section>
-<section id="verse-3-17" class="slide level2">
+</div></section>
+<section id="verse-3-17" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="e">Em</code> In Big Sur we take some<br />
-<code class="c">C</code> time to linger on <code
-class="b">B</code><br />
-<code class="e">Em</code> We three hunky dory’s got<br />
+<p><code class="e">Em</code> In Big Sur we take some<br>
+<code class="c">C</code> time to linger on <code class="b">B</code><br>
+<code class="e">Em</code> We three hunky dory’s got<br>
 <code class="c">C</code> our snake<code class="b">B</code>finger on</p>
-<p><code class="e">Em</code> Now let us drink the stars<br />
-<code class="c">C</code> It’s time to steal away <code
-class="b">B</code><br />
-<code class="e">Em</code> Let’s go get lost<br />
+<p><code class="e">Em</code> Now let us drink the stars<br>
+<code class="c">C</code> It’s time to steal away <code class="b">B</code><br>
+<code class="e">Em</code> Let’s go get lost<br>
 <del>anywhere</del> <strong>right <code class="c">C</code> here</strong>
 in the U.S.A. <code class="b">B</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="e">Em</code> Let’s go get lost<br />
+<p><code class="e">Em</code> Let’s go get lost<br>
 let’s go get <code class="c">C</code> lost <code class="b">B</code></p>
-<p><code class="e">Em</code> Blue you sit so pretty<br />
-<code class="c">C</code> West of the one <code class="b">B</code><br />
-<code class="e">Em</code> Sparkles light with yellow <code
-class="c">C</code> icing<br />
-Just a <code class="b">B</code> mirror for the sun <code
-class="e">Em</code></p>
-</section>
-<section id="chorus-39" class="slide level2">
+<p><code class="e">Em</code> Blue you sit so pretty<br>
+<code class="c">C</code> West of the one <code class="b">B</code><br>
+<code class="e">Em</code> Sparkles light with yellow <code class="c">C</code> icing<br>
+Just a <code class="b">B</code> mirror for the sun <code class="e">Em</code></p>
+</div></section>
+<section id="chorus-39" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> Just a <code class="b">B</code> mirror for
-the <code class="e">Em</code> sun<br />
+the <code class="e">Em</code> sun<br>
 <code class="c">C</code> Just a <code class="b">B</code> mirror for
-the<br />
-<code class="a">Am</code> Sun <code class="g">G/B</code> <code
-class="c">C</code> <code class="d">D</code></p>
+the<br>
+<code class="a">Am</code> Sun <code class="g">G/B</code> <code class="c">C</code> <code class="d">D</code></p>
 <p><code class="a">Am</code> These smiling <code class="g">G/B</code>
-eyes<br />
+eyes<br>
 are just a <code class="c">C</code> mirror for <code class="d">D</code>
 <em>(x3)</em></p>
-</section>
-<section id="resources-27" class="slide level2">
+</div></section>
+<section id="resources-27" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=11GYvfYjyV0">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/red-hot-chili-peppers/road-trippin-chords-1009501">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/red-hot-chili-peppers/road-trippin-chords-1009501">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=NXLH5YT1ZLM">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="s-zündhölzli-mani-matter" class="title-slide slide level1">
+<section id="s-zündhölzli-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>S Zündhölzli (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-29" class="slide level2">
+</div></section>
+<section id="verse-1-29" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>I han es <code class="c">C</code>Zündhölzli azündet<br />
-Und das <code class="g">G7</code> het e Flamme gäh<br />
-Und i <code class="a">Am</code> ha für d’Zigarette<br />
+<p>I han es <code class="c">C</code>Zündhölzli azündet<br>
+Und das <code class="g">G7</code> het e Flamme gäh<br>
+Und i <code class="a">Am</code> ha für d’Zigarette<br>
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
-<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
-Und <code class="c">C</code> uf e Teppich cho<br />
-Und es <code class="g">G7</code> hätt no fasch<br />
+<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br>
+Und <code class="c">C</code> uf e Teppich cho<br>
+Und es <code class="g">G7</code> hätt no fasch<br>
 Es Loch i Teppich <code class="c">C</code> gäh dervo</p>
-</section>
-<section id="verse-2-25" class="slide level2">
+</div></section>
+<section id="verse-2-25" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Ja me <code class="c">C</code> weiss was cha passiere<br />
-We me <code class="g">G7</code> nid ufpasst mit Füür<br />
-Und für d’<code class="a">Am</code>Gluet ar Zigarette<br />
+<p>Ja me <code class="c">C</code> weiss was cha passiere<br>
+We me <code class="g">G7</code> nid ufpasst mit Füür<br>
+Und für d’<code class="a">Am</code>Gluet ar Zigarette<br>
 Isch e <code class="e">E</code> Teppich doch de z’tüür</p>
-<p>Und vom <code class="f">F</code> Teppich hätt - oh Grus<br />
-Chönne ds <code class="c">C</code> Füür i ds ganze Hus<br />
-Und wär <code class="g">G7</code> weiss, was da<br />
+<p>Und vom <code class="f">F</code> Teppich hätt - oh Grus<br>
+Chönne ds <code class="c">C</code> Füür i ds ganze Hus<br>
+Und wär <code class="g">G7</code> weiss, was da<br>
 Nid alles no wär <code class="c">C</code> worde drus</p>
-</section>
-<section id="verse-3-18" class="slide level2">
+</div></section>
+<section id="verse-3-18" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>S’hätt e <code class="c">C</code> Brand gäh im Quartier<br />
-Und s’hätti d’<code class="g">G7</code>Füürwehr müesse cho<br />
-Hätti <code class="a">Am</code> ghornet i de Strasse<br />
+<p>S’hätt e <code class="c">C</code> Brand gäh im Quartier<br>
+Und s’hätti d’<code class="g">G7</code>Füürwehr müesse cho<br>
+Hätti <code class="a">Am</code> ghornet i de Strasse<br>
 Und dr <code class="e">E</code> Schluuch vom Wage gno</p>
-<p>Und sie <code class="f">F</code> hätte Wasser gsprützt<br />
-Und das <code class="c">C</code> hätt de glych nüt gnützt<br />
-Und die <code class="g">G7</code> ganzi Stadt hätt brönnt<br />
+<p>Und sie <code class="f">F</code> hätte Wasser gsprützt<br>
+Und das <code class="c">C</code> hätt de glych nüt gnützt<br>
+Und die <code class="g">G7</code> ganzi Stadt hätt brönnt<br>
 Es hätt se <code class="c">C</code> nüt meh gschützt</p>
-</section>
-<section id="verse-4-9" class="slide level2">
+</div></section>
+<section id="verse-4-9" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>Und d’Lüt <code class="c">C</code> wären umegsprunge<br />
-I dr <code class="g">G7</code> Angscht um Hab und Guet<br />
-Hätte <code class="a">Am</code> gmeint s’heig eine Füür gleit<br />
+<p>Und d’Lüt <code class="c">C</code> wären umegsprunge<br>
+I dr <code class="g">G7</code> Angscht um Hab und Guet<br>
+Hätte <code class="a">Am</code> gmeint s’heig eine Füür gleit<br>
 Hätte ds <code class="e">E</code> Sturmgwehr gno ir Wuet</p>
-<p>Alls hätt <code class="f">F</code> brüelet: Wär isch tschuld?<br />
-Ds ganze <code class="c">C</code> Land i eim Tumult<br />
-Dass me <code class="g">G7</code> gschosse hätt<br />
+<p>Alls hätt <code class="f">F</code> brüelet: Wär isch tschuld?<br>
+Ds ganze <code class="c">C</code> Land i eim Tumult<br>
+Dass me <code class="g">G7</code> gschosse hätt<br>
 Uf d’Bundesrät am <code class="c">C</code> Rednerpult</p>
-</section>
-<section id="verse-5-7" class="slide level2">
+</div></section>
+<section id="verse-5-7" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p>D’UNO <code class="c">C</code> hätt interveniert<br />
-Und d’UNO-<code class="g">G7</code>Gägner sofort o<br />
-Für ir <code class="a">Am</code> Schwyz dr Fride z’rette<br />
+<p>D’UNO <code class="c">C</code> hätt interveniert<br>
+Und d’UNO-<code class="g">G7</code>Gägner sofort o<br>
+Für ir <code class="a">Am</code> Schwyz dr Fride z’rette<br>
 Wäre <code class="e">E</code> beid mit Panzer cho</p>
-<p>S’hätt sech <code class="f">F</code> usdehnt nadisna<br />
-Uf Eu<code class="c">C</code>ropa, Afrika<br />
-S’hätt e <code class="g">G7</code> Wältchrieg gäh<br />
+<p>S’hätt sech <code class="f">F</code> usdehnt nadisna<br>
+Uf Eu<code class="c">C</code>ropa, Afrika<br>
+S’hätt e <code class="g">G7</code> Wältchrieg gäh<br>
 Und d’Mönschheit wär jitz <code class="c">C</code> nümme da</p>
-</section>
-<section id="verse-6-5" class="slide level2">
+</div></section>
+<section id="verse-6-5" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
-<p>I han es <code class="c">C</code> Zündhölzli azündet<br />
-Und das <code class="g">G7</code> het e Flamme gäh<br />
-Und i <code class="a">Am</code> ha für d’Zigarette<br />
+<p>I han es <code class="c">C</code> Zündhölzli azündet<br>
+Und das <code class="g">G7</code> het e Flamme gäh<br>
+Und i <code class="a">Am</code> ha für d’Zigarette<br>
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
-<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
-Und <code class="c">C</code> uf e Teppich cho -<br />
-<del>Und es hätt no fasch…</del> Gottsei<code
-class="g">G7</code>dank<br />
+<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br>
+Und <code class="c">C</code> uf e Teppich cho -<br>
+<del>Und es hätt no fasch…</del> Gottsei<code class="g">G7</code>dank<br>
 Dass i’s vom Teppich wider <code class="c">C</code> furt ha gno</p>
-</section>
-<section id="resources-28" class="slide level2">
+</div></section>
+<section id="resources-28" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=PkGatIgXERI">Song</a></li>
 <li><a href="https://tabs.ultimate-guitar.com/tab/1197401">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="sittin-on-the-dock-of-the-bay-otis-redding"
-class="title-slide slide level1">
+<section id="sittin-on-the-dock-of-the-bay-otis-redding" class="title-slide slide level1"><div class="slide-content">
 <h1>Sittin’ on the dock of the bay (Otis Redding)</h1>
 
-</section>
-<section id="verse-1-30" class="slide level2">
+</div></section>
+<section id="verse-1-30" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="g">G</code> Sittin’ in the mornin’ sun <code
-class="b">B7</code><br />
-I’ll be <code class="c">C</code> sittin’ when the evenin’ comes <code
-class="a">A</code><br />
-<code class="g">G</code> Watching the ships roll in <code
-class="b">B7</code><br />
-And then I <code class="c">C</code> watch ’em roll away again <code
-class="a">A</code> yeah</p>
-</section>
-<section id="chorus-40" class="slide level2">
+<p><code class="g">G</code> Sittin’ in the mornin’ sun <code class="b">B7</code><br>
+I’ll be <code class="c">C</code> sittin’ when the evenin’ comes <code class="a">A</code><br>
+<code class="g">G</code> Watching the ships roll in <code class="b">B7</code><br>
+And then I <code class="c">C</code> watch ’em roll away again <code class="a">A</code> yeah</p>
+</div></section>
+<section id="chorus-40" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I’m <code class="g">G</code> sittin’ on the dock of the <code
-class="e">E</code> bay<br />
-Watching the <code class="g">G</code> tide roll <code
-class="e">E</code>away, ooo<br />
-I’m just <code class="g">G</code> sittin’ on the dock of the <code
-class="a">A</code> bay<br />
+<p>I’m <code class="g">G</code> sittin’ on the dock of the <code class="e">E</code> bay<br>
+Watching the <code class="g">G</code> tide roll <code class="e">E</code>away, ooo<br>
+I’m just <code class="g">G</code> sittin’ on the dock of the <code class="a">A</code> bay<br>
 Wastin’ <code class="g">G</code> time <code class="e">E</code></p>
-</section>
-<section id="verse-2-26" class="slide level2">
+</div></section>
+<section id="verse-2-26" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>I <code class="g">G</code> left my home in <code class="b">B7</code>
-Georgia<br />
-<code class="c">C</code> Headed for the ’Frisco Bay <code
-class="a">A</code><br />
-<code class="g">G</code> ’Cause I’ve had nothing to <code
-class="b">B7</code> live for<br />
-And look like <code class="c">C</code> nothin’s gonna come my way <code
-class="a">A</code></p>
-</section>
-<section id="chorus-41" class="slide level2">
+Georgia<br>
+<code class="c">C</code> Headed for the ’Frisco Bay <code class="a">A</code><br>
+<code class="g">G</code> ’Cause I’ve had nothing to <code class="b">B7</code> live for<br>
+And look like <code class="c">C</code> nothin’s gonna come my way <code class="a">A</code></p>
+</div></section>
+<section id="chorus-41" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><del>I’m sittin’</del> <strong>So I’m just gonna <code
-class="g">G</code> sit</strong> on the dock of the <code
-class="e">E</code> bay<br />
-Watching the <code class="g">G</code> tide roll <code
-class="e">E</code>away, ooh<br />
+<p><del>I’m sittin’</del> <strong>So I’m just gonna <code class="g">G</code> sit</strong> on the dock of the <code class="e">E</code> bay<br>
+Watching the <code class="g">G</code> tide roll <code class="e">E</code>away, ooh<br>
 <del>I’m just</del> <strong>Ooo I’m</strong> <code class="g">G</code>
-sittin’ on the dock of the <code class="a">A</code> bay<br />
+sittin’ on the dock of the <code class="a">A</code> bay<br>
 Wastin’ <code class="g">G</code> time <code class="e">E</code></p>
-</section>
-<section id="bridge-6" class="slide level2">
+</div></section>
+<section id="bridge-6" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><code class="g">G</code> Looks like <code class="d">D</code>
-nothing’s <code class="c">C</code> gonna change <code
-class="g">G</code><br />
+nothing’s <code class="c">C</code> gonna change <code class="g">G</code><br>
 <code class="g">G</code> Everything <code class="d">D</code> still
-remains <code class="c">C</code> the same <code class="g">G</code><br />
-<code class="g">G</code> I can’t <code class="d">D</code> do what <code
-class="c">C</code> ten people <code class="g">G</code> tell me to
-do<br />
-So I <code class="f">F</code> guess I’ll remain the <code
-class="d">D</code> same, yes</p>
-</section>
-<section id="chorus-42" class="slide level2">
+remains <code class="c">C</code> the same <code class="g">G</code><br>
+<code class="g">G</code> I can’t <code class="d">D</code> do what <code class="c">C</code> ten people <code class="g">G</code> tell me to
+do<br>
+So I <code class="f">F</code> guess I’ll remain the <code class="d">D</code> same, yes</p>
+</div></section>
+<section id="chorus-42" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><strong>Now</strong> I’m <code class="g">G</code> sitting on the dock
-of the <code class="e">E</code> bay<br />
-Watching the <code class="g">G</code> tide roll <code
-class="e">E</code>away, ooh<br />
+of the <code class="e">E</code> bay<br>
+Watching the <code class="g">G</code> tide roll <code class="e">E</code>away, ooh<br>
 <del>I’m just</del> <strong>Ooo I’m</strong> <code class="g">G</code>
-sittin’ on the dock of the <code class="a">A</code> bay<br />
+sittin’ on the dock of the <code class="a">A</code> bay<br>
 Wastin’ <code class="g">G</code> time <code class="e">E</code></p>
 <p><em>(Repeat and whistle, fade)</em></p>
-</section>
-<section id="resources-29" class="slide level2">
+</div></section>
+<section id="resources-29" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=wyPKRcBTsFQ">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/otis-redding/sittin-on-the-dock-of-the-bay-chords-1088518">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/otis-redding/sittin-on-the-dock-of-the-bay-chords-1088518">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=WNvoNPbmREY">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="something-stupid-robbie-williams"
-class="title-slide slide level1">
+<section id="something-stupid-robbie-williams" class="title-slide slide level1"><div class="slide-content">
 <h1>Something stupid (Robbie Williams)</h1>
 
-</section>
-<section id="instructions-7" class="slide level2">
+</div></section>
+<section id="instructions-7" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>Sounds best with some barre chords:
 
@@ -4092,655 +3564,596 @@ G6 |3 2 0 0 3 0|
 And some more chords:
 
 D+ |x x 0 3 3 2| To switch from D, point pinky on G string</code></pre>
-</section>
-<section id="verse-1-31" class="slide level2">
+</div></section>
+<section id="verse-1-31" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>I <code class="g">G6</code> know I stand in line<br />
-until you think you have the time<br />
-to spend an <code class="a">Am</code> evening with me <code
-class="d">D7</code> <code class="a">Am</code> <code
-class="d">D7</code></p>
-<p>And <code class="a">Am</code> if we go some<code
-class="d">D7</code>place to dance<br />
-I <code class="a">Am</code> know that there’s a chance <code
-class="d">D7</code><br />
+<p>I <code class="g">G6</code> know I stand in line<br>
+until you think you have the time<br>
+to spend an <code class="a">Am</code> evening with me <code class="d">D7</code> <code class="a">Am</code> <code class="d">D7</code></p>
+<p>And <code class="a">Am</code> if we go some<code class="d">D7</code>place to dance<br>
+I <code class="a">Am</code> know that there’s a chance <code class="d">D7</code><br>
 you won’t be <code class="g">G6</code> leaving with me</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Then <code class="g">G</code> afterwards we drop<br />
-into a <code class="g">G7</code> quiet little place<br />
-and have a <code class="c">C</code> drink or two <code
-class="e">Eb</code></p>
+<p>Then <code class="g">G</code> afterwards we drop<br>
+into a <code class="g">G7</code> quiet little place<br>
+and have a <code class="c">C</code> drink or two <code class="e">Eb</code></p>
 <p>And <code class="a">Am</code> then I go and <code class="d">D7</code>
-spoil it all<br />
+spoil it all<br>
 by <code class="a">Am</code> saying something <code class="d">D7</code>
-stupid<br />
+stupid<br>
 like: “I <code class="g">G6</code> love you”</p>
-</section>
-<section id="bridge-7" class="slide level2">
+</div></section>
+<section id="bridge-7" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>I can <code class="g">G</code> see it in your eyes<br />
-that you de<code class="g">G7</code>spise the same old lies<br />
+<p>I can <code class="g">G</code> see it in your eyes<br>
+that you de<code class="g">G7</code>spise the same old lies<br>
 you heard the <code class="c">C</code> night before</p>
-<p>And <code class="a">A7</code> though it’s just a line to you<br />
-For me it’s true and<br />
-never seemed so <code class="d">D</code> right before <code
-class="d">D+</code></p>
-</section>
-<section id="verse-2-27" class="slide level2">
+<p>And <code class="a">A7</code> though it’s just a line to you<br>
+For me it’s true and<br>
+never seemed so <code class="d">D</code> right before <code class="d">D+</code></p>
+</div></section>
+<section id="verse-2-27" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>I <code class="g">G6</code> practice every day<br />
-to find some clever lines to say to make<br />
-the <code class="a">Am</code> meaning come through <code
-class="d">D7</code> <code class="a">Am</code> <code
-class="d">D7</code></p>
-<p>But <code class="a">Am</code> then I think I’ll <code
-class="d">D7</code> wait until<br />
-the <code class="a">Am</code> evening gets late <code
-class="d">D7</code><br />
+<p>I <code class="g">G6</code> practice every day<br>
+to find some clever lines to say to make<br>
+the <code class="a">Am</code> meaning come through <code class="d">D7</code> <code class="a">Am</code> <code class="d">D7</code></p>
+<p>But <code class="a">Am</code> then I think I’ll <code class="d">D7</code> wait until<br>
+the <code class="a">Am</code> evening gets late <code class="d">D7</code><br>
 and I’m <code class="g">G6</code> alone with you</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>The <code class="g">G</code> time is right<br />
-your perfume fills my <code class="g">G7</code> head<br />
-the stars get red<br />
-and oh the <code class="c">C</code> night’s so blue <code
-class="e">Eb</code></p>
+<p>The <code class="g">G</code> time is right<br>
+your perfume fills my <code class="g">G7</code> head<br>
+the stars get red<br>
+and oh the <code class="c">C</code> night’s so blue <code class="e">Eb</code></p>
 <p>And <code class="a">Am</code> then I go and <code class="d">D7</code>
-spoil it all<br />
+spoil it all<br>
 by <code class="a">Am</code> saying something <code class="d">D7</code>
-stupid<br />
+stupid<br>
 like: “I <code class="g">G6</code> love you”</p>
-</section>
-<section id="bridge-8" class="slide level2">
+</div></section>
+<section id="bridge-8" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><em>(Instrumental, maybe add whistling)</em></p>
-<p><code class="g">G</code> <code class="g">G7</code> <code
-class="c">C</code><br />
-<code class="a">A7</code> <code class="d">D</code> <code
-class="d">D+</code></p>
-</section>
-<section id="verse-2-28" class="slide level2">
+<p><code class="g">G</code> <code class="g">G7</code> <code class="c">C</code><br>
+<code class="a">A7</code> <code class="d">D</code> <code class="d">D+</code></p>
+</div></section>
+<section id="verse-2-28" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>I <code class="g">G6</code> practice every day<br />
-to find some clever lines to say to make<br />
-the <code class="a">Am</code> meaning come through <code
-class="d">D7</code> <code class="a">Am</code> <code
-class="d">D7</code></p>
-<p>But <code class="a">Am</code> then I think I’ll <code
-class="d">D7</code> wait until<br />
-the <code class="a">Am</code> evening gets late <code
-class="d">D7</code><br />
+<p>I <code class="g">G6</code> practice every day<br>
+to find some clever lines to say to make<br>
+the <code class="a">Am</code> meaning come through <code class="d">D7</code> <code class="a">Am</code> <code class="d">D7</code></p>
+<p>But <code class="a">Am</code> then I think I’ll <code class="d">D7</code> wait until<br>
+the <code class="a">Am</code> evening gets late <code class="d">D7</code><br>
 and I’m <code class="g">G6</code> alone with you</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>The <code class="g">G</code> time is right<br />
-your perfume fills my <code class="g">G7</code> head<br />
-the stars get red<br />
-and oh the <code class="c">C</code> night’s so blue <code
-class="e">Eb</code></p>
+<p>The <code class="g">G</code> time is right<br>
+your perfume fills my <code class="g">G7</code> head<br>
+the stars get red<br>
+and oh the <code class="c">C</code> night’s so blue <code class="e">Eb</code></p>
 <p>And <code class="a">Am</code> then I go and <code class="d">D7</code>
-spoil it all<br />
+spoil it all<br>
 by <code class="a">Am</code> saying something <code class="d">D7</code>
-stupid<br />
-like: “I <code class="g">G</code> love you” <code
-class="e">Eb</code></p>
+stupid<br>
+like: “I <code class="g">G</code> love you” <code class="e">Eb</code></p>
 <p>I <code class="g">G</code> love you <code class="e">Eb</code>
 <em>(Repeat and fade)</em></p>
-</section>
-<section id="resources-30" class="slide level2">
+</div></section>
+<section id="resources-30" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=icZHj6DG7ms">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/robbie-williams/something-stupid-chords-1186829">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/robbie-williams/something-stupid-chords-1186829">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=pXuxL7pMb7c">Guitar
 tutorial</a></li>
 <li><a href="https://www.youtube.com/watch?v=eet2ETbsRwU">Sing in
 harmony tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="somewhere-over-the-rainbow-israël-kamakawiwoole"
-class="title-slide slide level1">
+<section id="somewhere-over-the-rainbow-israël-kamakawiwoole" class="title-slide slide level1"><div class="slide-content">
 <h1>Somewhere over the rainbow (Israël Kamakawiwo’ole)</h1>
 
-</section>
-<section id="intro-20" class="slide level2">
+</div></section>
+<section id="intro-20" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="g">G</code> <code
-class="a">Am</code> <code class="f">F</code> <em>(repeat)</em></p>
+<p><code class="c">C</code> <code class="g">G</code> <code class="a">Am</code> <code class="f">F</code> <em>(repeat)</em></p>
 <p><code class="c">C</code> Ooo-ooo <code class="e">Em</code>
-ooo-ooo<br />
-<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br />
-<code class="f">F</code> Ooo-ooo <code class="e">E7</code> ooo-ooo<br />
+ooo-ooo<br>
+<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br>
+<code class="f">F</code> Ooo-ooo <code class="e">E7</code> ooo-ooo<br>
 <code class="a">Am</code> ooo-ooo <code class="f">F</code> ooo-ooo</p>
-</section>
-<section id="verse-1-32" class="slide level2">
+</div></section>
+<section id="verse-1-32" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><code class="c">C</code> Somewhere <code class="e">Em</code> over the
-rainbow<br />
-<code class="f">F</code> way up <code class="c">C</code> high<br />
+rainbow<br>
+<code class="f">F</code> way up <code class="c">C</code> high<br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dream of<br />
+you dream of<br>
 <code class="g">G</code> once in a lulla<code class="a">Am</code>by
 <code class="f">F</code></p>
 <p>Oh <code class="c">C</code> somewhere <code class="e">Em</code> over
-the rainbow<br />
-<code class="f">F</code> blue birds <code class="c">C</code> fly<br />
+the rainbow<br>
+<code class="f">F</code> blue birds <code class="c">C</code> fly<br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dream of<br />
+you dream of<br>
 <code class="g">G</code> dreams really do come <code class="a">Am</code>
 true <code class="f">F</code></p>
-</section>
-<section id="verse-2-29" class="slide level2">
+</div></section>
+<section id="verse-2-29" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Some<code class="c">C</code>day i’ll wish upon a star<br />
-<code class="g">G</code> To wake up where the clouds are far<br />
+<p>Some<code class="c">C</code>day i’ll wish upon a star<br>
+<code class="g">G</code> To wake up where the clouds are far<br>
 be<code class="a">Am</code>hind <code class="f">F</code> me</p>
-<p>Where <code class="c">C</code> trouble melts like lemon drops<br />
-<code class="g">G</code> High above the chimney tops<br />
-that’s <code class="a">Am</code> where<br />
+<p>Where <code class="c">C</code> trouble melts like lemon drops<br>
+<code class="g">G</code> High above the chimney tops<br>
+that’s <code class="a">Am</code> where<br>
 you’ll <code class="f">F</code> find me</p>
-</section>
-<section id="interlude-1-1" class="slide level2">
+</div></section>
+<section id="interlude-1-1" class="slide level2"><div class="slide-content">
 <h2>Interlude 1</h2>
 <p>Oh <code class="c">C</code> somewhere <code class="e">Em</code> over
-the rainbow<br />
-<code class="f">F</code> blue birds <code class="c">C</code> fly<br />
+the rainbow<br>
+<code class="f">F</code> blue birds <code class="c">C</code> fly<br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dare to oh<br />
+you dare to oh<br>
 <code class="g">G</code> why oh why can’t <code class="a">Am</code> I?
 <code class="f">F</code></p>
-</section>
-<section id="verse-3-19" class="slide level2">
+</div></section>
+<section id="verse-3-19" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Well I see <code class="c">C</code> trees of <code
-class="e">Em</code> green and<br />
-<code class="f">F</code> Red roses <code class="c">C</code> too<br />
+<p>Well I see <code class="c">C</code> trees of <code class="e">Em</code> green and<br>
+<code class="f">F</code> Red roses <code class="c">C</code> too<br>
 <code class="f">F</code> I’ll watch them <code class="c">C</code> bloom
-for<br />
+for<br>
 <code class="e">E7</code> me and <code class="a">Am</code> you</p>
-<p>And I <code class="f">F</code> think to myself<br />
+<p>And I <code class="f">F</code> think to myself<br>
 <code class="g">G</code> what a wonderful <code class="a">Am</code>
 world <code class="f">F</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Well I see <code class="c">C</code> skies of <code
-class="e">Em</code> blue and I see<br />
-<code class="f">F</code> clouds of <code class="c">C</code> white<br />
+<p>Well I see <code class="c">C</code> skies of <code class="e">Em</code> blue and I see<br>
+<code class="f">F</code> clouds of <code class="c">C</code> white<br>
 And the <code class="f">F</code> brightness of <code class="c">C</code>
-day<br />
+day<br>
 <code class="e">E7</code> I like the <code class="a">Am</code> dark</p>
-<p>And I <code class="f">F</code> think to myself<br />
+<p>And I <code class="f">F</code> think to myself<br>
 <code class="g">G</code> what a wonderful <code class="c">C</code> world
 <code class="f">F</code> <code class="c">C</code></p>
-</section>
-<section id="bridge-9" class="slide level2">
+</div></section>
+<section id="bridge-9" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>The <code class="g">G</code> colours of the rainbow<br />
-so <code class="c">C</code> pretty in the sky<br />
-Are <code class="g">G</code> also on the faces<br />
+<p>The <code class="g">G</code> colours of the rainbow<br>
+so <code class="c">C</code> pretty in the sky<br>
+Are <code class="g">G</code> also on the faces<br>
 of <code class="c">C</code> people passing bye</p>
 <p>See <code class="f">F</code> friends shaking <code class="c">C</code>
-hands<br />
+hands<br>
 saying <code class="f">F</code> how do you <code class="c">C</code>
-do?<br />
+do?<br>
 <code class="f">F</code> They’re really <code class="c">C</code>
-saying<br />
+saying<br>
 <code class="d">Dm7</code> I - I love <code class="d">D</code> you</p>
-</section>
-<section id="interlude-2-1" class="slide level2">
+</div></section>
+<section id="interlude-2-1" class="slide level2"><div class="slide-content">
 <h2>Interlude 2</h2>
 <p>I hear <code class="c">C</code> babies <code class="e">Em</code> cry
-and I<br />
-<code class="f">F</code> watch them <code class="c">C</code> grow<br />
+and I<br>
+<code class="f">F</code> watch them <code class="c">C</code> grow<br>
 <code class="f">F</code> They’ll learn much <code class="c">C</code>
-more<br />
+more<br>
 <code class="e">E7</code> than we’ll <code class="a">Am</code> know</p>
-<p>And I <code class="f">F</code> think to myself<br />
+<p>And I <code class="f">F</code> think to myself<br>
 <code class="g">G</code> what a wonderful <code class="a">Am</code>
 world <code class="f">F</code> world</p>
-</section>
-<section id="verse-2-30" class="slide level2">
+</div></section>
+<section id="verse-2-30" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Some<code class="c">C</code>day i’ll wish upon a star<br />
-<code class="g">G</code> To wake up where the clouds are far<br />
+<p>Some<code class="c">C</code>day i’ll wish upon a star<br>
+<code class="g">G</code> To wake up where the clouds are far<br>
 be<code class="a">Am</code>hind <code class="f">F</code> me</p>
-<p>Where <code class="c">C</code> trouble melts like lemon drops<br />
-<code class="g">G</code> High above the chimney tops<br />
-that’s <code class="a">Am</code> where<br />
+<p>Where <code class="c">C</code> trouble melts like lemon drops<br>
+<code class="g">G</code> High above the chimney tops<br>
+that’s <code class="a">Am</code> where<br>
 you’ll <code class="f">F</code> find me</p>
-</section>
-<section id="interlude-1-2" class="slide level2">
+</div></section>
+<section id="interlude-1-2" class="slide level2"><div class="slide-content">
 <h2>Interlude 1</h2>
 <p><code class="c">C</code> Oh somewhere <code class="e">Em</code> over
-the rainbow<br />
-<del>blue birds fly</del><br />
+the rainbow<br>
+<del>blue birds fly</del><br>
 <strong><code class="f">F</code> way up <code class="c">C</code>
-high</strong><br />
+high</strong><br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dare to<br />
+you dare to<br>
 <code class="g">G</code> why oh why can’t <code class="a">Am</code> I?
 <code class="f">F</code></p>
-</section>
-<section id="outro-7" class="slide level2">
+</div></section>
+<section id="outro-7" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
 <p><code class="c">C</code> Ooo-ooo <code class="e">Em</code>
-ooo-ooo<br />
-<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br />
-<code class="f">F</code> ooo-ooo <code class="e">E7</code> ooo-ooo<br />
+ooo-ooo<br>
+<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br>
+<code class="f">F</code> ooo-ooo <code class="e">E7</code> ooo-ooo<br>
 <code class="a">Am</code> ooo-a-eh-a <code class="f">F</code>
 a-a-a-a-a</p>
-</section>
-<section id="resources-31" class="slide level2">
+</div></section>
+<section id="resources-31" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=Z26BvHOD_sg">Song</a></li>
-<li><a
-href="https://ukutabs.com/i/israel-kamakawiwoole/somewhere-over-the-rainbow-what-a-wonderful-world/">Source
+<li><a href="https://ukutabs.com/i/israel-kamakawiwoole/somewhere-over-the-rainbow-what-a-wonderful-world/">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="summer-wine-nancy-sinatra-lee-hazlewood"
-class="title-slide slide level1">
+<section id="summer-wine-nancy-sinatra-lee-hazlewood" class="title-slide slide level1"><div class="slide-content">
 <h1>Summer wine (Nancy Sinatra &amp; Lee Hazlewood)</h1>
 
-</section>
-<section id="intro-frauen" class="slide level2">
-<h2>Intro <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="intro-frauen" class="slide level2"><div class="slide-content">
+<h2>Intro <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
 <p><code class="a">Am</code> (x4)</p>
-</section>
-<section id="verse-1-männer" class="slide level2">
-<h2>Verse 1 <em>(Männer)</em></h2>
-<p><code class="a">Am</code> I walked in town on silver<br />
-<code class="g">G</code> spurs that jingled to<br />
-<code class="a">Am</code> A song that I had only<br />
+</div></section>
+<section id="verse-1-männer" class="slide level2"><div class="slide-content">
+<h2>Verse 1 <em>(Männer)</em>
+</h2>
+<p><code class="a">Am</code> I walked in town on silver<br>
+<code class="g">G</code> spurs that jingled to<br>
+<code class="a">Am</code> A song that I had only<br>
 <code class="g">G</code> sang to just a few</p>
-<p><code class="d">Dm</code> She saw my silver spurs and<br />
-<code class="a">Am</code> said let’s pass some time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> She saw my silver spurs and<br>
+<code class="a">Am</code> said let’s pass some time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="chorus-frauen" class="slide level2">
-<h2>Chorus <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="chorus-frauen" class="slide level2"><div class="slide-content">
+<h2>Chorus <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
-<p><code class="d">Dm</code> Take off your silver spurs and<br />
-<code class="a">Am</code> help me pass the time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> Take off your silver spurs and<br>
+<code class="a">Am</code> help me pass the time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="verse-2-männer" class="slide level2">
-<h2>Verse 2 <em>(Männer)</em></h2>
-<p><code class="a">Am</code> My eyes grew heavy and my<br />
-<code class="g">G</code> lips they could not speak<br />
-<code class="a">Am</code> I tried to get up but I<br />
+</div></section>
+<section id="verse-2-männer" class="slide level2"><div class="slide-content">
+<h2>Verse 2 <em>(Männer)</em>
+</h2>
+<p><code class="a">Am</code> My eyes grew heavy and my<br>
+<code class="g">G</code> lips they could not speak<br>
+<code class="a">Am</code> I tried to get up but I<br>
 <code class="g">G</code> couldn’t find my feet</p>
-<p><code class="d">Dm</code> She reassured me with an<br />
-<code class="a">Am</code> unfamiliar line<br />
-<code class="d">Dm</code> And then she gave to me<br />
+<p><code class="d">Dm</code> She reassured me with an<br>
+<code class="a">Am</code> unfamiliar line<br>
+<code class="d">Dm</code> And then she gave to me<br>
 <code class="a">Am</code> more summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="chorus-frauen-1" class="slide level2">
-<h2>Chorus <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="chorus-frauen-1" class="slide level2"><div class="slide-content">
+<h2>Chorus <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
-<p><code class="d">Dm</code> Take off your silver spurs and<br />
-<code class="a">Am</code> help me pass the time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> Take off your silver spurs and<br>
+<code class="a">Am</code> help me pass the time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="verse-2-männer-1" class="slide level2">
-<h2>Verse 2 <em>(Männer)</em></h2>
-<p><code class="a">Am</code> When I woke up the sun was<br />
-<code class="g">G</code> shining in my eyes<br />
-<code class="a">Am</code> My silver spurs were gone<br />
+</div></section>
+<section id="verse-2-männer-1" class="slide level2"><div class="slide-content">
+<h2>Verse 2 <em>(Männer)</em>
+</h2>
+<p><code class="a">Am</code> When I woke up the sun was<br>
+<code class="g">G</code> shining in my eyes<br>
+<code class="a">Am</code> My silver spurs were gone<br>
 my <code class="g">G</code> head felt twice its size</p>
-<p><code class="d">Dm</code> She took my silver spurs<br />
-a <code class="a">Am</code> dollar and a dime<br />
-<code class="d">Dm</code> And left me cravin’ for <code
-class="a">Am</code> more summer wine</p>
+<p><code class="d">Dm</code> She took my silver spurs<br>
+a <code class="a">Am</code> dollar and a dime<br>
+<code class="d">Dm</code> And left me cravin’ for <code class="a">Am</code> more summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="chorus-frauen-2" class="slide level2">
-<h2>Chorus <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="chorus-frauen-2" class="slide level2"><div class="slide-content">
+<h2>Chorus <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
-<p><code class="d">Dm</code> Take off your silver spurs and<br />
-<code class="a">Am</code> help me pass the time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> Take off your silver spurs and<br>
+<code class="a">Am</code> help me pass the time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="outro-8" class="slide level2">
+</div></section>
+<section id="outro-8" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="a">Am</code> <code class="g">G</code> <code
-class="a">Am</code> <code class="g">G</code><br />
-<code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code></p>
-</section>
-<section id="resources-32" class="slide level2">
+<p><code class="a">Am</code> <code class="g">G</code> <code class="a">Am</code> <code class="g">G</code><br>
+<code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code></p>
+</div></section>
+<section id="resources-32" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=Ib_eW9VSUwM">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/ville-valo/summer-wine-chords-590088">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/ville-valo/summer-wine-chords-590088">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="the-river-is-flowing-indian-summer"
-class="title-slide slide level1">
+<section id="the-river-is-flowing-indian-summer" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ The river is flowing (Indian Summer)</h1>
 
-</section>
-<section id="verse-1-33" class="slide level2">
+</div></section>
+<section id="verse-1-33" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><em>(Chords sequence remains the same)</em></p>
 <p>The <code class="a">Am</code> river is <code class="c">C</code>
-flowing<br />
+flowing<br>
 <code class="g">G</code> flowing in <code class="a">Am</code>
-growing<br />
-the river is flowing<br />
+growing<br>
+the river is flowing<br>
 back to the sea</p>
-<p>Mother Earth is caring me<br />
-her child I will always be<br />
-Mother Earth is caring me<br />
+<p>Mother Earth is caring me<br>
+her child I will always be<br>
+Mother Earth is caring me<br>
 back to the sea</p>
-</section>
-<section id="verse-2-31" class="slide level2">
+</div></section>
+<section id="verse-2-31" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>The <code class="a">Am</code> Moon she <code class="c">C</code> is
-waiting<br />
+waiting<br>
 <code class="g">G</code> waxing and <code class="a">Am</code>
-waning<br />
-the Moon she is waiting<br />
+waning<br>
+the Moon she is waiting<br>
 for us to be free</p>
-<p>Sister Moon watch over me<br />
-a child I will always be<br />
-Sister Moon watch over me<br />
+<p>Sister Moon watch over me<br>
+a child I will always be<br>
+Sister Moon watch over me<br>
 until we are free</p>
-</section>
-<section id="verse-3-20" class="slide level2">
+</div></section>
+<section id="verse-3-20" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p>The <code class="a">Am</code> Sun he <code class="c">C</code> is
-shining<br />
+shining<br>
 <code class="g">G</code> brightly he’s <code class="a">Am</code>
-shining<br />
-the Sun he is shining<br />
+shining<br>
+the Sun he is shining<br>
 lightning the way</p>
-<p>Father Sun shine over me<br />
-your child I will always be<br />
-father Sun shine over me<br />
+<p>Father Sun shine over me<br>
+your child I will always be<br>
+father Sun shine over me<br>
 until we can see</p>
-</section>
-<section id="verse-4-10" class="slide level2">
+</div></section>
+<section id="verse-4-10" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
 <p>The <code class="a">Am</code> Fire <code class="c">C</code> is
-burning<br />
+burning<br>
 <code class="g">G</code> destroying and <code class="a">Am</code>
-healing<br />
-the Fire is burning<br />
+healing<br>
+the Fire is burning<br>
 for us to get pure</p>
-<p>Violet Flame burn over me<br />
-a child I will always be<br />
-violet Flame burn over me<br />
+<p>Violet Flame burn over me<br>
+a child I will always be<br>
+violet Flame burn over me<br>
 until we are pure</p>
-</section>
-<section id="resources-33" class="slide level2">
+</div></section>
+<section id="resources-33" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=sB2AaVVjF-0">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/indian-summer/the-river-is-flowing-chords-1159196">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/indian-summer/the-river-is-flowing-chords-1159196">Source
 tab</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="verdammt-ich-lieb-dich-matthias-reim"
-class="title-slide slide level1">
+<section id="verdammt-ich-lieb-dich-matthias-reim" class="title-slide slide level1"><div class="slide-content">
 <h1>Verdammt ich lieb dich (Matthias Reim)</h1>
 
-</section>
-<section id="verse-1-34" class="slide level2">
+</div></section>
+<section id="verse-1-34" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>Ich <code class="a">Am</code> ziehe durch die Straßen bis nach
-Mitternacht<br />
-hab das früher auch gern gemacht<br />
+Mitternacht<br>
+hab das früher auch gern gemacht<br>
 dich <code class="g">G</code> brauch ich dafür <code class="a">Am</code>
 nicht!</p>
 <p>Ich <code class="a">Am</code> sitze am Tresen, trinke noch ’n
-Bier<br />
-früher war’n wir oft gemeinsam hier<br />
-das <code class="g">G</code> macht mir, macht mir <code
-class="a">Am</code> nichts!</p>
-</section>
-<section class="slide level2">
+Bier<br>
+früher war’n wir oft gemeinsam hier<br>
+das <code class="g">G</code> macht mir, macht mir <code class="a">Am</code> nichts!</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="c">C</code> Gegenüber sitzt ‘n Typ wie’n Bär<br />
+<p><code class="c">C</code> Gegenüber sitzt ‘n Typ wie’n Bär<br>
 ich <code class="g">G</code> stell’ mir vor, wenn das dein Neuer
-wär’<br />
+wär’<br>
 Das <code class="a">Am</code> juckt mich <code class="g">G</code>
 überhaupt <code class="a">Am</code> nicht.</p>
 <p>Auf <code class="c">C</code> einmal packt’s mich, ich geh auf ihn
-zu<br />
+zu<br>
 und <code class="g">G</code> mach ihn an: “Lass meine Frau in
-Ruh!”<br />
+Ruh!”<br>
 Er <code class="a">Am</code> fragt nur: <code class="g">G</code> “Hast
 du’n <code class="a">Am</code> Stich?”</p>
-<p>Und ich <code class="f">F</code> denke schon wieder nur an <code
-class="g">G</code> dich…</p>
-</section>
-<section id="chorus-43" class="slide level2">
+<p>Und ich <code class="f">F</code> denke schon wieder nur an <code class="g">G</code> dich…</p>
+</div></section>
+<section id="chorus-43" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><em>(x2: gently first time, then repeat intensively)</em></p>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br>
 ich lieb’ dich <code class="g">G</code> nicht.</p>
-<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
-brauch’ dich <code class="a">Am</code> nicht. <code
-class="g">G</code></p>
-<p>Verdammt, ich <code class="c">C</code> will dich,<br />
-ich will dich <code class="g">G</code> nicht,<br />
-Ich <code class="f">F</code> will dich nicht verli<code
-class="a">Am</code>er’n!</p>
-</section>
-<section id="verse-2-32" class="slide level2">
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br>
+brauch’ dich <code class="a">Am</code> nicht. <code class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br>
+ich will dich <code class="g">G</code> nicht,<br>
+Ich <code class="f">F</code> will dich nicht verli<code class="a">Am</code>er’n!</p>
+</div></section>
+<section id="verse-2-32" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>So <code class="a">Am</code> langsam fällt mir alles wieder
-ein:<br />
-Ich wollt doch nur’n bisschen freier sein.<br />
-Jetzt <code class="g">G</code> bin ich’s - oder <code
-class="a">Am</code> nicht?</p>
-<p>Ich <code class="a">Am</code> passte nicht in deine heile Welt<br />
-doch die und du ist, was mir jetzt so fehlt<br />
+ein:<br>
+Ich wollt doch nur’n bisschen freier sein.<br>
+Jetzt <code class="g">G</code> bin ich’s - oder <code class="a">Am</code> nicht?</p>
+<p>Ich <code class="a">Am</code> passte nicht in deine heile Welt<br>
+doch die und du ist, was mir jetzt so fehlt<br>
 ich <code class="g">G</code> glaub das einfach <code class="a">Am</code>
 nicht.</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="c">C</code> Gegenüber steht ’n Telefon<br />
-es <code class="g">G</code> lacht mich ständig an voll Hohn<br />
+<p><code class="c">C</code> Gegenüber steht ’n Telefon<br>
+es <code class="g">G</code> lacht mich ständig an voll Hohn<br>
 Es <code class="a">Am</code> klingelt, <code class="g">G</code> klingelt
 aber <code class="a">Am</code> nicht.</p>
-<p><code class="c">C</code> Sieben Bier, zuviel geraucht<br />
-das <code class="g">G</code> ist es, was ein Mann so braucht,<br />
+<p><code class="c">C</code> Sieben Bier, zuviel geraucht<br>
+das <code class="g">G</code> ist es, was ein Mann so braucht,<br>
 Doch <code class="f">F</code> niemand, <code class="g">G</code> niemand
 sagt: “Hör auf”. <code class="a">Am</code></p>
-<p>Und ich <code class="f">F</code> denke schon wieder nur an <code
-class="g">G</code> dich…</p>
-</section>
-<section id="chorus-44" class="slide level2">
+<p>Und ich <code class="f">F</code> denke schon wieder nur an <code class="g">G</code> dich…</p>
+</div></section>
+<section id="chorus-44" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br>
 ich lieb’ dich <code class="g">G</code> nicht.</p>
-<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
-brauch’ dich <code class="a">Am</code> nicht. <code
-class="g">G</code></p>
-<p>Verdammt, ich <code class="c">C</code> will dich,<br />
-ich will dich <code class="g">G</code> nicht,<br />
-Ich <code class="f">F</code> will dich nicht verli<code
-class="a">Am</code>er’n! - Ooooh!</p>
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br>
+brauch’ dich <code class="a">Am</code> nicht. <code class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br>
+ich will dich <code class="g">G</code> nicht,<br>
+Ich <code class="f">F</code> will dich nicht verli<code class="a">Am</code>er’n! - Ooooh!</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
-<section id="resources-34" class="slide level2">
+</div></section>
+<section id="resources-34" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=x6q0ciiqyG0">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/matthias-reim/verdammt-ich-lieb-dich-chords-1680929">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/matthias-reim/verdammt-ich-lieb-dich-chords-1680929">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=GIlCtOrisx0">Guitar
 cover</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="whats-up-4-non-blondes" class="title-slide slide level1">
+<section id="whats-up-4-non-blondes" class="title-slide slide level1"><div class="slide-content">
 <h1>Whats up (4 Non Blondes)</h1>
 
-</section>
-<section id="intro-21" class="slide level2">
+</div></section>
+<section id="intro-21" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="d">D</code> <code class="e">Em</code> <code
-class="g">G</code> <code class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse-1-35" class="slide level2">
+<p><code class="d">D</code> <code class="e">Em</code> <code class="g">G</code> <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-1-35" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="d">D</code> Twenty-five years and my life is still<br />
-<code class="e">Em</code> Trying to get up that great big hill<br />
-Of <code class="g">G</code> hope for a destina<code
-class="d">D</code>tion</p>
+<p><code class="d">D</code> Twenty-five years and my life is still<br>
+<code class="e">Em</code> Trying to get up that great big hill<br>
+Of <code class="g">G</code> hope for a destina<code class="d">D</code>tion</p>
 <p>I <code class="d">D</code> realized quickly when I knew I
-should<br />
+should<br>
 That the world <code class="e">Em</code> was made of this
-brotherhood<br />
-Of man, <code class="g">G</code> for whatever that means <code
-class="d">D</code></p>
-</section>
-<section id="pre-chorus-2" class="slide level2">
+brotherhood<br>
+Of man, <code class="g">G</code> for whatever that means <code class="d">D</code></p>
+</div></section>
+<section id="pre-chorus-2" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
 <p>And so I <code class="d">D</code> cry sometimes when I’m lying in
-bed<br />
+bed<br>
 Just to <code class="e">Em</code> get it all out, what’s in my
-head<br />
-and I <code class="g">G</code> - I am feeling a little pecu<code
-class="d">D</code>liar</p>
+head<br>
+and I <code class="g">G</code> - I am feeling a little pecu<code class="d">D</code>liar</p>
 <p>And so I <code class="d">D</code> wake in the morning and I step
-outside<br />
+outside<br>
 and I <code class="e">Em</code> take a deep breath and I get real high
-and<br />
+and<br>
 I <code class="g">G</code> scream at the top of my lungs:</p>
 <p>“What’s going <code class="d">D</code> on?”</p>
-</section>
-<section id="chorus-45" class="slide level2">
+</div></section>
+<section id="chorus-45" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code><br />
-And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code></p>
-</section>
-<section id="interlude-6" class="slide level2">
+<p>And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code><br>
+And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code></p>
+</div></section>
+<section id="interlude-6" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
-<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code
-class="g">G</code> Ooh <code class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse" class="slide level2">
+<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code class="g">G</code> Ooh <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse" class="slide level2"><div class="slide-content">
 <h2>Verse</h2>
-<p>And I try, <code class="d">D</code> oh my Aod do I try <code
-class="e">Em</code><br />
-I try all the time, <code class="g">G</code> in this institu<code
-class="d">D</code>tion<br />
-And I pray, <code class="d">D</code> oh my god do I pray <code
-class="e">Em</code><br />
-I pray every single day <code class="g">G</code><br />
+<p>And I try, <code class="d">D</code> oh my Aod do I try <code class="e">Em</code><br>
+I try all the time, <code class="g">G</code> in this institu<code class="d">D</code>tion<br>
+And I pray, <code class="d">D</code> oh my god do I pray <code class="e">Em</code><br>
+I pray every single day <code class="g">G</code><br>
 For a revo<code class="d">D</code>lution</p>
-</section>
-<section id="pre-chorus-3" class="slide level2">
+</div></section>
+<section id="pre-chorus-3" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
 <p>And so I <code class="d">D</code> cry sometimes when I’m lying in
-bed<br />
+bed<br>
 Just to <code class="e">Em</code> get it all out, what’s in my
-head<br />
-and I <code class="g">G</code> - I am feeling a little pecu<code
-class="d">D</code>liar</p>
+head<br>
+and I <code class="g">G</code> - I am feeling a little pecu<code class="d">D</code>liar</p>
 <p>And so I <code class="d">D</code> wake in the morning and I step
-outside<br />
+outside<br>
 and I <code class="e">Em</code> take a deep breath and I get real high
-and<br />
+and<br>
 I <code class="g">G</code> scream at the top of my lungs:</p>
 <p>“What’s going <code class="d">D</code> on?”</p>
-</section>
-<section id="chorus-46" class="slide level2">
+</div></section>
+<section id="chorus-46" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code><br />
-And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code></p>
+<p>And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code><br>
+And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code></p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="interlude-7" class="slide level2">
+</div></section>
+<section id="interlude-7" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
-<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code
-class="g">G</code> Ooh <code class="d">D</code></p>
-</section>
-<section id="outro-9" class="slide level2">
+<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code class="g">G</code> Ooh <code class="d">D</code></p>
+</div></section>
+<section id="outro-9" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="d">D</code> Twenty-five years and my life is still<br />
-<code class="e">Em</code> Trying to get up that great big hill<br />
-Of <code class="g">G</code> hope for a destina<code
-class="d">D</code>tion</p>
-</section>
-<section id="resources-35" class="slide level2">
+<p><code class="d">D</code> Twenty-five years and my life is still<br>
+<code class="e">Em</code> Trying to get up that great big hill<br>
+Of <code class="g">G</code> hope for a destina<code class="d">D</code>tion</p>
+</div></section>
+<section id="resources-35" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=6NXnxTNIWkc">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/4-non-blondes/whats-up-chords-268676">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/4-non-blondes/whats-up-chords-268676">Source
 tab</a></li>
 <li><a href="">Guitar tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="wild-world-cat-stevens" class="title-slide slide level1">
+<section id="wild-world-cat-stevens" class="title-slide slide level1"><div class="slide-content">
 <h1>Wild world (Cat Stevens)</h1>
 
-</section>
-<section id="instructions-8" class="slide level2">
+</div></section>
+<section id="instructions-8" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>     |E A D G B e|
      |-----------|
@@ -4755,209 +4168,189 @@ G |---2p0-------|--------------|
 D |------3p2p0--|--------------|
 A |-----------3-|---0-3-3-3-0-3|
 E |------------3|3-3---------3-|</code></pre>
-</section>
-<section id="intro-22" class="slide level2">
+</div></section>
+<section id="intro-22" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="d">D/F#</code> <code
-class="g">G</code> <code class="c">C</code> <code class="f">F</code>
-<code class="d">Dm</code> <code class="e">E</code> <code
-class="e">Esus4</code> <code class="e">E</code><br />
+<p><code class="a">Am</code> <code class="d">D/F#</code> <code class="g">G</code> <code class="c">C</code> <code class="f">F</code>
+<code class="d">Dm</code> <code class="e">E</code> <code class="e">Esus4</code> <code class="e">E</code><br>
 La la la…</p>
-</section>
-<section id="verse-1-36" class="slide level2">
+</div></section>
+<section id="verse-1-36" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><code class="a">Am</code> Now that I’ve <code class="d">D/F#</code>
-lost everything to <code class="g">G</code> you<br />
-You say you <code class="c">C</code> wanna start something <code
-class="f">F</code> new<br />
-And it’s <code class="d">Dm</code> breaking my heart you’re <code
-class="e">E</code> leaving<br />
-Baby I’m <code class="e">Esus4</code> griev<code
-class="e">E</code>ing</p>
-<p>But <code class="a">Am</code> if you wanna <code
-class="d">D/F#</code> leave take good <code class="g">G</code>
-care<br />
+lost everything to <code class="g">G</code> you<br>
+You say you <code class="c">C</code> wanna start something <code class="f">F</code> new<br>
+And it’s <code class="d">Dm</code> breaking my heart you’re <code class="e">E</code> leaving<br>
+Baby I’m <code class="e">Esus4</code> griev<code class="e">E</code>ing</p>
+<p>But <code class="a">Am</code> if you wanna <code class="d">D/F#</code> leave take good <code class="g">G</code>
+care<br>
 Hope you have a <code class="c">C</code> lot of nice things to wear
-<code class="f">F</code><br />
-But then a <code class="d">Dm</code> lot of nice things turn<br />
-<code class="e">E</code> bad out<code class="e">E7</code>there <code
-class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
+<code class="f">F</code><br>
+But then a <code class="d">Dm</code> lot of nice things turn<br>
+<code class="e">E</code> bad out<code class="e">E7</code>there <code class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 <code class="g">G5</code></p>
-</section>
-<section id="chorus-47" class="slide level2">
+</div></section>
+<section id="chorus-47" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> It’s hard to get by<br>
 <code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> I’ll always remember you<br>
 <code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
-</section>
-<section id="verse-2-33" class="slide level2">
+</div></section>
+<section id="verse-2-33" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> You know I’ve seen a <code
-class="d">D/F#</code> lot of<br />
-what the world can <code class="g">G</code> do<br />
-And it’s <code class="c">C</code> breaking my heart in <code
-class="f">F</code> two<br />
-’cause I <code class="d">Dm</code> never want to see you <code
-class="e">E</code> sad girl<br />
+<p><code class="a">Am</code> You know I’ve seen a <code class="d">D/F#</code> lot of<br>
+what the world can <code class="g">G</code> do<br>
+And it’s <code class="c">C</code> breaking my heart in <code class="f">F</code> two<br>
+’cause I <code class="d">Dm</code> never want to see you <code class="e">E</code> sad girl<br>
 Don’t be a <code class="e">Esus4</code> bad <code class="e">E</code>
 girl</p>
-<p>But <code class="a">Am</code> if you wanna <code
-class="d">D/F#</code> leave take good <code class="g">G</code>
-care<br />
+<p>But <code class="a">Am</code> if you wanna <code class="d">D/F#</code> leave take good <code class="g">G</code>
+care<br>
 Hope you make a <code class="c">C</code> lot of nice friends out there
-<code class="f">F</code><br />
-But just re<code class="d">Dm</code>member there’s a lot of bad<br />
-<code class="e">E</code> and be<code class="e">E7</code>ware <code
-class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
+<code class="f">F</code><br>
+But just re<code class="d">Dm</code>member there’s a lot of bad<br>
+<code class="e">E</code> and be<code class="e">E7</code>ware <code class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 <code class="g">G5</code></p>
-</section>
-<section id="chorus-48" class="slide level2">
+</div></section>
+<section id="chorus-48" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> It’s hard to get by<br>
 <code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> I’ll always remember you<br>
 <code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
-</section>
-<section id="verse-3-21" class="slide level2">
+</div></section>
+<section id="verse-3-21" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> <code class="d">D/F#</code> <code
-class="g">G</code> <code class="c">C</code> <code class="f">F</code>
-<code class="d">Dm</code> <code class="e">E</code> <code
-class="e">Esus4</code> <code class="e">E</code><br />
+<p><code class="a">Am</code> <code class="d">D/F#</code> <code class="g">G</code> <code class="c">C</code> <code class="f">F</code>
+<code class="d">Dm</code> <code class="e">E</code> <code class="e">Esus4</code> <code class="e">E</code><br>
 La la la… Baby I love you</p>
-<p>But <code class="a">Am</code> if you wanna <code
-class="d">D/F#</code> leave take good <code class="g">G</code>
-care<br />
+<p>But <code class="a">Am</code> if you wanna <code class="d">D/F#</code> leave take good <code class="g">G</code>
+care<br>
 Hope you make a <code class="c">C</code> lot of nice friends out there
-<code class="f">F</code><br />
-But just re<code class="d">Dm</code>member there’s a lot of bad<br />
-<code class="e">E</code> and be<code class="e">E7</code>ware <code
-class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
+<code class="f">F</code><br>
+But just re<code class="d">Dm</code>member there’s a lot of bad<br>
+<code class="e">E</code> and be<code class="e">E7</code>ware <code class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 <code class="g">G5</code></p>
-</section>
-<section id="chorus-49" class="slide level2">
+</div></section>
+<section id="chorus-49" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> It’s hard to get by<br>
 <code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> I’ll always remember you<br>
 <code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code> <em>(1st time
 only)</em></p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="resources-36" class="slide level2">
+</div></section>
+<section id="resources-36" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=yffOnXYgy3o">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/cat-stevens/wild-world-chords-992169">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/cat-stevens/wild-world-chords-992169">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=SeDzGf7L3Fs">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
 <section>
-<section id="wish-you-were-here-pink-floyd"
-class="title-slide slide level1">
+<section id="wish-you-were-here-pink-floyd" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ Wish you were here (Pink Floyd)</h1>
 
-</section>
-<section id="intro-23" class="slide level2">
+</div></section>
+<section id="intro-23" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="a">A</code> <code class="e">Em</code><br />
+<p><code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="a">A</code> <code class="e">Em</code><br>
 <code class="a">A</code> <code class="g">G</code></p>
 <p><em>(Repeat with solo)</em></p>
-</section>
-<section id="verse-1-37" class="slide level2">
+</div></section>
+<section id="verse-1-37" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="c">C</code> So, so you think you can <code
-class="d">D</code> tell<br />
-heaven from <code class="a">Am</code> hell?<br />
+<p><code class="c">C</code> So, so you think you can <code class="d">D</code> tell<br>
+heaven from <code class="a">Am</code> hell?<br>
 Blue skies from <code class="g">G</code> pain?</p>
-<p>Can you tell a green <code class="d">D</code> field<br />
-from a cold steel <code class="c">C</code> rail?<br />
-A smile from a <code class="a">Am</code> veil?<br />
+<p>Can you tell a green <code class="d">D</code> field<br>
+from a cold steel <code class="c">C</code> rail?<br>
+A smile from a <code class="a">Am</code> veil?<br>
 Do you think you can <code class="g">G</code> tell?</p>
-</section>
-<section id="verse-2-34" class="slide level2">
+</div></section>
+<section id="verse-2-34" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Did they get you to <code class="c">C</code> trade<br />
-your heroes for <code class="d">D</code> ghosts?<br />
-Hot ashes for <code class="a">Am</code> trees?<br />
+<p>Did they get you to <code class="c">C</code> trade<br>
+your heroes for <code class="d">D</code> ghosts?<br>
+Hot ashes for <code class="a">Am</code> trees?<br>
 Hot air for a <code class="g">G</code> cool breeze?</p>
-<p>Cold comfort for <code class="d">D</code> change?<br />
-And did you ex<code class="c">C</code>change<br />
-a walk-on part in the <code class="a">Am</code> war<br />
+<p>Cold comfort for <code class="d">D</code> change?<br>
+And did you ex<code class="c">C</code>change<br>
+a walk-on part in the <code class="a">Am</code> war<br>
 for a lead role in a <code class="g">G</code> cage?</p>
-</section>
-<section id="interlude-8" class="slide level2">
+</div></section>
+<section id="interlude-8" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
-<p><code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="a">A</code> <code class="e">Em</code><br />
+<p><code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="a">A</code> <code class="e">Em</code><br>
 <code class="a">A</code> <code class="g">G</code></p>
-</section>
-<section id="chorus-50" class="slide level2">
+</div></section>
+<section id="chorus-50" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> How I wish<br />
-how I wish you were <code class="d">D</code> here<br />
-We’re just <code class="a">Am</code> two lost souls<br />
-swimming in a fishbowl<br />
+<p><code class="c">C</code> How I wish<br>
+how I wish you were <code class="d">D</code> here<br>
+We’re just <code class="a">Am</code> two lost souls<br>
+swimming in a fishbowl<br>
 <code class="g">G</code> year after year</p>
-<p><code class="d">D</code> Running over the same old ground<br />
-<code class="c">C</code> what have we found?<br />
-The same old <code class="a">Am</code> fears<br />
+<p><code class="d">D</code> Running over the same old ground<br>
+<code class="c">C</code> what have we found?<br>
+The same old <code class="a">Am</code> fears<br>
 Wish you were <code class="g">G</code> here</p>
-</section>
-<section id="outro-10" class="slide level2">
+</div></section>
+<section id="outro-10" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="a">A</code> <code class="e">Em</code><br />
+<p><code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="a">A</code> <code class="e">Em</code><br>
 <code class="a">A</code> <code class="g">G</code></p>
 <p><em>(Fade out slowly)</em></p>
-</section>
-<section id="resources-37" class="slide level2">
+</div></section>
+<section id="resources-37" class="slide level2"><div class="slide-content">
 <h2>Resources</h2>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=IXdNnw99-Ic">Song</a></li>
-<li><a
-href="https://tabs.ultimate-guitar.com/tab/pink-floyd/wish-you-were-here-chords-1088963">Source
+<li><a href="https://tabs.ultimate-guitar.com/tab/pink-floyd/wish-you-were-here-chords-1088963">Source
 tab</a></li>
 <li><a href="https://www.youtube.com/watch?v=N2dQRYyaglk">Guitar
 tutorial</a></li>
 </ul>
-</section></section>
+</div></section></section>
     </div>
   </div>
 
@@ -5081,7 +4474,7 @@ tutorial</a></li>
         mouseWheel: false,
 
         // The display mode that will be used to show slides
-        display: 'block',
+        display: 'flex',
 
         // Hide cursor if inactive
         hideInactiveCursor: true,
@@ -5116,5 +4509,6 @@ tutorial</a></li>
     </script>
       <script src="https://multiplex.up.railway.app/socket.io/socket.io.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
+  <script src="style/slide-zoom.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4562,12 +4562,13 @@ class="g">G</code> dich…</p>
 <section id="chorus-43" class="slide level2">
 <h2>Chorus</h2>
 <p><em>(x2: gently first time, then repeat intensively)</em></p>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich, ich lieb’ dich
-<code class="g">G</code> nicht.<br />
-Verdammt, ich <code class="d">Dm</code> brauch’ dich, brauch’ dich <code
-class="a">Am</code> nicht. <code class="g">G</code><br />
-Verdammt, ich <code class="c">C</code> will dich, ich will dich <code
-class="g">G</code> nicht,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+ich lieb’ dich <code class="g">G</code> nicht.</p>
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
+brauch’ dich <code class="a">Am</code> nicht. <code
+class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br />
+ich will dich <code class="g">G</code> nicht,<br />
 Ich <code class="f">F</code> will dich nicht verli<code
 class="a">Am</code>er’n!</p>
 </section>
@@ -4598,12 +4599,13 @@ class="g">G</code> dich…</p>
 </section>
 <section id="chorus-44" class="slide level2">
 <h2>Chorus</h2>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich, ich lieb’ dich
-<code class="g">G</code> nicht.<br />
-Verdammt, ich <code class="d">Dm</code> brauch’ dich, brauch’ dich <code
-class="a">Am</code> nicht. <code class="g">G</code><br />
-Verdammt, ich <code class="c">C</code> will dich, ich will dich <code
-class="g">G</code> nicht,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+ich lieb’ dich <code class="g">G</code> nicht.</p>
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
+brauch’ dich <code class="a">Am</code> nicht. <code
+class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br />
+ich will dich <code class="g">G</code> nicht,<br />
 Ich <code class="f">F</code> will dich nicht verli<code
 class="a">Am</code>er’n! - Ooooh!</p>
 <p><em>(Repeat and fade)</em></p>
@@ -4784,17 +4786,17 @@ class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 </section>
 <section id="chorus-47" class="slide level2">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by <code class="f">F</code>
-just upon a <code class="c">C</code> smile<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> It’s hard to get by<br />
+<code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> I’ll always remember you<br />
+<code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-2-33" class="slide level2">
@@ -4820,17 +4822,17 @@ class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 </section>
 <section id="chorus-48" class="slide level2">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by <code class="f">F</code>
-just upon a <code class="c">C</code> smile<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> It’s hard to get by<br />
+<code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> I’ll always remember you<br />
+<code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-3-21" class="slide level2">
@@ -4852,17 +4854,17 @@ class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 </section>
 <section id="chorus-49" class="slide level2">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by <code class="f">F</code>
-just upon a <code class="c">C</code> smile<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> It’s hard to get by<br />
+<code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> I’ll always remember you<br />
+<code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code> <em>(1st time
 only)</em></p>
 <p><em>(Repeat)</em></p>
@@ -5012,7 +5014,7 @@ tutorial</a></li>
 
         // Disables the default reveal.js slide layout (scaling and centering)
         // so that you can use custom CSS layout
-        disableLayout: false,
+        disableLayout: true,
 
         // Vertical centering of slides
         center: true,
@@ -5107,13 +5109,6 @@ tutorial</a></li>
         // devices. It is advisable to set this to a lower number than
         // viewDistance in order to save resources.
         mobileViewDistance: 2,
-
-        // The "normal" size of the presentation, aspect ratio will be preserved
-        // when the presentation is scaled to fit different resolutions. Can be
-        // specified using percentage units.
-        width: 960,
-
-        height: 640,
 
         // reveal.js plugins
         plugins: []

--- a/print.html
+++ b/print.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
   <meta name="author" content="😊 Josua &amp; Monika ❤️">
@@ -34,8 +35,20 @@ body {
 #TOC ul {
   font-size: 0.85em;
 }
+.reveal section .slide-content {
+  padding: 10px;
+}
+
 .reveal section h1 {
-  font-size: 3em;
+  font-size: 2em;
+}
+
+.reveal section h2 {
+  font-size: 1.5em;
+}
+
+.reveal section h3 {
+  font-size: 1.25em;
 }
 
 .reveal section code {
@@ -77,6 +90,20 @@ body {
   text-align: left;
 }
 
+.reveal section.slide.level2 .slide-content {
+  white-space: nowrap;
+}
+
+section.stack {
+  flex-direction: column;
+  justify-content: center;
+}
+
+section.slide.level2 {
+  display: flex;
+  justify-content: center;
+}
+
     .reveal .sourceCode {  /* see #7635 */
       overflow: visible;
     }
@@ -104,128 +131,94 @@ body {
   <div class="reveal">
     <div class="slides">
 
-<section id="title-slide" data-background-image="style/background.jpg">
+<section id="title-slide" data-background-image="style/background.jpg"><div class="slide-content">
   <h1 class="title">Lieblings-Songs 🔥🎶🌛</h1>
   <p class="author">😊 Josua &amp; Monika ❤️</p>
-</section>
-<section id="TOC">
+</div></section>
+<section id="TOC"><div class="slide-content">
 <nav role="doc-toc"> 
 <ul>
-<li><a href="#/introduction"
-id="/toc-introduction">Introduction</a></li>
-<li><a href="#/across-the-universe-beatles"
-id="/toc-across-the-universe-beatles">Across the universe
+<li><a href="#/introduction" id="/toc-introduction">Introduction</a></li>
+<li><a href="#/across-the-universe-beatles" id="/toc-across-the-universe-beatles">Across the universe
 (Beatles)</a></li>
-<li><a href="#/as-long-as-you-love-me-backstreet-boys"
-id="/toc-as-long-as-you-love-me-backstreet-boys">As long as you love me
+<li><a href="#/as-long-as-you-love-me-backstreet-boys" id="/toc-as-long-as-you-love-me-backstreet-boys">As long as you love me
 (Backstreet Boys)</a></li>
-<li><a href="#/baby-one-more-time-britney-spears"
-id="/toc-baby-one-more-time-britney-spears">Baby one more time (Britney
+<li><a href="#/baby-one-more-time-britney-spears" id="/toc-baby-one-more-time-britney-spears">Baby one more time (Britney
 Spears)</a></li>
-<li><a href="#/bella-ciao-traditional"
-id="/toc-bella-ciao-traditional">Bella ciao (Traditional)</a></li>
-<li><a href="#/dont-worry-be-happy-bobby-mcferrin"
-id="/toc-dont-worry-be-happy-bobby-mcferrin">Don’t worry be happy (Bobby
+<li><a href="#/bella-ciao-traditional" id="/toc-bella-ciao-traditional">Bella ciao (Traditional)</a></li>
+<li><a href="#/dont-worry-be-happy-bobby-mcferrin" id="/toc-dont-worry-be-happy-bobby-mcferrin">Don’t worry be happy (Bobby
 McFerrin)</a></li>
 <li><a href="#/dr-eskimo-mani-matter" id="/toc-dr-eskimo-mani-matter">Dr
 Eskimo (Mani Matter)</a></li>
-<li><a href="#/dr-sidi-abdel-assar-mani-matter"
-id="/toc-dr-sidi-abdel-assar-mani-matter">Dr Sidi Abdel Assar (Mani
+<li><a href="#/dr-sidi-abdel-assar-mani-matter" id="/toc-dr-sidi-abdel-assar-mani-matter">Dr Sidi Abdel Assar (Mani
 Matter)</a></li>
-<li><a href="#/dr-wilhelm-täll-mani-matter"
-id="/toc-dr-wilhelm-täll-mani-matter">Dr Wilhelm Täll (Mani
+<li><a href="#/dr-wilhelm-t%C3%A4ll-mani-matter" id="/toc-dr-wilhelm-täll-mani-matter">Dr Wilhelm Täll (Mani
 Matter)</a></li>
-<li><a href="#/dynamit-mani-matter"
-id="/toc-dynamit-mani-matter">Dynamit (Mani Matter)</a></li>
-<li><a href="#/father-and-son-cat-stevens"
-id="/toc-father-and-son-cat-stevens">Father and son (Cat
+<li><a href="#/dynamit-mani-matter" id="/toc-dynamit-mani-matter">Dynamit (Mani Matter)</a></li>
+<li><a href="#/father-and-son-cat-stevens" id="/toc-father-and-son-cat-stevens">Father and son (Cat
 Stevens)</a></li>
 <li><a href="#/feel-robbie-williams" id="/toc-feel-robbie-williams">Feel
 (Robbie Williams)</a></li>
-<li><a href="#/further-on-up-the-road-johnny-cash"
-id="/toc-further-on-up-the-road-johnny-cash">Further on up the road
+<li><a href="#/further-on-up-the-road-johnny-cash" id="/toc-further-on-up-the-road-johnny-cash">Further on up the road
 (Johnny Cash)</a></li>
-<li><a href="#/griechischer-wein-udo-jürgens"
-id="/toc-griechischer-wein-udo-jürgens">Griechischer Wein (Udo
+<li><a href="#/griechischer-wein-udo-j%C3%BCrgens" id="/toc-griechischer-wein-udo-jürgens">Griechischer Wein (Udo
 Jürgens)</a></li>
-<li><a href="#/hallelujah-leonard-cohen"
-id="/toc-hallelujah-leonard-cohen">❤️ Hallelujah (Leonard
+<li><a href="#/hallelujah-leonard-cohen" id="/toc-hallelujah-leonard-cohen">❤️ Hallelujah (Leonard
 Cohen)</a></li>
-<li><a href="#/hemmige-mani-matter"
-id="/toc-hemmige-mani-matter">Hemmige (Mani Matter)</a></li>
+<li><a href="#/hemmige-mani-matter" id="/toc-hemmige-mani-matter">Hemmige (Mani Matter)</a></li>
 <li><a href="#/hurt-johnny-cash" id="/toc-hurt-johnny-cash">Hurt (Johnny
 Cash)</a></li>
-<li><a href="#/i-am-sailing-rod-stewart"
-id="/toc-i-am-sailing-rod-stewart">I am sailing (Rod Stewart)</a></li>
+<li><a href="#/i-am-sailing-rod-stewart" id="/toc-i-am-sailing-rod-stewart">I am sailing (Rod Stewart)</a></li>
 <li><a href="#/jolene-dolly-parton" id="/toc-jolene-dolly-parton">❤️
 Jolene (Dolly Parton)</a></li>
-<li><a href="#/junge-die-ärzte" id="/toc-junge-die-ärzte">Junge (Die
+<li><a href="#/junge-die-%C3%A4rzte" id="/toc-junge-die-ärzte">Junge (Die
 Ärzte)</a></li>
-<li><a href="#/keep-on-the-sunny-side-carter-family"
-id="/toc-keep-on-the-sunny-side-carter-family">Keep on the sunny side
+<li><a href="#/keep-on-the-sunny-side-carter-family" id="/toc-keep-on-the-sunny-side-carter-family">Keep on the sunny side
 (Carter Family)</a></li>
-<li><a href="#/lemon-tree-fools-garden"
-id="/toc-lemon-tree-fools-garden">Lemon tree (Fool’s Garden)</a></li>
-<li><a href="#/morning-has-broken-cat-stevens"
-id="/toc-morning-has-broken-cat-stevens">Morning has broken (Cat
+<li><a href="#/lemon-tree-fools-garden" id="/toc-lemon-tree-fools-garden">Lemon tree (Fool’s Garden)</a></li>
+<li><a href="#/morning-has-broken-cat-stevens" id="/toc-morning-has-broken-cat-stevens">Morning has broken (Cat
 Stevens)</a></li>
-<li><a href="#/männer-sind-schweine-die-ärzte"
-id="/toc-männer-sind-schweine-die-ärzte">Männer sind Schweine (Die
+<li><a href="#/m%C3%A4nner-sind-schweine-die-%C3%A4rzte" id="/toc-männer-sind-schweine-die-ärzte">Männer sind Schweine (Die
 Ärzte)</a></li>
-<li><a href="#/no-woman-no-cry-bob-marley"
-id="/toc-no-woman-no-cry-bob-marley">No woman no cry (Bob
+<li><a href="#/no-woman-no-cry-bob-marley" id="/toc-no-woman-no-cry-bob-marley">No woman no cry (Bob
 Marley)</a></li>
 <li><a href="#/one-u2" id="/toc-one-u2">One (U2)</a></li>
-<li><a href="#/rivers-of-babylon-boney-m."
-id="/toc-rivers-of-babylon-boney-m.">Rivers of Babylon (Boney
+<li><a href="#/rivers-of-babylon-boney-m." id="/toc-rivers-of-babylon-boney-m.">Rivers of Babylon (Boney
 M.)</a></li>
-<li><a href="#/road-to-mandalay-robbie-williams"
-id="/toc-road-to-mandalay-robbie-williams">Road to Mandalay (Robbie
+<li><a href="#/road-to-mandalay-robbie-williams" id="/toc-road-to-mandalay-robbie-williams">Road to Mandalay (Robbie
 Williams)</a></li>
-<li><a href="#/road-trippin-red-hot-chili-peppers"
-id="/toc-road-trippin-red-hot-chili-peppers">Road trippin’ (Red Hot
+<li><a href="#/road-trippin-red-hot-chili-peppers" id="/toc-road-trippin-red-hot-chili-peppers">Road trippin’ (Red Hot
 Chili Peppers)</a></li>
-<li><a href="#/s-zündhölzli-mani-matter"
-id="/toc-s-zündhölzli-mani-matter">S Zündhölzli (Mani Matter)</a></li>
-<li><a href="#/sittin-on-the-dock-of-the-bay-otis-redding"
-id="/toc-sittin-on-the-dock-of-the-bay-otis-redding">Sittin’ on the dock
+<li><a href="#/s-z%C3%BCndh%C3%B6lzli-mani-matter" id="/toc-s-zündhölzli-mani-matter">S Zündhölzli (Mani Matter)</a></li>
+<li><a href="#/sittin-on-the-dock-of-the-bay-otis-redding" id="/toc-sittin-on-the-dock-of-the-bay-otis-redding">Sittin’ on the dock
 of the bay (Otis Redding)</a></li>
-<li><a href="#/something-stupid-robbie-williams"
-id="/toc-something-stupid-robbie-williams">Something stupid (Robbie
+<li><a href="#/something-stupid-robbie-williams" id="/toc-something-stupid-robbie-williams">Something stupid (Robbie
 Williams)</a></li>
-<li><a href="#/somewhere-over-the-rainbow-israël-kamakawiwoole"
-id="/toc-somewhere-over-the-rainbow-israël-kamakawiwoole">Somewhere over
+<li><a href="#/somewhere-over-the-rainbow-isra%C3%ABl-kamakawiwoole" id="/toc-somewhere-over-the-rainbow-israël-kamakawiwoole">Somewhere over
 the rainbow (Israël Kamakawiwo’ole)</a></li>
-<li><a href="#/summer-wine-nancy-sinatra-lee-hazlewood"
-id="/toc-summer-wine-nancy-sinatra-lee-hazlewood">Summer wine (Nancy
+<li><a href="#/summer-wine-nancy-sinatra-lee-hazlewood" id="/toc-summer-wine-nancy-sinatra-lee-hazlewood">Summer wine (Nancy
 Sinatra &amp; Lee Hazlewood)</a></li>
-<li><a href="#/the-river-is-flowing-indian-summer"
-id="/toc-the-river-is-flowing-indian-summer">❤️ The river is flowing
+<li><a href="#/the-river-is-flowing-indian-summer" id="/toc-the-river-is-flowing-indian-summer">❤️ The river is flowing
 (Indian Summer)</a></li>
-<li><a href="#/verdammt-ich-lieb-dich-matthias-reim"
-id="/toc-verdammt-ich-lieb-dich-matthias-reim">Verdammt ich lieb dich
+<li><a href="#/verdammt-ich-lieb-dich-matthias-reim" id="/toc-verdammt-ich-lieb-dich-matthias-reim">Verdammt ich lieb dich
 (Matthias Reim)</a></li>
-<li><a href="#/whats-up-4-non-blondes"
-id="/toc-whats-up-4-non-blondes">Whats up (4 Non Blondes)</a></li>
-<li><a href="#/wild-world-cat-stevens"
-id="/toc-wild-world-cat-stevens">Wild world (Cat Stevens)</a></li>
-<li><a href="#/wish-you-were-here-pink-floyd"
-id="/toc-wish-you-were-here-pink-floyd">❤️ Wish you were here (Pink
+<li><a href="#/whats-up-4-non-blondes" id="/toc-whats-up-4-non-blondes">Whats up (4 Non Blondes)</a></li>
+<li><a href="#/wild-world-cat-stevens" id="/toc-wild-world-cat-stevens">Wild world (Cat Stevens)</a></li>
+<li><a href="#/wish-you-were-here-pink-floyd" id="/toc-wish-you-were-here-pink-floyd">❤️ Wish you were here (Pink
 Floyd)</a></li>
 </ul>
 </nav>
-</section>
+</div></section>
 
 <section>
-<section id="introduction" class="title-slide slide level1">
+<section id="introduction" class="title-slide slide level1"><div class="slide-content">
 <h1>Introduction</h1>
 
-</section>
-<section id="welcome" class="slide level2">
+</div></section>
+<section id="welcome" class="slide level2"><div class="slide-content">
 <h2>Welcome</h2>
-<p>This is a collection of my favourite guitar songs.<br />
-🎤😍🎸🔥 Find it on <a
-href="https://songs.josh.ch">songs.josh.ch</a>.</p>
+<p>This is a collection of my favourite guitar songs.<br>
+🎤😍🎸🔥 Find it on <a href="https://songs.josh.ch">songs.josh.ch</a>.</p>
 <ul>
 <li>Use arrow keys or swipe gestures to navigate</li>
 <li>To toggle chords display, click 🎹</li>
@@ -234,8 +227,8 @@ then open from there</li>
 </ul>
 <p>Let’s sing together and have some fun! 💫</p>
 <p>🙏 Cheers, Josua + Monika 🌛</p>
-</section>
-<section id="basic-chords" class="slide level2">
+</div></section>
+<section id="basic-chords" class="slide level2"><div class="slide-content">
 <h2>Basic chords</h2>
 <pre><code>x Not played / muted
 = Barre
@@ -262,813 +255,676 @@ Gm |3 x 0 0 1 1| Easier, A string muted
 
 Feeling bored of major chords (A, D, E...)?
   =&gt; Try playing a seventh chord instead (A7, D7, E7...)!</code></pre>
-</section></section>
+</div></section></section>
 <section>
-<section id="across-the-universe-beatles"
-class="title-slide slide level1">
+<section id="across-the-universe-beatles" class="title-slide slide level1"><div class="slide-content">
 <h1>Across the universe (Beatles)</h1>
 
-</section>
-<section id="instructions" class="slide level2">
+</div></section>
+<section id="instructions" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>       |E A D G B e|
        |-----------|
 A7sus4 |x 0 2 0 3 0|
 F#m    |2=4=4=2=2=2|</code></pre>
-</section>
-<section id="intro" class="slide level2">
+</div></section>
+<section id="intro" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-</section>
-<section id="verse-1" class="slide level2">
+</div></section>
+<section id="verse-1" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="d">D</code> Words are flowing out <code
-class="b">Bm</code><br />
-like endless <code class="f">F#m</code> rain into a paper cup<br />
-They <code class="e">Em7</code> slither wildly as they slip away<br />
+<p><code class="d">D</code> Words are flowing out <code class="b">Bm</code><br>
+like endless <code class="f">F#m</code> rain into a paper cup<br>
+They <code class="e">Em7</code> slither wildly as they slip away<br>
 a<code class="a">A</code>cross the <code class="a">A7</code>
 universe</p>
 <p><code class="d">D</code> Pools of sorrow, <code class="b">Bm</code>
-waves of joy<br />
-are <code class="f">F#m</code> drifting through my opened mind<br />
-Poss<code class="e">Em7</code>essing and car<code
-class="g">Gm</code>essing me</p>
-</section>
-<section id="chorus" class="slide level2">
+waves of joy<br>
+are <code class="f">F#m</code> drifting through my opened mind<br>
+Poss<code class="e">Em7</code>essing and car<code class="g">Gm</code>essing me</p>
+</div></section>
+<section id="chorus" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code></p>
-<p><code class="a">A</code> Nothing’s gonna change my world <code
-class="a">A7</code><br />
-<code class="g">G</code> Nothing’s gonna change my world <code
-class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse-2" class="slide level2">
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code></p>
+<p><code class="a">A</code> Nothing’s gonna change my world <code class="a">A7</code><br>
+<code class="g">G</code> Nothing’s gonna change my world <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-2" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p><code class="d">D</code> Images of <code class="b">Bm</code> broken
-light which<br />
-<code class="f">F#m</code> dance before me like a million <code
-class="e">Em7</code> eyes<br />
-They call me on and on<br />
+light which<br>
+<code class="f">F#m</code> dance before me like a million <code class="e">Em7</code> eyes<br>
+They call me on and on<br>
 a<code class="a">A</code>cross the <code class="a">A7</code>
 universe</p>
 <p><code class="d">D</code> Thoughts meander <code class="b">Bm</code>
-like a restless<br />
-<code class="f">F#m</code> wind inside a letterbox<br />
-They <code class="e">Em7</code> tumble blindly<br />
-as they make their <code class="a">A</code> way<br />
+like a restless<br>
+<code class="f">F#m</code> wind inside a letterbox<br>
+They <code class="e">Em7</code> tumble blindly<br>
+as they make their <code class="a">A</code> way<br>
 across the <code class="a">A7</code> universe</p>
-</section>
-<section id="chorus-1" class="slide level2">
+</div></section>
+<section id="chorus-1" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code></p>
-<p><code class="a">A</code> Nothing’s gonna change my world <code
-class="a">A7</code><br />
-<code class="g">G</code> Nothing’s gonna change my world <code
-class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse-3" class="slide level2">
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code></p>
+<p><code class="a">A</code> Nothing’s gonna change my world <code class="a">A7</code><br>
+<code class="g">G</code> Nothing’s gonna change my world <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-3" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="d">D</code> Sounds of laughter, <code
-class="b">Bm</code> shades of life<br />
-are <code class="f">F#m</code> ringing through my opened ears<br />
+<p><code class="d">D</code> Sounds of laughter, <code class="b">Bm</code> shades of life<br>
+are <code class="f">F#m</code> ringing through my opened ears<br>
 In<code class="e">Em7</code>citing and in<code class="g">Gm</code>viting
 me</p>
 <p><code class="d">D</code> Limitless, un<code class="b">Bm</code>dying
-love<br />
-which <code class="f">F#m</code>shines around me like<br />
-a million <code class="e">Em7</code> suns and calls me on and on<br />
-a<code class="a">A</code>cross the universe <code
-class="a">A7</code></p>
-</section>
-<section id="chorus-2" class="slide level2">
+love<br>
+which <code class="f">F#m</code>shines around me like<br>
+a million <code class="e">Em7</code> suns and calls me on and on<br>
+a<code class="a">A</code>cross the universe <code class="a">A7</code></p>
+</div></section>
+<section id="chorus-2" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code></p>
-<p><code class="a">A</code> Nothing’s gonna change my world <code
-class="a">A7</code><br />
-<code class="g">G</code> Nothing’s gonna change my world <code
-class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="outro" class="slide level2">
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code></p>
+<p><code class="a">A</code> Nothing’s gonna change my world <code class="a">A7</code><br>
+<code class="g">G</code> Nothing’s gonna change my world <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="outro" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="d">D</code> Jai guru deva om <code
-class="a">A7sus4</code> <em>(Repeat and fade)</em></p>
-</section>
+<p><code class="d">D</code> Jai guru deva om <code class="a">A7sus4</code> <em>(Repeat and fade)</em></p>
+</div></section>
 </section>
 <section>
-<section id="as-long-as-you-love-me-backstreet-boys"
-class="title-slide slide level1">
+<section id="as-long-as-you-love-me-backstreet-boys" class="title-slide slide level1"><div class="slide-content">
 <h1>As long as you love me (Backstreet Boys)</h1>
 
-</section>
-<section id="intro-1" class="slide level2">
+</div></section>
+<section id="intro-1" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="c">C</code> <code class="g">G</code> <code
-class="e">Em</code> <code class="d">D</code><br />
+<p><code class="c">C</code> <code class="g">G</code> <code class="e">Em</code> <code class="d">D</code><br>
 As long as you love me</p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="verse-1-1" class="slide level2">
+</div></section>
+<section id="verse-1-1" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Although <code class="e">Em</code> loneliness has always been<br />
-a <code class="c">C</code> friend of mine<br />
-I’m <code class="d">D</code> leavin’ my life in your hands <code
-class="g">G</code> <code class="d">D</code><br />
-<code class="e">Em</code> People say I’m crazy and that <code
-class="c">C</code> I am blind<br />
-<code class="d">D</code> Risking it all in a glance <code
-class="g">G</code> <code class="d">D</code></p>
-<p>And <code class="e">Em</code> how you got me blind is still a <code
-class="c">C</code> mystery<br />
-I <code class="d">D</code> can’t get you out of my head <code
-class="g">G</code> <code class="d">D</code><br />
-<code class="e">Em</code> Don’t care what is written in your <code
-class="c">C</code> history<br />
-As <code class="d">D</code> long as you’re here with me <code
-class="g">G</code></p>
-</section>
-<section id="chorus-3" class="slide level2">
+<p>Although <code class="e">Em</code> loneliness has always been<br>
+a <code class="c">C</code> friend of mine<br>
+I’m <code class="d">D</code> leavin’ my life in your hands <code class="g">G</code> <code class="d">D</code><br>
+<code class="e">Em</code> People say I’m crazy and that <code class="c">C</code> I am blind<br>
+<code class="d">D</code> Risking it all in a glance <code class="g">G</code> <code class="d">D</code></p>
+<p>And <code class="e">Em</code> how you got me blind is still a <code class="c">C</code> mystery<br>
+I <code class="d">D</code> can’t get you out of my head <code class="g">G</code> <code class="d">D</code><br>
+<code class="e">Em</code> Don’t care what is written in your <code class="c">C</code> history<br>
+As <code class="d">D</code> long as you’re here with me <code class="g">G</code></p>
+</div></section>
+<section id="chorus-3" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I don’t care who <code class="c">C</code> you are<br />
-Where <code class="g">G</code> you’re from<br />
-What <code class="e">Em</code> you did<br />
+<p>I don’t care who <code class="c">C</code> you are<br>
+Where <code class="g">G</code> you’re from<br>
+What <code class="e">Em</code> you did<br>
 As long <code class="d">D</code> as you love me</p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="verse-2-1" class="slide level2">
+</div></section>
+<section id="verse-2-1" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="e">Em</code> Every little thing that you have <code
-class="c">C</code> said and done<br />
-Feels <code class="d">D</code> like it’s deep within me <code
-class="g">G</code> <code class="d">D</code><br />
-<code class="e">Em</code> Doesn’t really matter if you’re <code
-class="c">C</code> on the run<br />
+<p><code class="e">Em</code> Every little thing that you have <code class="c">C</code> said and done<br>
+Feels <code class="d">D</code> like it’s deep within me <code class="g">G</code> <code class="d">D</code><br>
+<code class="e">Em</code> Doesn’t really matter if you’re <code class="c">C</code> on the run<br>
 It <code class="d">D</code> seems like we’re <code class="g">G</code>
 meant to be <code class="d">D</code></p>
-</section>
-<section id="chorus-4" class="slide level2">
+</div></section>
+<section id="chorus-4" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I don’t care who <code class="c">C</code> you are<br />
-Where <code class="g">G</code> you’re from<br />
-What <code class="e">Em</code> you did<br />
+<p>I don’t care who <code class="c">C</code> you are<br>
+Where <code class="g">G</code> you’re from<br>
+What <code class="e">Em</code> you did<br>
 As long <code class="d">D</code> as you love me (yeah)</p>
 <p><em>(Repeat)</em></p>
-<p><code class="c">C</code> <code class="g">G</code> <code
-class="e">Em</code> <code class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="bridge" class="slide level2">
+<p><code class="c">C</code> <code class="g">G</code> <code class="e">Em</code> <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="bridge" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p><code class="e">Em</code> I’ve tried to hide it so that <code
-class="g">G</code> no one knows<br />
-But I <code class="c">C</code> guess it shows<br />
-When you <code class="c">C</code> look into my eyes <code
-class="d">D</code></p>
-<p><code class="e">Em</code> What you did and where you’re <code
-class="g">G</code> comin from<br />
+<p><code class="e">Em</code> I’ve tried to hide it so that <code class="g">G</code> no one knows<br>
+But I <code class="c">C</code> guess it shows<br>
+When you <code class="c">C</code> look into my eyes <code class="d">D</code></p>
+<p><code class="e">Em</code> What you did and where you’re <code class="g">G</code> comin from<br>
 I don’t <code class="d">D</code> care, <code class="c">C</code> as long
 <code class="d">D</code> as you <code class="c">C</code> love me,
-baby<br />
-<code class="g">G</code> <code class="d">D</code> <code
-class="e">Em</code> <code class="c">C</code> <code
-class="d">D</code></p>
-</section>
-<section id="chorus-5" class="slide level2">
+baby<br>
+<code class="g">G</code> <code class="d">D</code> <code class="e">Em</code> <code class="c">C</code> <code class="d">D</code></p>
+</div></section>
+<section id="chorus-5" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I don’t care who <code class="c">C</code> you are<br />
-Where <code class="g">G</code> you’re from<br />
-What <code class="e">Em</code> you did<br />
+<p>I don’t care who <code class="c">C</code> you are<br>
+Where <code class="g">G</code> you’re from<br>
+What <code class="e">Em</code> you did<br>
 As long <code class="d">D</code> as you love me</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="baby-one-more-time-britney-spears"
-class="title-slide slide level1">
+<section id="baby-one-more-time-britney-spears" class="title-slide slide level1"><div class="slide-content">
 <h1>Baby one more time (Britney Spears)</h1>
 
-</section>
-<section id="intro-2" class="slide level2">
+</div></section>
+<section id="intro-2" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><code class="a">Am</code> Oh baby, baby <em>(x2)</em></p>
-</section>
-<section id="verse-1-2" class="slide level2">
+</div></section>
+<section id="verse-1-2" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="a">Am</code> Oh baby, baby<br />
-How <code class="e">E</code> was I supposed to know <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby, baby<br>
+How <code class="e">E</code> was I supposed to know <code class="c">C</code><br>
 That <code class="d">Dm</code> something wasn’t <code class="e">E</code>
 right here</p>
-<p><code class="a">Am</code> Oh baby baby<br />
-I <code class="e">E</code> shouldn’t have let you go <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby baby<br>
+I <code class="e">E</code> shouldn’t have let you go <code class="c">C</code><br>
 And <code class="d">Dm</code> now you’re out of <code class="e">E</code>
 sight, yeah</p>
-</section>
-<section id="pre-chorus" class="slide level2">
+</div></section>
+<section id="pre-chorus" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
-<p><code class="a">Am</code> Show me, how you want it <code
-class="e">E</code> to be<br />
-Tell me <code class="c">C</code> baby<br />
-’Cause I need to <code class="d">Dm</code> know now<br />
+<p><code class="a">Am</code> Show me, how you want it <code class="e">E</code> to be<br>
+Tell me <code class="c">C</code> baby<br>
+’Cause I need to <code class="d">Dm</code> know now<br>
 what we’ve got <code class="e">E</code></p>
-</section>
-<section id="chorus-6" class="slide level2">
+</div></section>
+<section id="chorus-6" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
-killing me<br />
+killing me<br>
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe<br />
+still believe<br>
 <code class="e">E</code> (still believe)</p>
-<p><code class="a">Am</code> When I’m not with you I lose <code
-class="e">E</code> my mind<br />
-<code class="g">G</code> Give me a sign <code class="c">C</code><br />
+<p><code class="a">Am</code> When I’m not with you I lose <code class="e">E</code> my mind<br>
+<code class="g">G</code> Give me a sign <code class="c">C</code><br>
 <code class="d">Dm</code> Hit me baby <code class="e">E</code> one more
 time</p>
-</section>
-<section id="verse-2-2" class="slide level2">
+</div></section>
+<section id="verse-2-2" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> Oh baby, baby<br />
-The <code class="e">E</code> reason I breathe is you <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby, baby<br>
+The <code class="e">E</code> reason I breathe is you <code class="c">C</code><br>
 <code class="d">Dm</code> Boy you’ve got me <code class="e">E</code>
 flying</p>
-<p><code class="a">Am</code> Oh pretty baby<br />
-There’s <code class="e">E</code> nothing that I woul<code
-class="c">C</code>dn’t do<br />
+<p><code class="a">Am</code> Oh pretty baby<br>
+There’s <code class="e">E</code> nothing that I woul<code class="c">C</code>dn’t do<br>
 It’s <code class="d">Dm</code> not the way I <code class="e">E</code>
 planned it</p>
-</section>
-<section id="pre-chorus-1" class="slide level2">
+</div></section>
+<section id="pre-chorus-1" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
-<p><code class="a">Am</code> Show me, how you want it <code
-class="e">E</code> to be<br />
-Tell me <code class="c">C</code> baby<br />
-’Cause I need to <code class="d">Dm</code> know now<br />
+<p><code class="a">Am</code> Show me, how you want it <code class="e">E</code> to be<br>
+Tell me <code class="c">C</code> baby<br>
+’Cause I need to <code class="d">Dm</code> know now<br>
 what we’ve got <code class="e">E</code></p>
-</section>
-<section id="chorus-7" class="slide level2">
+</div></section>
+<section id="chorus-7" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
-killing me (and I)<br />
+killing me (and I)<br>
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe<br />
+still believe<br>
 <code class="e">E</code> (still believe)</p>
-<p><code class="a">Am</code> When I’m not with you I lose <code
-class="e">E</code> my mind<br />
-<code class="g">G</code> Give me a sign <code class="c">C</code><br />
+<p><code class="a">Am</code> When I’m not with you I lose <code class="e">E</code> my mind<br>
+<code class="g">G</code> Give me a sign <code class="c">C</code><br>
 <code class="d">Dm</code> Hit me baby <code class="e">E</code> one more
 time</p>
-</section>
-<section id="interlude" class="slide level2">
+</div></section>
+<section id="interlude" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><code class="a">Am</code> Oh baby, baby <em>(x2)</em></p>
-<p><code class="a">Am</code> Oh baby, baby<br />
-How <code class="e">E</code> was I supposed to know <code
-class="c">C</code><br />
+<p><code class="a">Am</code> Oh baby, baby<br>
+How <code class="e">E</code> was I supposed to know <code class="c">C</code><br>
 <code class="d">Dm</code> <code class="e">E</code></p>
-<p><code class="f">F</code> Oh pretty baby<br />
-I <code class="g">G</code> shouldn’t have let you go <code
-class="d">Dm</code> <code class="f">F</code> <code
-class="g">G</code></p>
-</section>
-<section id="bridge-1" class="slide level2">
+<p><code class="f">F</code> Oh pretty baby<br>
+I <code class="g">G</code> shouldn’t have let you go <code class="d">Dm</code> <code class="f">F</code> <code class="g">G</code></p>
+</div></section>
+<section id="bridge-1" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>I must confess <code class="a">Am</code> that my loneliness <code
-class="e">E</code><br />
-Is killing me now <code class="c">C</code><br />
+<p>I must confess <code class="a">Am</code> that my loneliness <code class="e">E</code><br>
+Is killing me now <code class="c">C</code><br>
 don’t you <code class="d">Dm</code> know I <code class="e">E</code>
-still believe <code class="f">F</code><br />
-That you will be here <code class="g">G</code><br />
+still believe <code class="f">F</code><br>
+That you will be here <code class="g">G</code><br>
 Now give me a sign <code class="f">F</code></p>
-<p><code class="d">Dm</code> Hit me baby<br />
-<code class="g">G</code> one <code class="g">G#m</code> more <code
-class="a">Am</code> time <em>(use barre and move up)</em></p>
-</section>
-<section id="chorus-8" class="slide level2">
+<p><code class="d">Dm</code> Hit me baby<br>
+<code class="g">G</code> one <code class="g">G#m</code> more <code class="a">Am</code> time <em>(use barre and move up)</em></p>
+</div></section>
+<section id="chorus-8" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="a">Am</code> My loneliness is <code class="e">E</code>
-killing me (and I)<br />
+killing me (and I)<br>
 <code class="c">C</code> I must confess I <code class="d">Dm</code>
-still believe<br />
+still believe<br>
 <code class="e">E</code> (still believe)</p>
-<p><code class="a">Am</code> When I’m not with you I lose <code
-class="e">E</code> my mind<br />
-<code class="g">G</code> Give me a sign <code class="c">C</code><br />
+<p><code class="a">Am</code> When I’m not with you I lose <code class="e">E</code> my mind<br>
+<code class="g">G</code> Give me a sign <code class="c">C</code><br>
 <code class="d">Dm</code> Hit me baby <code class="e">E</code> <del>one
 more time</del> <strong>I must confess…</strong></p>
-<p><em>(Repeat and add 2nd voice)</em> <strong>…that my loneliness<br />
-is killing me now, don’t you know I still believe<br />
+<p><em>(Repeat and add 2nd voice)</em> <strong>…that my loneliness<br>
+is killing me now, don’t you know I still believe<br>
 that you would be here and give me a sign</strong></p>
-<p><em>(Together)</em> Hit me baby one more time! <code
-class="a">Am</code></p>
-</section>
+<p><em>(Together)</em> Hit me baby one more time! <code class="a">Am</code></p>
+</div></section>
 </section>
 <section>
-<section id="bella-ciao-traditional" class="title-slide slide level1">
+<section id="bella-ciao-traditional" class="title-slide slide level1"><div class="slide-content">
 <h1>Bella ciao (Traditional)</h1>
 
-</section>
-<section id="verse-1-3" class="slide level2">
+</div></section>
+<section id="verse-1-3" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>Una mat<code class="a">Am</code>tina mi son svegliato</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>Una mat<code class="d">Dm</code>tina mi son sveg<code
-class="a">Am</code>liato<br />
-e ho tro<code class="e">E7</code>vato l’inva<code
-class="a">Am</code>sor</p>
-</section>
-<section id="verse-2-3" class="slide level2">
+<p>Una mat<code class="d">Dm</code>tina mi son sveg<code class="a">Am</code>liato<br>
+e ho tro<code class="e">E7</code>vato l’inva<code class="a">Am</code>sor</p>
+</div></section>
+<section id="verse-2-3" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>O parti<code class="a">Am</code>giano, portami via</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>O parti<code class="d">Dm</code>giano, portami Am via<br />
-ché mi <code class="e">E7</code> sento di mo<code
-class="a">Am</code>rir</p>
-</section>
-<section id="verse-3-1" class="slide level2">
+<p>O parti<code class="d">Dm</code>giano, portami Am via<br>
+ché mi <code class="e">E7</code> sento di mo<code class="a">Am</code>rir</p>
+</div></section>
+<section id="verse-3-1" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p>E se io <code class="a">Am</code> muoio da partigiano</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>E se io <code class="d">Dm</code> muoio da parti<code
-class="a">Am</code>giano<br />
-tu mi <code class="e">E7</code> devi seppel<code
-class="a">Am</code>lir</p>
-</section>
-<section id="verse-4" class="slide level2">
+<p>E se io <code class="d">Dm</code> muoio da parti<code class="a">Am</code>giano<br>
+tu mi <code class="e">E7</code> devi seppel<code class="a">Am</code>lir</p>
+</div></section>
+<section id="verse-4" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
 <p>E seppel<code class="a">Am</code>lire lassù in montagna</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>E seppel<code class="d">Dm</code>lire lassù in mon<code
-class="a">Am</code>tagna<br />
-Sotto <code class="e">E7</code> l’ombra di un bel <code
-class="a">Am</code> fior</p>
-</section>
-<section id="verse-5" class="slide level2">
+<p>E seppel<code class="d">Dm</code>lire lassù in mon<code class="a">Am</code>tagna<br>
+Sotto <code class="e">E7</code> l’ombra di un bel <code class="a">Am</code> fior</p>
+</div></section>
+<section id="verse-5" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p>Tutte le <code class="a">Am</code> genti che passeranno</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>Tutte le <code class="d">Dm</code> genti che passe<code
-class="a">Am</code>ranno<br />
+<p>Tutte le <code class="d">Dm</code> genti che passe<code class="a">Am</code>ranno<br>
 Ti di<code class="e">E7</code>ranno “Che bel <code class="a">Am</code>
 fior!”</p>
-</section>
-<section id="verse-6" class="slide level2">
+</div></section>
+<section id="verse-6" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
 <p>“È questo il <code class="a">Am</code> fiore del partigiano”</p>
-<p>O bella, ciao! Bella, ciao!<br />
+<p>O bella, ciao! Bella, ciao!<br>
 Bella, <code class="a">Am7</code> ciao, ciao, ciao!</p>
-<p>“È questo il <code class="d">Dm</code> fiore del parti<code
-class="a">Am</code>giano<br />
-morto <code class="e">E7</code> per la liber<code
-class="a">Am</code>tà!” <em>(Repeat and fade)</em></p>
-</section>
+<p>“È questo il <code class="d">Dm</code> fiore del parti<code class="a">Am</code>giano<br>
+morto <code class="e">E7</code> per la liber<code class="a">Am</code>tà!” <em>(Repeat and fade)</em></p>
+</div></section>
 </section>
 <section>
-<section id="dont-worry-be-happy-bobby-mcferrin"
-class="title-slide slide level1">
+<section id="dont-worry-be-happy-bobby-mcferrin" class="title-slide slide level1"><div class="slide-content">
 <h1>Don’t worry be happy (Bobby McFerrin)</h1>
 
-</section>
-<section id="intro-3" class="slide level2">
+</div></section>
+<section id="intro-3" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="verse-1-4" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-1-4" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="g">G</code> Here’s a little song I wrote<br />
-You <code class="a">Am</code> might want to sing it note for note<br />
+<p><code class="g">G</code> Here’s a little song I wrote<br>
+You <code class="a">Am</code> might want to sing it note for note<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-<p>In <code class="g">G</code> every life we have some trouble<br />
-<code class="a">Am</code> When you worry you make it double<br />
+<p>In <code class="g">G</code> every life we have some trouble<br>
+<code class="a">Am</code> When you worry you make it double<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-</section>
-<section id="chorus-9" class="slide level2">
+</div></section>
+<section id="chorus-9" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
-</section>
-<section id="verse-2-4" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
+</div></section>
+<section id="verse-2-4" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="g">G</code> Ain’t got no place to lay your head<br />
-<code class="a">Am</code> Somebody came and took your bed<br />
+<p><code class="g">G</code> Ain’t got no place to lay your head<br>
+<code class="a">Am</code> Somebody came and took your bed<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-<p>The <code class="g">G</code> landlord say your rent is late<br />
-<code class="a">Am</code> He may have to litigate<br />
+<p>The <code class="g">G</code> landlord say your rent is late<br>
+<code class="a">Am</code> He may have to litigate<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-</section>
-<section id="chorus-10" class="slide level2">
+</div></section>
+<section id="chorus-10" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
-</section>
-<section id="verse-3-2" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
+</div></section>
+<section id="verse-3-2" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="g">G</code> Ain’t got no cash, ain’t got no style<br />
-<code class="a">Am</code> Ain’t got no girl to make you smile<br />
-<strong>But</strong> don’t <code class="c">C</code> worry, be <code
-class="g">G</code> happy</p>
+<p><code class="g">G</code> Ain’t got no cash, ain’t got no style<br>
+<code class="a">Am</code> Ain’t got no girl to make you smile<br>
+<strong>But</strong> don’t <code class="c">C</code> worry, be <code class="g">G</code> happy</p>
 <p>Cause <code class="g">G</code> when you worry, your face will
-frown<br />
-<code class="a">Am</code> And that will bring everybody down<br />
-<strong>So</strong> don’t <code class="c">C</code> worry, be <code
-class="g">G</code> happy</p>
-</section>
-<section id="chorus-11" class="slide level2">
+frown<br>
+<code class="a">Am</code> And that will bring everybody down<br>
+<strong>So</strong> don’t <code class="c">C</code> worry, be <code class="g">G</code> happy</p>
+</div></section>
+<section id="chorus-11" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
-</section>
-<section id="verse-4-1" class="slide level2">
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
+</div></section>
+<section id="verse-4-1" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p><code class="g">G</code> There is this little song I wrote<br />
-<code class="a">Am</code> I hope you learn it note for note<br />
+<p><code class="g">G</code> There is this little song I wrote<br>
+<code class="a">Am</code> I hope you learn it note for note<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
 <p>(Listen to what I say!)</p>
-<p><code class="g">G</code> In your life expect some trouble<br />
-<code class="a">Am</code> But when you worry, you make it double<br />
+<p><code class="g">G</code> In your life expect some trouble<br>
+<code class="a">Am</code> But when you worry, you make it double<br>
 Don’t <code class="c">C</code> worry, be <code class="g">G</code>
 happy</p>
-</section>
-<section id="chorus-12" class="slide level2">
+</div></section>
+<section id="chorus-12" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>(Whistle)</p>
-<p><code class="g">G</code> <code class="a">Am</code> <code
-class="c">C</code> <code class="g">G</code> (x2)</p>
+<p><code class="g">G</code> <code class="a">Am</code> <code class="c">C</code> <code class="g">G</code> (x2)</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="dr-eskimo-mani-matter" class="title-slide slide level1">
+<section id="dr-eskimo-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dr Eskimo (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-5" class="slide level2">
+</div></section>
+<section id="verse-1-5" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="a">Am</code> Kenned ihr das Gschichtli scho<br />
+<p><code class="a">Am</code> Kenned ihr das Gschichtli scho<br>
 <code class="e">E</code> Vu dem arme <code class="a">Am</code>
-Eskimo<br />
-<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code
-class="e">Em</code> einisch <code class="a">Am</code> so<br />
+Eskimo<br>
+<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code class="e">Em</code> einisch <code class="a">Am</code> so<br>
 <code class="e">Em</code> Truurig <code class="a">Am</code> isch ums
 <code class="e">Em</code> Lebe <code class="a">Am</code> cho.</p>
-</section>
-<section id="verse-2-5" class="slide level2">
+</div></section>
+<section id="verse-2-5" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> Er hät dank em Radio<br />
+<p><code class="a">Am</code> Er hät dank em Radio<br>
 <code class="e">E</code> Freud ar Musig <code class="a">Am</code>
-übercho<br />
+übercho<br>
 <code class="e">Em</code> Und het <code class="a">Am</code> denkt das
-<code class="e">Em</code> chan i <code class="a">Am</code> o<br />
-<code class="e">Em</code> So isch <code class="a">Am</code> er is <code
-class="e">Em</code> unglück <code class="a">Am</code> cho.</p>
-</section>
-<section id="verse-3-3" class="slide level2">
+<code class="e">Em</code> chan i <code class="a">Am</code> o<br>
+<code class="e">Em</code> So isch <code class="a">Am</code> er is <code class="e">Em</code> unglück <code class="a">Am</code> cho.</p>
+</div></section>
+<section id="verse-3-3" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> Nämlich hät er sich für zwo<br />
+<p><code class="a">Am</code> Nämlich hät er sich für zwo<br>
 <code class="e">E</code> Fläsche Leber<code class="a">Am</code>tran es
-no<br />
-<code class="e">Em</code> Guet er<code class="a">Am</code>haltnigs <code
-class="e">Em</code> Cemba<code class="a">Am</code>lo<br />
+no<br>
+<code class="e">Em</code> Guet er<code class="a">Am</code>haltnigs <code class="e">Em</code> Cemba<code class="a">Am</code>lo<br>
 <code class="e">Em</code> Kouft und <code class="a">Am</code> hets i d
 <code class="e">Em</code> Höhli <code class="a">Am</code> gno.</p>
-</section>
-<section id="verse-4-2" class="slide level2">
+</div></section>
+<section id="verse-4-2" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p><code class="a">Am</code> Doch won er fortissimo<br />
+<p><code class="a">Am</code> Doch won er fortissimo<br>
 <code class="e">E</code> Gspilt het uf sim <code class="a">Am</code>
-Cembalo<br />
-<code class="e">Em</code> Isch en <code class="a">Am</code> Iisbär <code
-class="e">Em</code> ine <code class="e">Em</code> cho und<br />
+Cembalo<br>
+<code class="e">Em</code> Isch en <code class="a">Am</code> Iisbär <code class="e">Em</code> ine <code class="e">Em</code> cho und<br>
 <code class="a">Am</code> Hetne <code class="a">Am</code> zwüsche
 d’<code class="e">Em</code>Chralle <code class="a">Am</code> gno.</p>
-</section>
-<section id="verse-5-1" class="slide level2">
+</div></section>
+<section id="verse-5-1" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p><code class="a">Am</code> D’Kunst isch geng es Risiko<br />
+<p><code class="a">Am</code> D’Kunst isch geng es Risiko<br>
 <code class="e">E</code> So isch er ums <code class="a">Am</code> Lebe
-cho<br />
+cho<br>
 <code class="e">Em</code> Und ihr <code class="a">Am</code> gsänd
-d’Mo<code class="e">Em</code>ral der<code class="a">Am</code>vo<br />
-<code class="e">Em</code> Choufed <code class="a">Am</code> nie es <code
-class="e">Em</code> Cemba<code class="a">Am</code>lo<br />
+d’Mo<code class="e">Em</code>ral der<code class="a">Am</code>vo<br>
+<code class="e">Em</code> Choufed <code class="a">Am</code> nie es <code class="e">Em</code> Cemba<code class="a">Am</code>lo<br>
 <code class="e">Em</code> Süscht geits <code class="a">Am</code> euch
-grad <code class="e">Em</code> äbe<code class="a">Am</code>so<br />
-<code class="e">Em</code> Wie dem <code class="a">Am</code> arme <code
-class="e">Em</code> Eski<code class="a">Am</code>mo<br />
-<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code
-class="e">Em</code> einisch <code class="a">Am</code> so<br />
+grad <code class="e">Em</code> äbe<code class="a">Am</code>so<br>
+<code class="e">Em</code> Wie dem <code class="a">Am</code> arme <code class="e">Em</code> Eski<code class="a">Am</code>mo<br>
+<code class="e">Em</code> Wo in <code class="a">Am</code> Grönland <code class="e">Em</code> einisch <code class="a">Am</code> so<br>
 <code class="e">Em</code> Truurig <code class="a">Am</code> isch ums
 <code class="e">Em</code> Lebe <code class="a">Am</code> cho.</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="dr-sidi-abdel-assar-mani-matter"
-class="title-slide slide level1">
+<section id="dr-sidi-abdel-assar-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dr Sidi Abdel Assar (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-6" class="slide level2">
+</div></section>
+<section id="verse-1-6" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Dr <code class="a">Am</code> Sidi Abdel Assar vo El Hama<br />
-Het <code class="a">Am</code> mal am Morge früe no im Pijama<br />
-Ir <code class="d">Dm</code> Strass vor dr Moschee<br />
-Zwöi <code class="a">Am</code> schöni Ouge gseh<br />
-Das <code class="e">E</code> isch dr Afang worde vo sim <code
-class="a">Am</code> Drama</p>
-</section>
-<section id="verse-2-6" class="slide level2">
+<p>Dr <code class="a">Am</code> Sidi Abdel Assar vo El Hama<br>
+Het <code class="a">Am</code> mal am Morge früe no im Pijama<br>
+Ir <code class="d">Dm</code> Strass vor dr Moschee<br>
+Zwöi <code class="a">Am</code> schöni Ouge gseh<br>
+Das <code class="e">E</code> isch dr Afang worde vo sim <code class="a">Am</code> Drama</p>
+</div></section>
+<section id="verse-2-6" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>S isch <code class="a">Am</code> Tochter gsy vom Mohamed
-Mustafa<br />
-Dr <code class="a">Am</code> Abdel Assar het nümm choenne schlafa<br />
-Bis <code class="d">Dm</code> er bim Mohamed<br />
-Um <code class="a">Am</code> d’Hand aghalte hed<br />
-Und <code class="e">E</code> gseit: I biete hundertfüfzig <code
-class="a">Am</code> Schaf a</p>
-</section>
-<section id="verse-3-4" class="slide level2">
+Mustafa<br>
+Dr <code class="a">Am</code> Abdel Assar het nümm choenne schlafa<br>
+Bis <code class="d">Dm</code> er bim Mohamed<br>
+Um <code class="a">Am</code> d’Hand aghalte hed<br>
+Und <code class="e">E</code> gseit: I biete hundertfüfzig <code class="a">Am</code> Schaf a</p>
+</div></section>
+<section id="verse-3-4" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Dr <code class="a">Am</code> Mohamed het gantwortet: Bi Allah<br />
+<p>Dr <code class="a">Am</code> Mohamed het gantwortet: Bi Allah<br>
 Es <code class="a">Am</code> froeit mi, dass mi Tochter dir het
-gfalla<br />
-Doch <code class="d">Dm</code> wärt isch si, mi Seel<br />
-Zwöi<code class="a">Am</code>hundertzwänzg Kamel<br />
-Und <code class="e">E</code> drunder chan i dir sen uf ke <code
-class="a">Am</code> Fall la</p>
-</section>
-<section id="verse-4-3" class="slide level2">
+gfalla<br>
+Doch <code class="d">Dm</code> wärt isch si, mi Seel<br>
+Zwöi<code class="a">Am</code>hundertzwänzg Kamel<br>
+Und <code class="e">E</code> drunder chan i dir sen uf ke <code class="a">Am</code> Fall la</p>
+</div></section>
+<section id="verse-4-3" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>Da <code class="a">Am</code> het dr Abdel Assar gseit: O Sidi<br />
-Uf <code class="a">Am</code> sone türe Handel gang i nid y<br />
-Isch <code class="d">Dm</code> furt, het gly druf scho<br />
-E <code class="a">Am</code> billigeri gno<br />
-Wo <code class="e">E</code> nid so schoen isch gsy, defuer e <code
-class="a">Am</code> gschydi</p>
-</section>
-<section id="verse-5-2" class="slide level2">
+<p>Da <code class="a">Am</code> het dr Abdel Assar gseit: O Sidi<br>
+Uf <code class="a">Am</code> sone türe Handel gang i nid y<br>
+Isch <code class="d">Dm</code> furt, het gly druf scho<br>
+E <code class="a">Am</code> billigeri gno<br>
+Wo <code class="e">E</code> nid so schoen isch gsy, defuer e <code class="a">Am</code> gschydi</p>
+</div></section>
+<section id="verse-5-2" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p><em>(Langsam)</em></p>
 <p>Doch <code class="a">Am</code> wenn es Nacht wird ueber der
-Sahara<br />
+Sahara<br>
 Luegt <code class="a">Am</code> er dr Mond am Himmel hell und klar
-a<br />
-Und <code class="d">Dm</code> truret hie und da<br />
+a<br>
+Und <code class="d">Dm</code> truret hie und da<br>
 De <code class="a">Am</code> schoene Ouge na -</p>
 <p><em>(Schnell)</em></p>
-<p>Und <code class="e">E</code> daenkt: Haett i doch frueecher afa <code
-class="a">Am</code> spara!</p>
-</section>
+<p>Und <code class="e">E</code> daenkt: Haett i doch frueecher afa <code class="a">Am</code> spara!</p>
+</div></section>
 </section>
 <section>
-<section id="dr-wilhelm-täll-mani-matter"
-class="title-slide slide level1">
+<section id="dr-wilhelm-täll-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dr Wilhelm Täll (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-7" class="slide level2">
+</div></section>
+<section id="verse-1-7" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br />
-Im <code class="g">G7</code> Löie z’Nottis<code
-class="c">C</code>wil<br />
-Da <code class="c">C</code> bruchts viel Volk, gwüss z’halbe Dorf<br />
+<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br>
+Im <code class="g">G7</code> Löie z’Nottis<code class="c">C</code>wil<br>
+Da <code class="c">C</code> bruchts viel Volk, gwüss z’halbe Dorf<br>
 Hett <code class="g">G7</code> mitgmacht i däm <code class="c">C</code>
 Schpil</p>
 <p>Die <code class="e">E7</code> andri Hälfti <code class="a">Am</code>
-isch im Saal gsy<br />
+isch im Saal gsy<br>
 <code class="g">G7</code> Bim’ne grosse <code class="c">C</code>
-Bier<br />
+Bier<br>
 Als <code class="f">F</code> publikum, het <code class="c">C</code>
-zuegluegt<br />
-Und isch <code class="g">G7</code> gschpannt gsy, was pas<code
-class="c">C</code>sier</p>
-</section>
-<section id="verse-2-7" class="slide level2">
+zuegluegt<br>
+Und isch <code class="g">G7</code> gschpannt gsy, was pas<code class="c">C</code>sier</p>
+</div></section>
+<section id="verse-2-7" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Am <code class="c">C</code> Aafang isch es schön gsy<br />
-Do het <code class="g">G7</code> als Schtouffache<code
-class="c">C</code>rin<br />
-D’Frou <code class="c">C</code> Pfarrer mit dem Schnyder gret<br />
+<p>Am <code class="c">C</code> Aafang isch es schön gsy<br>
+Do het <code class="g">G7</code> als Schtouffache<code class="c">C</code>rin<br>
+D’Frou <code class="c">C</code> Pfarrer mit dem Schnyder gret<br>
 I <code class="g">G7</code> Wort vo tiefem <code class="c">C</code>
 Sinn</p>
-<p>Und <code class="e">E7</code> alls isch grüert gsy, <code
-class="a">Am</code> sy het dasmal<br />
-<code class="g">G7</code> Nid gseit, s’Chleid sig z’<code
-class="c">C</code>tüür<br />
-Und <code class="f">F</code> är het guet uf<code
-class="c">C</code>passt<br />
-Das är der <code class="g">G7</code> Fade nid ver<code
-class="c">C</code>lüür</p>
-</section>
-<section id="verse-3-5" class="slide level2">
+<p>Und <code class="e">E7</code> alls isch grüert gsy, <code class="a">Am</code> sy het dasmal<br>
+<code class="g">G7</code> Nid gseit, s’Chleid sig z’<code class="c">C</code>tüür<br>
+Und <code class="f">F</code> är het guet uf<code class="c">C</code>passt<br>
+Das är der <code class="g">G7</code> Fade nid ver<code class="c">C</code>lüür</p>
+</div></section>
+<section id="verse-3-5" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Uf <code class="c">C</code> z’Mal, churz vor em Öpfelschuss<br />
+<p>Uf <code class="c">C</code> z’Mal, churz vor em Öpfelschuss<br>
 Dr <code class="g">G7</code> Lehrer chunnt als <code class="c">C</code>
-Täll<br />
-Sy <code class="c">C</code> Sohn, dä fragt’ne dis und äis<br />
+Täll<br>
+Sy <code class="c">C</code> Sohn, dä fragt’ne dis und äis<br>
 Do <code class="g">G7</code> rüeft dert eine <code class="c">C</code>
 schnäll</p>
-<p>Wo <code class="e">E7</code> und’rem Huet als <code
-class="a">Am</code> Wach isch gschtande<br />
+<p>Wo <code class="e">E7</code> und’rem Huet als <code class="a">Am</code> Wach isch gschtande<br>
 <code class="g">G7</code> So dass’ jede <code class="c">C</code>
-ghört<br />
+ghört<br>
 Wi<code class="f">F</code>so fragt dä so <code class="c">C</code>
-dumm<br />
-Het dä ir <code class="g">G7</code> Schuel de nüt rächts <code
-class="c">C</code> glehrt</p>
-</section>
-<section id="verse-4-4" class="slide level2">
+dumm<br>
+Het dä ir <code class="g">G7</code> Schuel de nüt rächts <code class="c">C</code> glehrt</p>
+</div></section>
+<section id="verse-4-4" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>E <code class="c">C</code> Fründ vom Täll, e Maa us Altdorf<br />
+<p>E <code class="c">C</code> Fründ vom Täll, e Maa us Altdorf<br>
 <code class="g">G7</code> Zwickt em eis uf ds <code class="c">C</code>
-Muul<br />
-Und <code class="c">C</code> dise wo dr Huet bewacht<br />
+Muul<br>
+Und <code class="c">C</code> dise wo dr Huet bewacht<br>
 Git <code class="g">G7</code> ume, gar nid <code class="c">C</code>
 fuul</p>
-<p>Und <code class="e">E7</code> stosst ihm mit syr <code
-class="a">Am</code> Helebarde<br />
+<p>Und <code class="e">E7</code> stosst ihm mit syr <code class="a">Am</code> Helebarde<br>
 <code class="g">G7</code> Eine z’Mitzt i <code class="c">C</code>
-Buuch<br />
-Da <code class="f">F</code> chunnt scho s’Volk vo <code
-class="c">C</code> Uri z’springe<br />
+Buuch<br>
+Da <code class="f">F</code> chunnt scho s’Volk vo <code class="c">C</code> Uri z’springe<br>
 <code class="g">G7</code> Donner jetzt geits <code class="c">C</code>
 ruuch</p>
-</section>
-<section id="verse-5-3" class="slide level2">
+</div></section>
+<section id="verse-5-3" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p>Die <code class="c">C</code> einte, die vo Öschterrich<br />
-<code class="g">G7</code> Die näh für d’Wach Par<code
-class="c">C</code>tei<br />
-Die <code class="c">C</code> andre, die vo Altdorf<br />
-Füre <code class="g">G7</code> Täll - ei Schläge<code
-class="c">C</code>rei</p>
+<p>Die <code class="c">C</code> einte, die vo Öschterrich<br>
+<code class="g">G7</code> Die näh für d’Wach Par<code class="c">C</code>tei<br>
+Die <code class="c">C</code> andre, die vo Altdorf<br>
+Füre <code class="g">G7</code> Täll - ei Schläge<code class="c">C</code>rei</p>
 <p>Mit <code class="e">E7</code> Helebarde, <code class="a">Am</code>
-Kartonschwärt<br />
+Kartonschwärt<br>
 <code class="g">G7</code> Kulisse schlöh sy <code class="c">C</code>
-dry<br />
+dry<br>
 <code class="f">F</code> Der Täll liit und’rem <code class="c">C</code>
-Gessler scho<br />
-Da <code class="g">G7</code> mischt der Saal sech <code
-class="c">C</code> y</p>
-</section>
-<section id="verse-6-1" class="slide level2">
+Gessler scho<br>
+Da <code class="g">G7</code> mischt der Saal sech <code class="c">C</code> y</p>
+</div></section>
+<section id="verse-6-1" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
-<p>Jitz <code class="c">C</code> chöme Gläser z’flüge<br />
-Jede <code class="g">G7</code> stillt sy gheimi Wuet <code
-class="c">C</code><br />
-Es <code class="c">C</code> chrose Tisch, u bänk und’s Bier<br />
+<p>Jitz <code class="c">C</code> chöme Gläser z’flüge<br>
+Jede <code class="g">G7</code> stillt sy gheimi Wuet <code class="c">C</code><br>
+Es <code class="c">C</code> chrose Tisch, u bänk und’s Bier<br>
 Ver<code class="g">G7</code>mischt sech mit em <code class="c">C</code>
 Bluet</p>
-<p>Dr <code class="e">E7</code> Wirt rouft sech sys <code
-class="a">Am</code> Haar<br />
-D’Frou schinet <code class="g">G7</code> brochni glider y <code
-class="c">C</code><br />
-Zwo <code class="f">F</code> Stund lang het das duu<code
-class="c">C</code>ret<br />
-Do isch <code class="g">G7</code> Öschtrich gschlage <code
-class="c">C</code> gsy</p>
-</section>
-<section id="verse-7" class="slide level2">
+<p>Dr <code class="e">E7</code> Wirt rouft sech sys <code class="a">Am</code> Haar<br>
+D’Frou schinet <code class="g">G7</code> brochni glider y <code class="c">C</code><br>
+Zwo <code class="f">F</code> Stund lang het das duu<code class="c">C</code>ret<br>
+Do isch <code class="g">G7</code> Öschtrich gschlage <code class="c">C</code> gsy</p>
+</div></section>
+<section id="verse-7" class="slide level2"><div class="slide-content">
 <h2>Verse 7</h2>
-<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br />
-Im <code class="g">G7</code> Löie z’Nottis<code
-class="c">C</code>wil<br />
-Und <code class="c">C</code> gwüss no niene i<br />
+<p>Si <code class="c">C</code> hei der Willhelm Täll ufgfüehrt<br>
+Im <code class="g">G7</code> Löie z’Nottis<code class="c">C</code>wil<br>
+Und <code class="c">C</code> gwüss no niene i<br>
 natura<code class="g">G7</code>listischerem <code class="c">C</code>
 Stil</p>
 <p>D’Ver<code class="e">E7</code>sicherig het <code class="a">Am</code>
-zahlt<br />
-Hingäge <code class="g">G7</code> eis weiss ig sit<code
-class="c">C</code>här:</p>
+zahlt<br>
+Hingäge <code class="g">G7</code> eis weiss ig sit<code class="c">C</code>här:</p>
 <p>Sy <code class="f">F</code> würde d’Freiheit <code class="c">C</code>
-gwinne<br />
-Wenn sy <code class="g">G7</code> dä Wäg z’gwinne <code
-class="c">C</code> wär <em>(x2)</em></p>
-</section>
+gwinne<br>
+Wenn sy <code class="g">G7</code> dä Wäg z’gwinne <code class="c">C</code> wär <em>(x2)</em></p>
+</div></section>
 </section>
 <section>
-<section id="dynamit-mani-matter" class="title-slide slide level1">
+<section id="dynamit-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Dynamit (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-8" class="slide level2">
+</div></section>
+<section id="verse-1-8" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="a">Am</code> Einisch ir Nacht won i spät no bi <code
-class="e">E7</code> gloffe<br />
-<code class="a">Am</code> D’Bundesterrasse z’düruf gäge <code
-class="g">G</code> hei<br />
-<code class="a">Am</code> Han i e bärtige Kärli a<code
-class="e">E7</code>troffe<br />
+<p><code class="a">Am</code> Einisch ir Nacht won i spät no bi <code class="e">E7</code> gloffe<br>
+<code class="a">Am</code> D’Bundesterrasse z’düruf gäge <code class="g">G</code> hei<br>
+<code class="a">Am</code> Han i e bärtige Kärli a<code class="e">E7</code>troffe<br>
 <code class="a">Am</code> Und gseh grad, dass dä sech dert, jemers nei
-<code class="g">G7</code><br />
-<code class="c">C</code> Dass dä sech dert zu nachtschlafener <code
-class="e">E</code> Zyt<br />
-<code class="a">Am</code> Am Bundeshus z’schaffe macht <code
-class="e">E7</code> mit Dyna<code class="a">Am</code>mit</p>
-</section>
-<section id="verse-2-8" class="slide level2">
+<code class="g">G7</code><br>
+<code class="c">C</code> Dass dä sech dert zu nachtschlafener <code class="e">E</code> Zyt<br>
+<code class="a">Am</code> Am Bundeshus z’schaffe macht <code class="e">E7</code> mit Dyna<code class="a">Am</code>mit</p>
+</div></section>
+<section id="verse-2-8" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> I bi erchlüpft und ha zuen ihm gseit: <code
-class="e">E7</code> Säget<br />
-<code class="a">Am</code> Exgüse, aber es gseht fasch so <code
-class="g">G</code> us<br />
-<code class="a">Am</code> Wi dass dir da jitze würklech er<code
-class="e">E7</code>wäget<br />
-<code class="a">Am</code> Das grad id Luft welle z’spränge das <code
-class="g">G7</code> Hus<br />
-<code class="c">C</code> Ja, seit dä Ma mir mit Füür, es mues <code
-class="e">E</code> sy<br />
-<code class="a">Am</code> Furt mit däm Ghütt, i bi <code
-class="e">E7</code> für d’Anar<code class="a">Am</code>chie</p>
-</section>
-<section id="verse-3-6" class="slide level2">
+<p><code class="a">Am</code> I bi erchlüpft und ha zuen ihm gseit: <code class="e">E7</code> Säget<br>
+<code class="a">Am</code> Exgüse, aber es gseht fasch so <code class="g">G</code> us<br>
+<code class="a">Am</code> Wi dass dir da jitze würklech er<code class="e">E7</code>wäget<br>
+<code class="a">Am</code> Das grad id Luft welle z’spränge das <code class="g">G7</code> Hus<br>
+<code class="c">C</code> Ja, seit dä Ma mir mit Füür, es mues <code class="e">E</code> sy<br>
+<code class="a">Am</code> Furt mit däm Ghütt, i bi <code class="e">E7</code> für d’Anar<code class="a">Am</code>chie</p>
+</div></section>
+<section id="verse-3-6" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> Was isch als Bürger mir da übrig<code
-class="e">E7</code>blybe<br />
-<code class="a">Am</code> Als ihm’s probiere uszrede, i <code
-class="g">G</code> ha<br />
-<code class="a">Am</code> Ihm afa d’Vorteile alli be<code
-class="e">E7</code>schrybe<br />
-<code class="a">Am</code> Vo üsem Staat, eso guet dass i <code
-class="g">G7</code> cha<br />
-<code class="c">C</code> Ds Rütli und d’Freiheit und d’Demokra<code
-class="e">E</code>tie<br />
+<p><code class="a">Am</code> Was isch als Bürger mir da übrig<code class="e">E7</code>blybe<br>
+<code class="a">Am</code> Als ihm’s probiere uszrede, i <code class="g">G</code> ha<br>
+<code class="a">Am</code> Ihm afa d’Vorteile alli be<code class="e">E7</code>schrybe<br>
+<code class="a">Am</code> Vo üsem Staat, eso guet dass i <code class="g">G7</code> cha<br>
+<code class="c">C</code> Ds Rütli und d’Freiheit und d’Demokra<code class="e">E</code>tie<br>
 <code class="a">Am</code> Han i beschworen, är <code class="e">E7</code>
 sölls doch la <code class="a">Am</code> sy</p>
-</section>
-<section id="verse-4-5" class="slide level2">
+</div></section>
+<section id="verse-4-5" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p><code class="a">Am</code> D’Angscht het mys Rednertalänt la ent<code
-class="e">E7</code>falte<br />
-<code class="a">Am</code> Chüel het dr Wind um üs gwäit i dr <code
-class="g">G</code> Nacht<br />
-<code class="a">Am</code> Während ig ihm en Ouguschtred ha <code
-class="e">E7</code> ghalte<br />
-<code class="a">Am</code> Dass es es Ross patriotisch hätt <code
-class="g">G7</code> gmacht<br />
-<code class="c">C</code> Z’letscht hei dä Ma mini Wort so be<code
-class="e">E</code>rückt<br />
+<p><code class="a">Am</code> D’Angscht het mys Rednertalänt la ent<code class="e">E7</code>falte<br>
+<code class="a">Am</code> Chüel het dr Wind um üs gwäit i dr <code class="g">G</code> Nacht<br>
+<code class="a">Am</code> Während ig ihm en Ouguschtred ha <code class="e">E7</code> ghalte<br>
+<code class="a">Am</code> Dass es es Ross patriotisch hätt <code class="g">G7</code> gmacht<br>
+<code class="c">C</code> Z’letscht hei dä Ma mini Wort so be<code class="e">E</code>rückt<br>
 <code class="a">Am</code> Dass är e Träne im <code class="e">E7</code>
 Oug het ver<code class="a">Am</code>drückt</p>
-</section>
-<section id="verse-5-4" class="slide level2">
+</div></section>
+<section id="verse-5-4" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p><code class="a">Am</code> So han i schliesslech dr Staat chönne <code
-class="e">E7</code> rette<br />
-<code class="a">Am</code> Är isch mit sym Dynamit wieder <code
-class="g">G</code> hei<br />
-<code class="a">Am</code> Und i ha mir a däm Abe im <code
-class="e">E7</code> Bett en<br />
-<code class="a">Am</code> Orde zuegsproche für my ganz al<code
-class="g">G7</code>lei<br />
+<p><code class="a">Am</code> So han i schliesslech dr Staat chönne <code class="e">E7</code> rette<br>
+<code class="a">Am</code> Är isch mit sym Dynamit wieder <code class="g">G</code> hei<br>
+<code class="a">Am</code> Und i ha mir a däm Abe im <code class="e">E7</code> Bett en<br>
+<code class="a">Am</code> Orde zuegsproche für my ganz al<code class="g">G7</code>lei<br>
 <code class="c">C</code> Glunge isch nume, dass
-zmonderischt<sup>_*_</sup> <code class="e">E</code> scho<br />
+zmonderischt<sup>_*_</sup> <code class="e">E</code> scho<br>
 <code class="a">Am</code> Über mi Red mir du <code class="e">E7</code>
 Zwyfel si <code class="a">Am</code> cho</p>
 <p><em><sup>*</sup> Zmonderischt: Ein Tag, welcher nach einem
-schon<br />
-vergangenen Tag gekommen ist. (<a
-href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)</em></p>
-</section>
-<section id="verse-6-2" class="slide level2">
+schon<br>
+vergangenen Tag gekommen ist. (<a href="https://www.msn.com/de-ch/nachrichten/other/der-morndrig-tag-macht-hinecht-zu-n%C3%A4chti/ar-BBYnNVi">Quelle</a>)</em></p>
+</div></section>
+<section id="verse-6-2" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
-<p><code class="a">Am</code> Han ig ihm d’Schwyz o mit Rächt eso <code
-class="e">E7</code> prise?<br />
-<code class="a">Am</code> Fragen i mi no bis hüt hinde<code
-class="g">G</code>dry<br />
-<code class="a">Am</code> Und no uf eis het dä Ma mi hi<code
-class="e">E7</code>gwise<br />
-<code class="a">Am</code> Louf i am Bundeshus sider ver<code
-class="g">G7</code>by<br />
-<code class="c">C</code> Mues i gäng dänke, s’steit numen uf <code
-class="e">E</code> Zyt<br />
-<code class="a">Am</code> S’länge fürs z’Spränge paar <code
-class="e">E7</code> Seck Dyna<code class="a">Am</code>mit!</p>
+<p><code class="a">Am</code> Han ig ihm d’Schwyz o mit Rächt eso <code class="e">E7</code> prise?<br>
+<code class="a">Am</code> Fragen i mi no bis hüt hinde<code class="g">G</code>dry<br>
+<code class="a">Am</code> Und no uf eis het dä Ma mi hi<code class="e">E7</code>gwise<br>
+<code class="a">Am</code> Louf i am Bundeshus sider ver<code class="g">G7</code>by<br>
+<code class="c">C</code> Mues i gäng dänke, s’steit numen uf <code class="e">E</code> Zyt<br>
+<code class="a">Am</code> S’länge fürs z’Spränge paar <code class="e">E7</code> Seck Dyna<code class="a">Am</code>mit!</p>
 <p><code class="e">E7</code> <code class="a">Am</code></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="father-and-son-cat-stevens"
-class="title-slide slide level1">
+<section id="father-and-son-cat-stevens" class="title-slide slide level1"><div class="slide-content">
 <h1>Father and son (Cat Stevens)</h1>
 
-</section>
-<section id="instructions-1" class="slide level2">
+</div></section>
+<section id="instructions-1" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>     |E A D G B e|
      |-----------|
@@ -1082,686 +938,554 @@ G |0--0-0-0-0--5--5-|
 D |0--0-0-0-0-------|
 A |x--x-x-x-x-------| Mute with finger on E string
 E |3--3-3-3-3-------|</code></pre>
-</section>
-<section id="intro-4" class="slide level2">
+</div></section>
+<section id="intro-4" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Riff x4)</em></p>
-</section>
-<section id="verse-1---father" class="slide level2">
+</div></section>
+<section id="verse-1---father" class="slide level2"><div class="slide-content">
 <h2>Verse 1 - Father</h2>
-<p>It’s not <code class="g">G</code> time to make a change <code
-class="d">D/F#</code><br />
-just relax <code class="c">C</code> and take it ea<code
-class="a">Am7</code>sy<br />
-You’re still <code class="g">G</code> young, that’s your fault <code
-class="e">Em</code><br />
-there’s so <code class="a">Am</code> much you have to know <code
-class="d">D</code></p>
-<p>Find a <code class="g">G</code> girl, settle down <code
-class="d">D/F#</code><br />
-if you want <code class="c">C</code>, you can mar<code
-class="a">Am7</code>ry<br />
-Look at me <code class="g">G</code>, I am old <code
-class="e">Em</code><br />
+<p>It’s not <code class="g">G</code> time to make a change <code class="d">D/F#</code><br>
+just relax <code class="c">C</code> and take it ea<code class="a">Am7</code>sy<br>
+You’re still <code class="g">G</code> young, that’s your fault <code class="e">Em</code><br>
+there’s so <code class="a">Am</code> much you have to know <code class="d">D</code></p>
+<p>Find a <code class="g">G</code> girl, settle down <code class="d">D/F#</code><br>
+if you want <code class="c">C</code>, you can mar<code class="a">Am7</code>ry<br>
+Look at me <code class="g">G</code>, I am old <code class="e">Em</code><br>
 but I’m <code class="a">Am</code> happy <code class="d">D</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I was <code class="g">G</code> once like you are now <code
-class="d">D</code><br />
-and I know <code class="c">C</code> that it’s not ea<code
-class="a">Am7</code>sy<br />
-To be <code class="g">G</code> calm when you’ve found <code
-class="e">Em</code><br />
-something <code class="a">Am</code> going on <code
-class="d">D</code></p>
-<p>But take your time <code class="g">G</code>, think a lot <code
-class="d">D</code><br />
-why think of ev<code class="c">C</code>erything you’ve got <code
-class="a">Am7</code><br />
-For you will <code class="g">G</code> still be here tomorrow <code
-class="e">Em</code><br />
+<p>I was <code class="g">G</code> once like you are now <code class="d">D</code><br>
+and I know <code class="c">C</code> that it’s not ea<code class="a">Am7</code>sy<br>
+To be <code class="g">G</code> calm when you’ve found <code class="e">Em</code><br>
+something <code class="a">Am</code> going on <code class="d">D</code></p>
+<p>But take your time <code class="g">G</code>, think a lot <code class="d">D</code><br>
+why think of ev<code class="c">C</code>erything you’ve got <code class="a">Am7</code><br>
+For you will <code class="g">G</code> still be here tomorrow <code class="e">Em</code><br>
 but your <code class="a">Am</code> dreams <code class="d">D</code> may
 <code class="g">G</code> not</p>
 <p><em>(Riff x2)</em></p>
-</section>
-<section id="verse-2---son" class="slide level2">
+</div></section>
+<section id="verse-2---son" class="slide level2"><div class="slide-content">
 <h2>Verse 2 - Son</h2>
-<p>How can I <code class="g">G</code> try to explain? <code
-class="b">Bm</code><br />
-’cause when I <code class="c">C</code> do he turns a<code
-class="a">Am7</code>way again<br />
-It’s al<code class="g">G</code>ways been the same <code
-class="e">Em</code><br />
+<p>How can I <code class="g">G</code> try to explain? <code class="b">Bm</code><br>
+’cause when I <code class="c">C</code> do he turns a<code class="a">Am7</code>way again<br>
+It’s al<code class="g">G</code>ways been the same <code class="e">Em</code><br>
 same old <code class="a">Am</code> story <code class="d">D</code></p>
-<p>From the mo<code class="g">G</code>ment I could talk <code
-class="b">Bm</code><br />
-I was or<code class="c">C</code>dered to lis<code
-class="a">Am7</code>ten<br />
-Now there’s a way <code class="g">G</code>, and I know <code
-class="e">Em</code> that I <code class="d">D</code> have to go away
-<code class="g">G</code><br />
-I <code class="d">D</code> know I <code class="c">C</code> have to <code
-class="g">G</code> go</p>
+<p>From the mo<code class="g">G</code>ment I could talk <code class="b">Bm</code><br>
+I was or<code class="c">C</code>dered to lis<code class="a">Am7</code>ten<br>
+Now there’s a way <code class="g">G</code>, and I know <code class="e">Em</code> that I <code class="d">D</code> have to go away
+<code class="g">G</code><br>
+I <code class="d">D</code> know I <code class="c">C</code> have to <code class="g">G</code> go</p>
 <p><em>(Riff x2)</em></p>
-</section>
-<section id="interlude-1" class="slide level2">
+</div></section>
+<section id="interlude-1" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="g">G</code> <code class="d">D</code> <code
-class="c">C</code> <code class="a">Am7</code><br />
-<code class="g">G</code> <code class="e">Em</code> <code
-class="a">Am</code> <code class="c">C</code> <code
-class="d">D</code><br />
-<code class="g">G</code> <code class="d">D</code> <code
-class="c">C</code> <code class="a">Am7</code><br />
-<code class="g">G</code> <code class="e">Em</code> <code
-class="d">D</code> <code class="g">G</code><br />
-<code class="d">D</code> <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-3---father" class="slide level2">
+<p><code class="g">G</code> <code class="d">D</code> <code class="c">C</code> <code class="a">Am7</code><br>
+<code class="g">G</code> <code class="e">Em</code> <code class="a">Am</code> <code class="c">C</code> <code class="d">D</code><br>
+<code class="g">G</code> <code class="d">D</code> <code class="c">C</code> <code class="a">Am7</code><br>
+<code class="g">G</code> <code class="e">Em</code> <code class="d">D</code> <code class="g">G</code><br>
+<code class="d">D</code> <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-3---father" class="slide level2"><div class="slide-content">
 <h2>Verse 3 - Father</h2>
-<p>It’s not <code class="g">G</code> time to make a change <code
-class="d">D/F#</code><br />
+<p>It’s not <code class="g">G</code> time to make a change <code class="d">D/F#</code><br>
 just <del>relax</del> <strong>sit down</strong> <code class="c">C</code>
-and take it <del>easy</del> <strong>slow<code
-class="a">Am7</code>ly</strong><br />
-You’re still <code class="g">G</code> young, that’s your fault <code
-class="e">Em</code><br />
+and take it <del>easy</del> <strong>slow<code class="a">Am7</code>ly</strong><br>
+You’re still <code class="g">G</code> young, that’s your fault <code class="e">Em</code><br>
 there’s so <code class="a">Am</code> much you have to <del>know</del>
 <strong>go through</strong> <code class="d">D</code></p>
-<p>Find a <code class="g">G</code> girl, settle down <code
-class="d">D/F#</code><br />
-if you want <code class="c">C</code>, you can mar<code
-class="a">Am7</code>ry<br />
-Look at me <code class="g">G</code>, I am old <code
-class="e">Em</code><br />
+<p>Find a <code class="g">G</code> girl, settle down <code class="d">D/F#</code><br>
+if you want <code class="c">C</code>, you can mar<code class="a">Am7</code>ry<br>
+Look at me <code class="g">G</code>, I am old <code class="e">Em</code><br>
 but I’m <code class="a">Am</code> happy <code class="d">D</code></p>
-</section>
-<section id="verse-4---son" class="slide level2">
+</div></section>
+<section id="verse-4---son" class="slide level2"><div class="slide-content">
 <h2>Verse 4 - Son</h2>
-<p>All the times <code class="g">G</code> that I’ve cried <code
-class="b">Bm</code><br />
-keeping all <code class="c">C</code> the things I knew <code
-class="a">Am7</code> inside<br />
-It’s hard <code class="g">G</code><br />
-but it’s har<code class="e">Em</code>der to ig<code
-class="a">Am</code>nore it <code class="d">D</code></p>
-<p>If they were right <code class="g">G</code>, I’d agree <code
-class="b">Bm</code> <em>(I love this one!)</em><br />
-but it’s them <code class="c">C</code> they know, not me <code
-class="a">Am7</code><br />
-Now there’s a way <code class="g">G</code>, and I know <code
-class="e">Em</code><br />
-that I <code class="d">D</code> have to go away <code
-class="g">G</code></p>
+<p>All the times <code class="g">G</code> that I’ve cried <code class="b">Bm</code><br>
+keeping all <code class="c">C</code> the things I knew <code class="a">Am7</code> inside<br>
+It’s hard <code class="g">G</code><br>
+but it’s har<code class="e">Em</code>der to ig<code class="a">Am</code>nore it <code class="d">D</code></p>
+<p>If they were right <code class="g">G</code>, I’d agree <code class="b">Bm</code> <em>(I love this one!)</em><br>
+but it’s them <code class="c">C</code> they know, not me <code class="a">Am7</code><br>
+Now there’s a way <code class="g">G</code>, and I know <code class="e">Em</code><br>
+that I <code class="d">D</code> have to go away <code class="g">G</code></p>
 <p>I <code class="d">D</code> know I <code class="c">C</code> have to
 <code class="g">G</code> go</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="feel-robbie-williams" class="title-slide slide level1">
+<section id="feel-robbie-williams" class="title-slide slide level1"><div class="slide-content">
 <h1>Feel (Robbie Williams)</h1>
 
-</section>
-<section id="intro-5" class="slide level2">
+</div></section>
+<section id="intro-5" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code> <em>(2x)</em></p>
-</section>
-<section id="verse-1-9" class="slide level2">
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code> <em>(2x)</em></p>
+</div></section>
+<section id="verse-1-9" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Come on and hold my <code class="d">Dm</code> hand<br />
-<code class="a">Am</code> I wanna contact the living <code
-class="a">A</code> <code class="a">A7</code><br />
-Not sure I under<code class="g">Gm</code>stand<br />
-<code class="d">Dm</code> This role I’ve been gi<code
-class="a">A</code>ven <code class="a">A7</code></p>
-</section>
-<section class="slide level2">
+<p>Come on and hold my <code class="d">Dm</code> hand<br>
+<code class="a">Am</code> I wanna contact the living <code class="a">A</code> <code class="a">A7</code><br>
+Not sure I under<code class="g">Gm</code>stand<br>
+<code class="d">Dm</code> This role I’ve been gi<code class="a">A</code>ven <code class="a">A7</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I sit and talk to <code class="d">Dm</code> God<br />
-<code class="a">Am</code> and he just laughs at my <code
-class="a">A</code> plans <code class="a">A7</code><br />
-My head speaks a <code class="g">Gm</code> language<br />
+<p>I sit and talk to <code class="d">Dm</code> God<br>
+<code class="a">Am</code> and he just laughs at my <code class="a">A</code> plans <code class="a">A7</code><br>
+My head speaks a <code class="g">Gm</code> language<br>
 <code class="d">Dm</code> I don’t understand <code class="a">A</code>
 <code class="a">A7</code></p>
-</section>
-<section id="chorus-1-1" class="slide level2">
+</div></section>
+<section id="chorus-1-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p>I just wanna <code class="b">Bb</code> feel real lo<code
-class="f">F</code>ve<br />
-Fill the home that I li<code class="c">C</code>ve in<br />
-Cause I got too much li<code class="b">Bb</code>fe<br />
-Running through my ve<code class="f">F</code>igns<br />
+<p>I just wanna <code class="b">Bb</code> feel real lo<code class="f">F</code>ve<br>
+Fill the home that I li<code class="c">C</code>ve in<br>
+Cause I got too much li<code class="b">Bb</code>fe<br>
+Running through my ve<code class="f">F</code>igns<br>
 Going to waste <code class="c">C</code></p>
-</section>
-<section id="verse-2-9" class="slide level2">
+</div></section>
+<section id="verse-2-9" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>I dont wanna <code class="d">Dm</code> die<br />
-<code class="a">Am</code> But I ain’t keen on living ei<code
-class="a">A</code>ther <code class="a">A7</code><br />
-Before I fall in <code class="g">Gm</code> love<br />
+<p>I dont wanna <code class="d">Dm</code> die<br>
+<code class="a">Am</code> But I ain’t keen on living ei<code class="a">A</code>ther <code class="a">A7</code><br>
+Before I fall in <code class="g">Gm</code> love<br>
 <code class="d">Dm</code> I’m preparing to le<code class="a">A</code>ave
 her <code class="a">A7</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I scare myself to de<code class="d">Dm</code>ath<br />
-<code class="a">Am</code> That’s why I keep on run<code
-class="a">A</code>ning <code class="a">A7</code><br />
-Before I’ve ar<code class="g">Gm</code>rived<br />
-<code class="d">Dm</code> I can see myself co<code
-class="a">A</code>ming <code class="a">A7</code></p>
-</section>
-<section id="chorus-2-1" class="slide level2">
+<p>I scare myself to de<code class="d">Dm</code>ath<br>
+<code class="a">Am</code> That’s why I keep on run<code class="a">A</code>ning <code class="a">A7</code><br>
+Before I’ve ar<code class="g">Gm</code>rived<br>
+<code class="d">Dm</code> I can see myself co<code class="a">A</code>ming <code class="a">A7</code></p>
+</div></section>
+<section id="chorus-2-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p>I just wanna <code class="b">Bb</code> feel real lo<code
-class="f">F</code>ve<br />
-Fill the home that I li<code class="c">C</code>ve in<br />
-Cause I got too much li<code class="b">Bb</code>fe<br />
-Running through my ve<code class="f">F</code>igns<br />
+<p>I just wanna <code class="b">Bb</code> feel real lo<code class="f">F</code>ve<br>
+Fill the home that I li<code class="c">C</code>ve in<br>
+Cause I got too much li<code class="b">Bb</code>fe<br>
+Running through my ve<code class="f">F</code>igns<br>
 Going to waste <code class="c">C</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I just wanna feel <code class="b">Bb</code> real lo<code
-class="f">F</code>ve<br />
-And the life ever af<code class="c">C</code>ter<br />
+<p>I just wanna feel <code class="b">Bb</code> real lo<code class="f">F</code>ve<br>
+And the life ever af<code class="c">C</code>ter<br>
 I cannot get enough</p>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code> <em>(3x)</em></p>
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code> <em>(3x)</em></p>
 <p><code class="d">Dm</code> <code class="a">Am</code>
 <em>(Pause)</em></p>
-</section>
-<section id="chorus-2-2" class="slide level2">
+</div></section>
+<section id="chorus-2-2" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p>I just wanna <code class="b">Bb</code> feel real lo<code
-class="f">F</code>ve<br />
-Fill the home that I li<code class="c">C</code>ve in<br />
-Cause I got too much li<code class="b">Bb</code>fe<br />
-Running through my ve<code class="f">F</code>igns<br />
+<p>I just wanna <code class="b">Bb</code> feel real lo<code class="f">F</code>ve<br>
+Fill the home that I li<code class="c">C</code>ve in<br>
+Cause I got too much li<code class="b">Bb</code>fe<br>
+Running through my ve<code class="f">F</code>igns<br>
 Going to <code class="c">C</code> waste</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>I just wanna feel <code class="b">Bb</code> real lo<code
-class="f">F</code>ve<br />
-And the life ever af<code class="c">C</code>ter<br />
-There’s a hole in my soul <code class="b">Bb</code><br />
-you can see it in my face <code class="f">F</code><br />
+<p>I just wanna feel <code class="b">Bb</code> real lo<code class="f">F</code>ve<br>
+And the life ever af<code class="c">C</code>ter<br>
+There’s a hole in my soul <code class="b">Bb</code><br>
+you can see it in my face <code class="f">F</code><br>
 it’s a real big place <code class="c">C</code></p>
-</section>
-<section id="bridge-2" class="slide level2">
+</div></section>
+<section id="bridge-2" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><code class="d">Dm</code> <code class="a">Am</code> <em>(2x)</em></p>
-<p>Come on and hold my <code class="d">Dm</code> hand<br />
-<code class="a">Am</code> I wanna contact the li<code
-class="d">Dm</code>ving<br />
-<code class="a">Am</code> Not sure I under<code
-class="d">Dm</code>stand<br />
-<code class="a">Am</code> This role I’ve been gi<code
-class="d">Dm</code>ven</p>
-<p><code class="a">Am</code> Not sure I under<code
-class="d">Dm</code>stand <em>(4x)</em></p>
-</section>
+<p>Come on and hold my <code class="d">Dm</code> hand<br>
+<code class="a">Am</code> I wanna contact the li<code class="d">Dm</code>ving<br>
+<code class="a">Am</code> Not sure I under<code class="d">Dm</code>stand<br>
+<code class="a">Am</code> This role I’ve been gi<code class="d">Dm</code>ven</p>
+<p><code class="a">Am</code> Not sure I under<code class="d">Dm</code>stand <em>(4x)</em></p>
+</div></section>
 </section>
 <section>
-<section id="further-on-up-the-road-johnny-cash"
-class="title-slide slide level1">
+<section id="further-on-up-the-road-johnny-cash" class="title-slide slide level1"><div class="slide-content">
 <h1>Further on up the road (Johnny Cash)</h1>
 
-</section>
-<section id="intro-6" class="slide level2">
+</div></section>
+<section id="intro-6" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="c">C</code> <code
-class="a">Am</code> <code class="e">E7</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-1-10" class="slide level2">
+<p><code class="a">Am</code> <code class="c">C</code> <code class="a">Am</code> <code class="e">E7</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-1-10" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Where the road is <code class="a">Am</code> dark<br />
-And the seed is <code class="c">C</code> sowed<br />
-Where the gun is <code class="a">Am</code> cocked<br />
+<p>Where the road is <code class="a">Am</code> dark<br>
+And the seed is <code class="c">C</code> sowed<br>
+Where the gun is <code class="a">Am</code> cocked<br>
 As the bullet’s <code class="c">C</code> cold</p>
-<p>Where the miles are <code class="a">Am</code> marked<br />
+<p>Where the miles are <code class="a">Am</code> marked<br>
 <code class="g">G</code> In the blood and the <code class="a">Am</code>
-gold<br />
+gold<br>
 <code class="g">G</code> I’ll <code class="f">F</code> meet you further
 <code class="g">G</code> on up the road <code class="a">Am</code></p>
-</section>
-<section id="verse-2-10" class="slide level2">
+</div></section>
+<section id="verse-2-10" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Got on my dead man <code class="a">Am</code> suit<br />
-And my smilin’ skull <code class="c">C</code> ring<br />
-My lucky graveyard <code class="a">Am</code> boots<br />
+<p>Got on my dead man <code class="a">Am</code> suit<br>
+And my smilin’ skull <code class="c">C</code> ring<br>
+My lucky graveyard <code class="a">Am</code> boots<br>
 And a song to <code class="c">C</code> sing</p>
-<p>I got a song to <code class="a">Am</code> sing<br />
-<code class="g">G</code> That keeps me out of the <code
-class="a">Am</code> cold<br />
+<p>I got a song to <code class="a">Am</code> sing<br>
+<code class="g">G</code> That keeps me out of the <code class="a">Am</code> cold<br>
 <code class="g">G</code> And I’ll <code class="f">F</code> meet
-you<br />
+you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road</p>
-</section>
-<section id="chorus-1-2" class="slide level2">
+</div></section>
+<section id="chorus-1-2" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p>Further on up the <code class="c">C</code> road<br />
-Further on up the <code class="a">Am</code> road<br />
-Where the way is <code class="c">C</code> dark<br />
+<p>Further on up the <code class="c">C</code> road<br>
+Further on up the <code class="a">Am</code> road<br>
+Where the way is <code class="c">C</code> dark<br>
 And the night is <code class="e">E7</code> cold</p>
-<p>One sunny <code class="a">Am</code> mornin’<br />
+<p>One sunny <code class="a">Am</code> mornin’<br>
 <code class="g">G</code> We’ll rise I <code class="a">Am</code>
-know<br />
+know<br>
 <code class="g">G</code> And I’ll <code class="f">F</code> meet
-you<br />
+you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road</p>
-</section>
-<section id="instrumental" class="slide level2">
+</div></section>
+<section id="instrumental" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="a">Am</code> <code class="c">C</code> <code
-class="a">Am</code> <code class="e">E7</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-3-7" class="slide level2">
+<p><code class="a">Am</code> <code class="c">C</code> <code class="a">Am</code> <code class="e">E7</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-3-7" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Now I’ve been out in the <code class="a">Am</code> desert<br />
-Just don’t my <code class="c">C</code> time<br />
-Searchin’ through the <code class="a">Am</code> dust<br />
+<p>Now I’ve been out in the <code class="a">Am</code> desert<br>
+Just don’t my <code class="c">C</code> time<br>
+Searchin’ through the <code class="a">Am</code> dust<br>
 Lookin’ for a <code class="c">C</code> sign</p>
-<p>If there’s a light up a<code class="g">G</code>head<br />
-Well, brother I don’t <code class="a">Am</code> know<br />
-<code class="g">G</code> But I’ve <code class="f">F</code> got<br />
-this fever <code class="g">G</code> burnin’ in my soul <code
-class="a">Am</code></p>
-</section>
-<section id="chours-2" class="slide level2">
+<p>If there’s a light up a<code class="g">G</code>head<br>
+Well, brother I don’t <code class="a">Am</code> know<br>
+<code class="g">G</code> But I’ve <code class="f">F</code> got<br>
+this fever <code class="g">G</code> burnin’ in my soul <code class="a">Am</code></p>
+</div></section>
+<section id="chours-2" class="slide level2"><div class="slide-content">
 <h2>Chours 2</h2>
-<p>Further on up the <code class="c">C</code> road<br />
-Further on up the <code class="a">Am</code> road<br />
-Further on up the <code class="c">C</code> road<br />
+<p>Further on up the <code class="c">C</code> road<br>
+Further on up the <code class="a">Am</code> road<br>
+Further on up the <code class="c">C</code> road<br>
 Further on up the <code class="e">E7</code> road</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>One sunny <code class="a">Am</code> mornin’ <code
-class="g">G</code><br />
+<p>One sunny <code class="a">Am</code> mornin’ <code class="g">G</code><br>
 We’ll rise I <code class="a">Am</code> know <code class="g">G</code></p>
-<p>And I’ll <code class="f">F</code> meet you<br />
+<p>And I’ll <code class="f">F</code> meet you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road <code class="g">G</code> <em>(2x)</em></p>
-<p>And I’ll <code class="f">F</code> meet you<br />
+<p>And I’ll <code class="f">F</code> meet you<br>
 further <code class="g">G</code> on up the <code class="a">Am</code>
 road</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="griechischer-wein-udo-jürgens"
-class="title-slide slide level1">
+<section id="griechischer-wein-udo-jürgens" class="title-slide slide level1"><div class="slide-content">
 <h1>Griechischer Wein (Udo Jürgens)</h1>
 
-</section>
-<section id="intro-7" class="slide level2">
+</div></section>
+<section id="intro-7" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code><br />
-<code class="c">C</code> <code class="e">E</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-1-11" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dm</code> <code class="f">F</code> <code class="g">G</code><br>
+<code class="c">C</code> <code class="e">E</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-1-11" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Es war schon <code class="a">Am</code> dunkel, als ich durch<br />
-Vorstadtstrassen <code class="f">F</code> heim<code
-class="g">G</code>wärts <code class="c">C</code> ging<br />
-Da war ein Wirtshaus, aus dem das<br />
-Licht noch auf den Geh<code class="f">F</code>steig <code
-class="g">G</code> schien</p>
-<p>Ich hatte <code class="a">Am</code> Zeit und mir war <code
-class="e">E</code> kalt<br />
+<p>Es war schon <code class="a">Am</code> dunkel, als ich durch<br>
+Vorstadtstrassen <code class="f">F</code> heim<code class="g">G</code>wärts <code class="c">C</code> ging<br>
+Da war ein Wirtshaus, aus dem das<br>
+Licht noch auf den Geh<code class="f">F</code>steig <code class="g">G</code> schien</p>
+<p>Ich hatte <code class="a">Am</code> Zeit und mir war <code class="e">E</code> kalt<br>
 drum trat ich <code class="a">Am</code> ein</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Da sassen <code class="a">Am</code> Männer mit braunen Augen<br />
-und mit <code class="f">F</code> schwar<code class="g">G</code>zem <code
-class="c">C</code> Haar<br />
-Und aus der Jukebox erklang Musik<br />
+<p>Da sassen <code class="a">Am</code> Männer mit braunen Augen<br>
+und mit <code class="f">F</code> schwar<code class="g">G</code>zem <code class="c">C</code> Haar<br>
+Und aus der Jukebox erklang Musik<br>
 die fremd und süd<code class="f">F</code>lich <code class="g">G</code>
 war</p>
-<p>Als man mich sah <code class="a">Am</code>, stand einer auf <code
-class="e">E</code><br />
+<p>Als man mich sah <code class="a">Am</code>, stand einer auf <code class="e">E</code><br>
 und lud mich ein <code class="a">Am</code></p>
-</section>
-<section id="chorus-1-3" class="slide level2">
+</div></section>
+<section id="chorus-1-3" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
 <p><code class="f">F</code> Griechischer Wein ist so wie das Blut der
-Erde<br />
-<code class="c">C</code> Komm schenk dir ein<br />
+Erde<br>
+<code class="c">C</code> Komm schenk dir ein<br>
 Und wenn ich dann traurig werde, <code class="g">G</code> liegt es
-daran<br />
+daran<br>
 Dass ich immer träume von da<code class="c">C</code>heim</p>
 <p>Du musst ver<code class="e">E</code>zeihen!</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="f">F</code> Griechischer Wein und die alt vertrauten
-Lieder<br />
-<code class="c">C</code> Schenk nochmal ein<br />
+Lieder<br>
+<code class="c">C</code> Schenk nochmal ein<br>
 Denn ich fühl die Sehnsucht wieder</p>
-<p><code class="g">G</code> In dieser Stadt<br />
-werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br />
+<p><code class="g">G</code> In dieser Stadt<br>
+werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br>
 <code class="e">E</code> und al<code class="a">Am</code>lein</p>
-</section>
-<section id="verse-2-11" class="slide level2">
+</div></section>
+<section id="verse-2-11" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>Und dann er<code class="a">Am</code>zählten sie mir von grünen
-Hügeln<br />
-<code class="f">F</code> Meer <code class="g">G</code> und <code
-class="c">C</code> Wind<br />
+Hügeln<br>
+<code class="f">F</code> Meer <code class="g">G</code> und <code class="c">C</code> Wind<br>
 Von alten Häusern und jungen Frauen, die allei<code class="f">F</code>ne
 <code class="g">G</code> sind</p>
-<p>Und von dem <code class="a">Am</code> Kind<br />
-das seinen <code class="e">E</code> Vater noch nie <code
-class="a">Am</code> sah</p>
-</section>
-<section class="slide level2">
+<p>Und von dem <code class="a">Am</code> Kind<br>
+das seinen <code class="e">E</code> Vater noch nie <code class="a">Am</code> sah</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Sie sagten <code class="a">Am</code> sich immer wieder<br />
+<p>Sie sagten <code class="a">Am</code> sich immer wieder<br>
 irgendwann geht <code class="f">F</code> es <code class="g">G</code>
-zu<code class="c">C</code>rück<br />
-Und das Ersparte genügt zu Hause<br />
+zu<code class="c">C</code>rück<br>
+Und das Ersparte genügt zu Hause<br>
 für ein klei<code class="f">F</code>nes <code class="g">G</code>
 Glück</p>
-<p>Und bald denkt <code class="a">Am</code> keiner mehr da<code
-class="e">E</code>ran<br />
+<p>Und bald denkt <code class="a">Am</code> keiner mehr da<code class="e">E</code>ran<br>
 wie es hier <code class="a">Am</code> war</p>
-</section>
-<section id="chorus-2-3" class="slide level2">
+</div></section>
+<section id="chorus-2-3" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
 <p><code class="f">F</code> Griechischer Wein ist so wie das Blut der
-Erde<br />
-<code class="c">C</code> Komm schenk dir ein<br />
+Erde<br>
+<code class="c">C</code> Komm schenk dir ein<br>
 Und wenn ich dann traurig werde, <code class="g">G</code> liegt es
-daran<br />
+daran<br>
 Dass ich immer träume von da<code class="c">C</code>heim</p>
 <p>Du musst ver<code class="e">E</code>zeihen!</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="f">F</code> Griechischer Wein und die alt vertrauten
-Lieder<br />
-<code class="c">C</code> Schenk nochmal ein<br />
+Lieder<br>
+<code class="c">C</code> Schenk nochmal ein<br>
 Denn ich fühl die Sehnsucht wieder</p>
-<p><code class="g">G</code> in dieser Stadt<br />
-Werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br />
+<p><code class="g">G</code> in dieser Stadt<br>
+Werd’ ich immer nur ein Fremder <code class="a">Am</code> sein<br>
 <code class="e">E</code> und al<code class="a">Am</code>lein</p>
-</section>
-<section id="outro-1" class="slide level2">
+</div></section>
+<section id="outro-1" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="a">Am</code> <code class="d">Dm</code> <code
-class="f">F</code> <code class="g">G</code><br />
-<code class="c">C</code> <code class="e">E</code> <code
-class="a">Am</code></p>
-</section>
+<p><code class="a">Am</code> <code class="d">Dm</code> <code class="f">F</code> <code class="g">G</code><br>
+<code class="c">C</code> <code class="e">E</code> <code class="a">Am</code></p>
+</div></section>
 </section>
 <section>
-<section id="hallelujah-leonard-cohen" class="title-slide slide level1">
+<section id="hallelujah-leonard-cohen" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ Hallelujah (Leonard Cohen)</h1>
 
-</section>
-<section id="intro-8" class="slide level2">
+</div></section>
+<section id="intro-8" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><code class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="verse-1-12" class="slide level2">
+</div></section>
+<section id="verse-1-12" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Now I’ve <code class="c">C</code> heard there was a <code
-class="a">Am</code> secret chord<br />
-That <code class="c">C</code> David played, and it <code
-class="a">Am</code> pleased the Lord<br />
+<p>Now I’ve <code class="c">C</code> heard there was a <code class="a">Am</code> secret chord<br>
+That <code class="c">C</code> David played, and it <code class="a">Am</code> pleased the Lord<br>
 But <code class="f">F</code> you don’t really <code class="g">G</code>
-care for music, <code class="c">C</code> do you? <code
-class="g">G</code></p>
-<p>It <code class="c">C</code> goes like this, the <code
-class="f">F</code> fourth, the <code class="g">G</code> fifth<br />
+care for music, <code class="c">C</code> do you? <code class="g">G</code></p>
+<p>It <code class="c">C</code> goes like this, the <code class="f">F</code> fourth, the <code class="g">G</code> fifth<br>
 The <code class="a">Am</code> minor fall, the <code class="f">F</code>
-major lift<br />
+major lift<br>
 The <code class="g">G</code> baffled king <code class="e">E</code>
 composing, halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-13" class="slide level2">
+</div></section>
+<section id="chorus-13" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-2-12" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-2-12" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Your <code class="c">C</code> faith was strong, but you <code
-class="a">Am</code> needed proof<br />
+<p>Your <code class="c">C</code> faith was strong, but you <code class="a">Am</code> needed proof<br>
 You <code class="c">C</code> saw her bathing <code class="a">Am</code>
-on the roof<br />
+on the roof<br>
 Her <code class="f">F</code> beauty and the <code class="g">G</code>
-moonlight over<code class="c">C</code>threw ya <code
-class="g">G</code></p>
+moonlight over<code class="c">C</code>threw ya <code class="g">G</code></p>
 <p>She <code class="c">C</code> tied you to a <code class="f">F</code>
-kitchen <code class="g">G</code> chair<br />
-She <code class="a">Am</code> broke your throne, and she <code
-class="f">F</code> cut your hair<br />
+kitchen <code class="g">G</code> chair<br>
+She <code class="a">Am</code> broke your throne, and she <code class="f">F</code> cut your hair<br>
 And <code class="g">G</code> from your lips she <code class="e">E</code>
 drew the <code class="a">Am</code> hallelujah</p>
-</section>
-<section id="chorus-14" class="slide level2">
+</div></section>
+<section id="chorus-14" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-3-8" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-3-8" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p><code class="c">C</code> Baby, I’ve been <code class="a">Am</code>
-here before<br />
-I <code class="c">C</code> know this room, I’ve <code
-class="a">Am</code> walked this floor<br />
+here before<br>
+I <code class="c">C</code> know this room, I’ve <code class="a">Am</code> walked this floor<br>
 I <code class="f">F</code>used to live a<code class="g">G</code>lone
 before I <code class="c">C</code> knew you <code class="g">G</code></p>
-<p>I’ve <code class="c">C</code> seen your flag on the <code
-class="f">F</code> marble <code class="g">G</code> arch<br />
+<p>I’ve <code class="c">C</code> seen your flag on the <code class="f">F</code> marble <code class="g">G</code> arch<br>
 <code class="a">Am</code>Love is not a <code class="f">F</code> victory
-march<br />
-It’s a <code class="g">G</code> cold, and it’s a <code
-class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-15" class="slide level2">
+march<br>
+It’s a <code class="g">G</code> cold, and it’s a <code class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
+</div></section>
+<section id="chorus-15" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-4-6" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-4-6" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>There <code class="c">C</code> was a time when you <code
-class="a">Am</code> let me know<br />
+<p>There <code class="c">C</code> was a time when you <code class="a">Am</code> let me know<br>
 What’s <code class="c">C</code> really going <code class="a">Am</code>
-on below<br />
+on below<br>
 But <code class="f">F</code> now you never <code class="g">G</code> show
 it to me, <code class="c">C</code> do you? <code class="g">G</code></p>
 <p>And re<code class="c">C</code>member when I <code class="f">F</code>
-moved in <code class="g">G</code> you<br />
+moved in <code class="g">G</code> you<br>
 The <code class="a">Am</code> holy dove was <code class="f">F</code>
-moving too<br />
+moving too<br>
 And <code class="g">G</code> every breath we <code class="e">E</code>
 drew was halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-16" class="slide level2">
+</div></section>
+<section id="chorus-16" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-5-5" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-5-5" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p><code class="c">C</code> Maybe there’s a <code class="a">Am</code>
-God above<br />
+God above<br>
 And <code class="c">C</code> all I ever <code class="a">Am</code>
-learned from love<br />
+learned from love<br>
 Was <code class="f">F</code> how to shoot at <code class="g">G</code>
-someone who out<code class="c">C</code>drew you <code
-class="g">G</code></p>
-<p>It’s <code class="c">C</code> not a cry you can <code
-class="f">F</code> hear at <code class="g">G</code> night<br />
-It’s <code class="a">Am</code> not somebody who has <code
-class="f">F</code> seen the light<br />
-It’s a <code class="g">G</code> cold, and it’s a <code
-class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-17" class="slide level2">
+someone who out<code class="c">C</code>drew you <code class="g">G</code></p>
+<p>It’s <code class="c">C</code> not a cry you can <code class="f">F</code> hear at <code class="g">G</code> night<br>
+It’s <code class="a">Am</code> not somebody who has <code class="f">F</code> seen the light<br>
+It’s a <code class="g">G</code> cold, and it’s a <code class="e">E</code> broken halle<code class="a">Am</code>lujah</p>
+</div></section>
+<section id="chorus-17" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-6-3" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-6-3" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
 <p>You <code class="c">C</code> say I took the <code class="a">Am</code>
-name in vain<br />
+name in vain<br>
 Though <code class="c">C</code> I don’t even <code class="a">Am</code>
-know the name<br />
+know the name<br>
 But <code class="f">F</code> if I did, well <code class="g">G</code>
-really, what’s it <code class="c">C</code> to ya? <code
-class="g">G</code></p>
-<p>There’s a <code class="c">C</code> blaze of light in <code
-class="f">F</code> every <code class="g">G</code> word<br />
+really, what’s it <code class="c">C</code> to ya? <code class="g">G</code></p>
+<p>There’s a <code class="c">C</code> blaze of light in <code class="f">F</code> every <code class="g">G</code> word<br>
 It <code class="a">Am</code> doesn’t matter <code class="f">F</code>
-which you heard<br />
+which you heard<br>
 The <code class="g">G</code> holy or the <code class="e">E</code> broken
 halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-18" class="slide level2">
+</div></section>
+<section id="chorus-18" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
-</section>
-<section id="verse-7-1" class="slide level2">
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-7-1" class="slide level2"><div class="slide-content">
 <h2>Verse 7</h2>
 <p>I <code class="c">C</code> did my best, it <code class="a">Am</code>
-wasn’t much<br />
+wasn’t much<br>
 I <code class="c">C</code> couldn’t feel, so I <code class="a">Am</code>
-tried to touch<br />
+tried to touch<br>
 I’ve <code class="f">F</code> told the truth, I <code class="g">G</code>
-didn’t come to <code class="c">C</code> fool ya <code
-class="g">G</code></p>
+didn’t come to <code class="c">C</code> fool ya <code class="g">G</code></p>
 <p>And <code class="c">C</code> even though it <code class="f">F</code>
-all went <code class="g">G</code> wrong<br />
+all went <code class="g">G</code> wrong<br>
 I’ll <code class="a">Am</code> stand before the <code class="f">F</code>
-Lord of Song<br />
+Lord of Song<br>
 With <code class="g">G</code> nothing on my <code class="e">E</code>
 tongue but halle<code class="a">Am</code>lujah</p>
-</section>
-<section id="chorus-19" class="slide level2">
+</div></section>
+<section id="chorus-19" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Halle<code class="f">F</code>lujah, halle<code
-class="a">Am</code>lujah<br />
-Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code
-class="g">G</code>jah <code class="c">C</code> <code
-class="g">G</code></p>
+<p>Halle<code class="f">F</code>lujah, halle<code class="a">Am</code>lujah<br>
+Galle<code class="f">F</code>lujah, halle<code class="c">C</code>lu<code class="g">G</code>jah <code class="c">C</code> <code class="g">G</code></p>
 <p><em>(4x)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="hemmige-mani-matter" class="title-slide slide level1">
+<section id="hemmige-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>Hemmige (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-13" class="slide level2">
+</div></section>
+<section id="verse-1-13" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>S’git <code class="a">Am</code> Lüt, die würden alletwäge <code
-class="d">Dm</code> nie<br />
-Es <code class="g">G</code> Lied vorsinge, so win ig jitz <code
-class="c">C</code> hie<br />
-Eis singe <code class="c">C</code> - um kei Pris, nei bhüetis <code
-class="e">E7</code> nei!<br />
+<p>S’git <code class="a">Am</code> Lüt, die würden alletwäge <code class="d">Dm</code> nie<br>
+Es <code class="g">G</code> Lied vorsinge, so win ig jitz <code class="c">C</code> hie<br>
+Eis singe <code class="c">C</code> - um kei Pris, nei bhüetis <code class="e">E7</code> nei!<br>
 Will si <code class="a">Am</code> hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-2-13" class="slide level2">
+</div></section>
+<section id="verse-2-13" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Si <code class="a">Am</code> wäre vilicht gärn im Grund gno <code
-class="d">Dm</code> fräch<br />
-Und <code class="g">G</code> dänke, das syg ires grosse <code
-class="c">C</code> Päch<br />
-Und <code class="c">C</code> s’laschtet uf ne wine schwäre <code
-class="e">E7</code> Stei<br />
+<p>Si <code class="a">Am</code> wäre vilicht gärn im Grund gno <code class="d">Dm</code> fräch<br>
+Und <code class="g">G</code> dänke, das syg ires grosse <code class="c">C</code> Päch<br>
+Und <code class="c">C</code> s’laschtet uf ne wine schwäre <code class="e">E7</code> Stei<br>
 dass si <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-3-9" class="slide level2">
+</div></section>
+<section id="verse-3-9" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>I <code class="a">Am</code> weis, das macht eim heiss,<br />
-erschlat eim <code class="d">Dm</code> d’Stimm<br />
-Doch <code class="g">G</code> dünkt eim mängisch o<br />
-s’syg nüt so <code class="c">C</code> schlimm<br />
-S’isch <code class="c">C</code> glych es Glück, o we mirs gar nid <code
-class="e">E7</code> wei<br />
+<p>I <code class="a">Am</code> weis, das macht eim heiss,<br>
+erschlat eim <code class="d">Dm</code> d’Stimm<br>
+Doch <code class="g">G</code> dünkt eim mängisch o<br>
+s’syg nüt so <code class="c">C</code> schlimm<br>
+S’isch <code class="c">C</code> glych es Glück, o we mirs gar nid <code class="e">E7</code> wei<br>
 Dass mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-4-7" class="slide level2">
+</div></section>
+<section id="verse-4-7" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>Was <code class="a">Am</code> unterscheidet d’Mönsche vom schim<code
-class="d">Dm</code>pans?<br />
-S’isch <code class="g">G</code> nid die glatti Huut, dr fählend <code
-class="c">C</code> Schwanz<br />
-Nid <code class="c">C</code> dass mir schlächter d’Böim ufchöme, <code
-class="e">E7</code> nei<br />
+<p>Was <code class="a">Am</code> unterscheidet d’Mönsche vom schim<code class="d">Dm</code>pans?<br>
+S’isch <code class="g">G</code> nid die glatti Huut, dr fählend <code class="c">C</code> Schwanz<br>
+Nid <code class="c">C</code> dass mir schlächter d’Böim ufchöme, <code class="e">E7</code> nei<br>
 Dass mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-5-6" class="slide level2">
+</div></section>
+<section id="verse-5-6" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
 <p><em>(Interlude in Stephan Eicher’s Version)</em></p>
 <p>Me <code class="a">Am</code> stell sech d’Manne vor, wenns anders
-<code class="d">Dm</code> wär<br />
-Und <code class="g">G</code> s’chäm es hübsches Meiteli der<code
-class="c">C</code>här<br />
-Jitz <code class="c">C</code> luege mir doch höchstens chly uf d’<code
-class="e">E7</code>Bei<br />
+<code class="d">Dm</code> wär<br>
+Und <code class="g">G</code> s’chäm es hübsches Meiteli der<code class="c">C</code>här<br>
+Jitz <code class="c">C</code> luege mir doch höchstens chly uf d’<code class="e">E7</code>Bei<br>
 Will mir <code class="a">Am</code> Hemmige <code class="e">E7</code>
 hei</p>
-</section>
-<section id="verse-6-4" class="slide level2">
+</div></section>
+<section id="verse-6-4" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
 <p>Und <code class="a">Am</code> we me gseht, was hütt dr Mönschheit
-<code class="d">Dm</code> droht<br />
-So <code class="g">G</code> gseht me würklech schwarz, nid nume <code
-class="c">C</code> rot<br />
-Und <code class="c">C</code> was me no cha hoffen isch a<code
-class="e">E7</code>lei<br />
-Dass si <code class="a">Am</code> Hemm<code class="e">E7</code>ige <code
-class="a">Am</code> hei</p>
-</section>
+<code class="d">Dm</code> droht<br>
+So <code class="g">G</code> gseht me würklech schwarz, nid nume <code class="c">C</code> rot<br>
+Und <code class="c">C</code> was me no cha hoffen isch a<code class="e">E7</code>lei<br>
+Dass si <code class="a">Am</code> Hemm<code class="e">E7</code>ige <code class="a">Am</code> hei</p>
+</div></section>
 </section>
 <section>
-<section id="hurt-johnny-cash" class="title-slide slide level1">
+<section id="hurt-johnny-cash" class="title-slide slide level1"><div class="slide-content">
 <h1>Hurt (Johnny Cash)</h1>
 
-</section>
-<section id="instructions-2" class="slide level2">
+</div></section>
+<section id="instructions-2" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>Chorus chord variations:
 
@@ -1772,133 +1496,107 @@ C/E(2) |0 3 2 0 1 3|
 Fadd9  |1 0 3 2 1 3| Thumb on E string
 
 Just keep pinky on 3rd fret of e string</code></pre>
-</section>
-<section id="intro-9" class="slide level2">
+</div></section>
+<section id="intro-9" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-1-14" class="slide level2">
+<p><code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-1-14" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>I <code class="c">C</code> hurt myself <code class="d">D</code> today
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 to see <code class="c">C</code> if I <code class="d">D</code> still feel
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 I <code class="c">C</code> focus <code class="d">D</code> on the pain
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 the <code class="c">C</code> only thing <code class="d">D</code> that’s
 real <code class="a">Am</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>The <code class="c">C</code> needle <code class="d">D</code> tears a
-hole <code class="a">Am</code><br />
+hole <code class="a">Am</code><br>
 the <code class="c">C</code> old fa<code class="d">D</code>miliar sting
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 Try to <code class="c">C</code> kill it <code class="d">D</code> all
-away <code class="a">Am</code><br />
+away <code class="a">Am</code><br>
 but I re<code class="c">C</code>member <code class="d">D</code>
 everything <code class="g">G</code></p>
-</section>
-<section id="chorus-1-4" class="slide level2">
+</div></section>
+<section id="chorus-1-4" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p><code class="a">Am7</code> What have I become? <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My sweetest friend <code
-class="g">G</code><br />
-<code class="a">Am7</code> Everyone I know <code
-class="f">Fadd9</code><br />
-goes away <code class="c">C/E</code> in the end <code
-class="g">G</code></p>
-</section>
-<section class="slide level2">
+<p><code class="a">Am7</code> What have I become? <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My sweetest friend <code class="g">G</code><br>
+<code class="a">Am7</code> Everyone I know <code class="f">Fadd9</code><br>
+goes away <code class="c">C/E</code> in the end <code class="g">G</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>And <code class="a">Am7</code> you could have it all <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My empire of dirt <code
-class="g">G</code><br />
-<code class="a">Am7</code> I will let you down <code
-class="f">Fadd9</code><br />
-<code class="g">G</code> I will make you hurt <code
-class="a">Am</code></p>
-</section>
-<section id="transition" class="slide level2">
+<p>And <code class="a">Am7</code> you could have it all <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My empire of dirt <code class="g">G</code><br>
+<code class="a">Am7</code> I will let you down <code class="f">Fadd9</code><br>
+<code class="g">G</code> I will make you hurt <code class="a">Am</code></p>
+</div></section>
+<section id="transition" class="slide level2"><div class="slide-content">
 <h2>Transition</h2>
-<p><code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code></p>
-</section>
-<section id="verse-2-14" class="slide level2">
+<p><code class="c">C</code> <code class="d">D</code> <code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code></p>
+</div></section>
+<section id="verse-2-14" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>I <code class="c">C</code> wear this crown <code class="d">D</code>
-of thorns <code class="a">Am</code><br />
+of thorns <code class="a">Am</code><br>
 u<code class="c">C</code>pon my li<code class="d">D</code>ar’s chair
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 <code class="c">C</code> Full of bro<code class="d">D</code>ken thoughts
-<code class="a">Am</code><br />
-<code class="c">C</code>I cannot <code class="d">D</code> re<code
-class="a">Am</code>pair</p>
-</section>
-<section class="slide level2">
+<code class="a">Am</code><br>
+<code class="c">C</code>I cannot <code class="d">D</code> re<code class="a">Am</code>pair</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>Be<code class="c">C</code>neath the stains <code class="d">D</code>
-of <code class="a">Am</code> time<br />
+of <code class="a">Am</code> time<br>
 the <code class="c">C</code> feelings <code class="d">D</code> disappear
-<code class="a">Am</code><br />
+<code class="a">Am</code><br>
 <code class="c">C</code> You are some<code class="d">D</code>one else
-<code class="a">Am</code><br />
-<code class="c">C</code> I am still <code class="d">D</code> right <code
-class="g">G</code> here</p>
+<code class="a">Am</code><br>
+<code class="c">C</code> I am still <code class="d">D</code> right <code class="g">G</code> here</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="chorus-2-4" class="slide level2">
+</div></section>
+<section id="chorus-2-4" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p><code class="a">Am7</code> What have I become? <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My sweetest friend <code
-class="g">G</code><br />
-<code class="a">Am7</code> Everyone I know <code
-class="f">Fadd9</code><br />
-goes away <code class="c">C/E</code> in the end <code
-class="g">G</code></p>
-</section>
-<section class="slide level2">
+<p><code class="a">Am7</code> What have I become? <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My sweetest friend <code class="g">G</code><br>
+<code class="a">Am7</code> Everyone I know <code class="f">Fadd9</code><br>
+goes away <code class="c">C/E</code> in the end <code class="g">G</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>And <code class="a">Am7</code> you could have it all <code
-class="f">Fadd9</code><br />
-<code class="c">C/E</code> My empire of dirt <code
-class="g">G</code><br />
-<code class="a">Am7</code> I will let you down <code
-class="f">Fadd9</code><br />
+<p>And <code class="a">Am7</code> you could have it all <code class="f">Fadd9</code><br>
+<code class="c">C/E</code> My empire of dirt <code class="g">G</code><br>
+<code class="a">Am7</code> I will let you down <code class="f">Fadd9</code><br>
 <code class="g">G</code> I will make you hurt <code class="g">G</code>
 <em>(remain on G)</em></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>If I <code class="a">Am7</code> could start again <code
-class="f">Fadd9</code><br />
-a <code class="c">C/E</code> million miles a<code
-class="g">G</code>way<br />
-<code class="a">Am7</code> I would keep myself <code
-class="f">Fadd9</code><br />
+<p>If I <code class="a">Am7</code> could start again <code class="f">Fadd9</code><br>
+a <code class="c">C/E</code> million miles a<code class="g">G</code>way<br>
+<code class="a">Am7</code> I would keep myself <code class="f">Fadd9</code><br>
 <code class="g">G</code> I would find a way</p>
-<p><code class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code><br />
-<code class="c">C</code> <code class="d">D</code> <code
-class="a">Am</code></p>
-</section>
+<p><code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code><br>
+<code class="c">C</code> <code class="d">D</code> <code class="a">Am</code></p>
+</div></section>
 </section>
 <section>
-<section id="i-am-sailing-rod-stewart" class="title-slide slide level1">
+<section id="i-am-sailing-rod-stewart" class="title-slide slide level1"><div class="slide-content">
 <h1>I am sailing (Rod Stewart)</h1>
 
-</section>
-<section id="instructions-3" class="slide level2">
+</div></section>
+<section id="instructions-3" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <p>Capo on 3rd fret</p>
 <pre><code>   Riff:
@@ -1909,521 +1607,456 @@ D |----|----|0-------|----|----|0---0-2|
 A |----|----|--------|----|----|-------|
 E |----|----|--------|----|----|-------|
      x4   x2            x4   x2</code></pre>
-</section>
-<section id="intro-10" class="slide level2">
+</div></section>
+<section id="intro-10" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Riff)</em></p>
-</section>
-<section id="verse-1-15" class="slide level2">
+</div></section>
+<section id="verse-1-15" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>I am <code class="g">G</code> sailing, I am <code class="e">Em</code>
-sailing<br />
+sailing<br>
 home a<code class="c">C</code>gain ’cross the <code class="g">G</code>
 sea.</p>
-<p>I am <code class="a">Am</code> sailing stormy <code
-class="e">Em</code> waters<br />
+<p>I am <code class="a">Am</code> sailing stormy <code class="e">Em</code> waters<br>
 to be <code class="a">Am</code> near you, to be <code class="g">G</code>
 free. <code class="d">D</code></p>
-</section>
-<section id="verse-2-15" class="slide level2">
+</div></section>
+<section id="verse-2-15" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>I am <code class="g">G</code> flying, I am <code class="e">Em</code>
-flying<br />
+flying<br>
 like a <code class="c">C</code> bird ’cross the <code class="g">G</code>
 sea.</p>
-<p>I am <code class="a">Am</code> flying passing <code
-class="e">Em</code> high clouds<br />
+<p>I am <code class="a">Am</code> flying passing <code class="e">Em</code> high clouds<br>
 to be <code class="a">Am</code> near you, to be <code class="g">G</code>
 free. <code class="d">D</code></p>
-</section>
-<section id="chorus-20" class="slide level2">
+</div></section>
+<section id="chorus-20" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Can you <code class="g">G</code> hear me, can you <code
-class="e">Em</code> hear me<br />
-thru the <code class="c">C</code> dark night far a<code
-class="g">G</code>way?</p>
-<p>I am <code class="a">Am</code> dying, forever <code
-class="e">Em</code> trying<br />
-to be <code class="a">Am</code> with you, who can <code
-class="g">G</code> say? <code class="d">D</code></p>
-</section>
-<section id="verse-3-10" class="slide level2">
+<p>Can you <code class="g">G</code> hear me, can you <code class="e">Em</code> hear me<br>
+thru the <code class="c">C</code> dark night far a<code class="g">G</code>way?</p>
+<p>I am <code class="a">Am</code> dying, forever <code class="e">Em</code> trying<br>
+to be <code class="a">Am</code> with you, who can <code class="g">G</code> say? <code class="d">D</code></p>
+</div></section>
+<section id="verse-3-10" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>We are <code class="g">G</code> sailing, we are <code
-class="e">Em</code> sailing<br />
+<p>We are <code class="g">G</code> sailing, we are <code class="e">Em</code> sailing<br>
 home a<code class="c">C</code>gain ’cross the <code class="g">G</code>
 sea.</p>
-<p>We are <code class="a">Am</code> sailing stormy <code
-class="e">Em</code> waters<br />
+<p>We are <code class="a">Am</code> sailing stormy <code class="e">Em</code> waters<br>
 to be <code class="a">Am</code> near you, to be <code class="g">G</code>
 free. <code class="d">D</code> Oh Lord</p>
-</section>
-<section id="outro-2" class="slide level2">
+</div></section>
+<section id="outro-2" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p>To be <code class="a">Am</code> near you, to be <code
-class="g">G</code> free.<br />
-Oh Lord, to be <code class="a">Am</code> near you, to be free. <code
-class="g">G</code></p>
-</section>
+<p>To be <code class="a">Am</code> near you, to be <code class="g">G</code> free.<br>
+Oh Lord, to be <code class="a">Am</code> near you, to be free. <code class="g">G</code></p>
+</div></section>
 </section>
 <section>
-<section id="jolene-dolly-parton" class="title-slide slide level1">
+<section id="jolene-dolly-parton" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ Jolene (Dolly Parton)</h1>
 
-</section>
-<section id="intro-11" class="slide level2">
+</div></section>
+<section id="intro-11" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><code class="a">Am</code> <em>(x4)</em></p>
-</section>
-<section id="chorus-21" class="slide level2">
+</div></section>
+<section id="chorus-21" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-I’m <code class="g">G</code> begging of you<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+I’m <code class="g">G</code> begging of you<br>
 please don’t take my <code class="a">Am</code> man</p>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-<code class="g">G</code> Please don’t take him<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+<code class="g">G</code> Please don’t take him<br>
 <code class="e">Em</code> just because you <code class="a">Am</code>
 can</p>
-</section>
-<section id="verse-1-16" class="slide level2">
+</div></section>
+<section id="verse-1-16" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Your <code class="a">Am</code> beauty is be<code
-class="c">C</code>yond compare<br />
+<p>Your <code class="a">Am</code> beauty is be<code class="c">C</code>yond compare<br>
 With <code class="g">G</code> flaming locks of <code class="a">Am</code>
-auburn hair<br />
-With <code class="g">G</code> ivory skin<br />
+auburn hair<br>
+With <code class="g">G</code> ivory skin<br>
 and <code class="e">Em</code> eyes of emerald <code class="a">Am</code>
 green</p>
-<p>Your <code class="a">Am</code> smile is like a <code
-class="c">C</code> breath of spring<br />
-Your <code class="g">G</code> voice is soft like <code
-class="a">Am</code> summer rain<br />
+<p>Your <code class="a">Am</code> smile is like a <code class="c">C</code> breath of spring<br>
+Your <code class="g">G</code> voice is soft like <code class="a">Am</code> summer rain<br>
 And <code class="g">G</code> I cannot com<code class="e">Em</code>pete
-with you<br />
+with you<br>
 <code class="a">Am</code> Jolene</p>
-</section>
-<section id="verse-2-16" class="slide level2">
+</div></section>
+<section id="verse-2-16" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>He <code class="a">Am</code> talks about you <code class="c">C</code>
-in his sleep<br />
+in his sleep<br>
 There’s <code class="g">G</code> nothing I can <code class="a">Am</code>
-do to keep<br />
+do to keep<br>
 From <code class="g">G</code> crying when he <code class="e">Em</code>
-calls your name<br />
+calls your name<br>
 Jo<code class="a">Am</code>lene</p>
 <p>And <code class="a">Am</code> I can easily <code class="c">C</code>
-understand<br />
+understand<br>
 How <code class="g">G</code> you could easily <code class="a">Am</code>
-take my man<br />
-But you <code class="g">G</code> don’t know what he <code
-class="e">Em</code> means to me<br />
+take my man<br>
+But you <code class="g">G</code> don’t know what he <code class="e">Em</code> means to me<br>
 Jo<code class="a">Am</code>lene</p>
-</section>
-<section id="chorus-22" class="slide level2">
+</div></section>
+<section id="chorus-22" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-I’m <code class="g">G</code> begging of you<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+I’m <code class="g">G</code> begging of you<br>
 please don’t take my <code class="a">Am</code> man</p>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-<code class="g">G</code> Please don’t take him<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+<code class="g">G</code> Please don’t take him<br>
 <code class="e">Em</code> just because you <code class="a">Am</code>
 can</p>
-</section>
-<section id="verse-3-11" class="slide level2">
+</div></section>
+<section id="verse-3-11" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> You could have your <code
-class="c">C</code> choice of men<br />
+<p><code class="a">Am</code> You could have your <code class="c">C</code> choice of men<br>
 But <code class="g">G</code> I could never <code class="a">Am</code>
-love again<br />
+love again<br>
 <code class="g">G</code> He’s the only <code class="e">Em</code> one for
-me<br />
+me<br>
 Jo<code class="a">Am</code>lene</p>
 <p>I <code class="a">Am</code> had to have this <code class="c">C</code>
-talk with you<br />
+talk with you<br>
 My <code class="g">G</code> happiness de<code class="a">Am</code>pends
-on you<br />
+on you<br>
 What<code class="g">G</code>ever you de<code class="e">Em</code>cide to
-do<br />
+do<br>
 Jo<code class="a">Am</code>lene</p>
-</section>
-<section id="chorus-23" class="slide level2">
+</div></section>
+<section id="chorus-23" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-I’m <code class="g">G</code> begging of you<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+I’m <code class="g">G</code> begging of you<br>
 please don’t take my <code class="a">Am</code> man</p>
 <p>Jo<code class="a">Am</code>lene, Jo<code class="c">C</code>lene,
-Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br />
-<code class="g">G</code> Please don’t take him<br />
+Jo<code class="g">G</code>lene, Jo<code class="a">Am</code>lene<br>
+<code class="g">G</code> Please don’t take him<br>
 <code class="e">Em</code> <del>just because</del> <strong>even
 though</strong> you <code class="a">Am</code> can</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="junge-die-ärzte" class="title-slide slide level1">
+<section id="junge-die-ärzte" class="title-slide slide level1"><div class="slide-content">
 <h1>Junge (Die Ärzte)</h1>
 
-</section>
-<section id="intro-12" class="slide level2">
+</div></section>
+<section id="intro-12" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="a">Am</code> <code class="a">Am</code> <em>(x2)</em></p>
-</section>
-<section id="verse-1-17" class="slide level2">
+<p><code class="f">F</code> <code class="g">G</code> <code class="a">Am</code> <code class="a">Am</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-1-17" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><em>(Picking)</em></p>
 <p><code class="f">F</code> Junge, warum <code class="g">G</code> hast
-Du nichts gelernt? <code class="a">Am</code><br />
-Guck Dir den <code class="f">F</code> Dieter an:<br />
+Du nichts gelernt? <code class="a">Am</code><br>
+Guck Dir den <code class="f">F</code> Dieter an:<br>
 <code class="g">G</code> der hat sogar ein <code class="a">Am</code>
 Auto! <code class="e">Em</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Warum <code class="f">F</code> gehst Du nicht zu<br />
-Onkel Werner in die Werk<code class="g">G</code>statt?<br />
-Der gibt Dir ’ne <code class="a">Am</code> Festanstellung<br />
+<p>Warum <code class="f">F</code> gehst Du nicht zu<br>
+Onkel Werner in die Werk<code class="g">G</code>statt?<br>
+Der gibt Dir ’ne <code class="a">Am</code> Festanstellung<br>
 wenn Du ihn darum bittest</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
-</section>
-<section id="chorus-1-5" class="slide level2">
+</div></section>
+<section id="chorus-1-5" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
 <p><em>(Strumming)</em></p>
-<p>…und wie du wieder aus<code class="f">F</code>siehst<br />
-Löcher in der Ho<code class="d">Dm</code>se<br />
-und ständig dieser Lärm <code class="a">Am</code><br />
+<p>…und wie du wieder aus<code class="f">F</code>siehst<br>
+Löcher in der Ho<code class="d">Dm</code>se<br>
+und ständig dieser Lärm <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Und dann noch deine Ha<code class="f">F</code>are<br />
-da fehlen mir die Wor<code class="d">Dm</code>te<br />
-musst du die denn färb’n? <code class="a">Am</code><br />
+<p>Und dann noch deine Ha<code class="f">F</code>are<br>
+da fehlen mir die Wor<code class="d">Dm</code>te<br>
+musst du die denn färb’n? <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>Nie kommst du nach Hau<code class="f">F</code>se<br />
+<p>Nie kommst du nach Hau<code class="f">F</code>se<br>
 wir wissen nicht mehr wei<code class="d">Dm</code>ter</p>
-</section>
-<section id="verse-2-17" class="slide level2">
+</div></section>
+<section id="verse-2-17" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p><em>(Picking)</em></p>
 <p><code class="f">F</code> Junge, <code class="g">G</code> brich deiner
-Mutter nicht das Herz <code class="a">Am</code><br />
-es ist noch <code class="f">F</code> nicht zu spät <code
-class="g">G</code><br />
+Mutter nicht das Herz <code class="a">Am</code><br>
+es ist noch <code class="f">F</code> nicht zu spät <code class="g">G</code><br>
 dich an der Uni einzu<code class="a">Am</code>schreiben</p>
-<p>du hast dich doch <code class="f">F</code> früher so<br />
-für Tiere interessiert <code class="g">G</code><br />
+<p>du hast dich doch <code class="f">F</code> früher so<br>
+für Tiere interessiert <code class="g">G</code><br>
 wäre das nichts für <code class="a">Am</code> dich: eine eigene
 Praxis?</p>
 <p><code class="f">F</code> Junge… <code class="g">G</code></p>
-</section>
-<section id="chorus-2-5" class="slide level2">
+</div></section>
+<section id="chorus-2-5" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
 <p><em>(Strumming)</em></p>
-<p>…und wie du wieder aus<code class="f">F</code>siehst<br />
-Löcher in der Ho<code class="d">Dm</code>se<br />
-und ständig dieser Lärm <code class="a">Am</code><br />
+<p>…und wie du wieder aus<code class="f">F</code>siehst<br>
+Löcher in der Ho<code class="d">Dm</code>se<br>
+und ständig dieser Lärm <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>Elektrische Gi<code class="f">F</code>tarren<br />
-und immer diese Tex<code class="d">Dm</code>te<br />
-das will doch keiner hör’n <code class="a">Am</code><br />
+<p>Elektrische Gi<code class="f">F</code>tarren<br>
+und immer diese Tex<code class="d">Dm</code>te<br>
+das will doch keiner hör’n <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Nie kommst du nach Hau<code class="f">F</code>se<br />
-so viel schlechter Um<code class="d">Dm</code>gang<br />
-wir werden dich enterb’n <code class="a">Am</code><br />
+<p>Nie kommst du nach Hau<code class="f">F</code>se<br>
+so viel schlechter Um<code class="d">Dm</code>gang<br>
+wir werden dich enterb’n <code class="a">Am</code><br>
 (was soll das Finanz<code class="c">C</code>amt sagen?)</p>
-<p>wo soll das alles en<code class="f">F</code>den?<br />
+<p>wo soll das alles en<code class="f">F</code>den?<br>
 Wir machen uns doch Sor<code class="d">Dm</code>gen</p>
-</section>
-<section id="bridge-3" class="slide level2">
+</div></section>
+<section id="bridge-3" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><em>(Very fast strumming)</em></p>
 <p><code class="f">F</code> und du warst <code class="d">Dm</code> so
-ein süsses <code class="a">Am</code> Kind<br />
-und du warst <code class="c">C</code> so ein süsses <code
-class="f">F</code> Kind<br />
-und du warst <code class="d">Dm</code> so ein süsses <code
-class="a">Am</code> Kind<br />
+ein süsses <code class="a">Am</code> Kind<br>
+und du warst <code class="c">C</code> so ein süsses <code class="f">F</code> Kind<br>
+und du warst <code class="d">Dm</code> so ein süsses <code class="a">Am</code> Kind<br>
 du warst so <code class="c">C</code> süss</p>
-</section>
-<section id="chorus-24" class="slide level2">
+</div></section>
+<section id="chorus-24" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Und immer deine Freun<code class="f">F</code>de<br />
-ihr nehmt doch alle Dro<code class="d">Dm</code>gen<br />
-und ständig dieser Lärm <code class="a">Am</code><br />
+<p>Und immer deine Freun<code class="f">F</code>de<br>
+ihr nehmt doch alle Dro<code class="d">Dm</code>gen<br>
+und ständig dieser Lärm <code class="a">Am</code><br>
 (Was soll’n die Nach<code class="c">C</code>barn sagen?)</p>
-<p>denk’ an deine Zu<code class="f">F</code>kunft<br />
+<p>denk’ an deine Zu<code class="f">F</code>kunft<br>
 denk’ an deine El<code class="d">Dm</code>tern…</p>
 <p>…willst du, dass wir <code class="a">Am</code> sterb’n?</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="keep-on-the-sunny-side-carter-family"
-class="title-slide slide level1">
+<section id="keep-on-the-sunny-side-carter-family" class="title-slide slide level1"><div class="slide-content">
 <h1>Keep on the sunny side (Carter Family)</h1>
 
-</section>
-<section id="intro-13" class="slide level2">
+</div></section>
+<section id="intro-13" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code><br />
-<code class="c">C</code> <code class="g">G</code><br />
-<code class="g">G7</code> <code class="c">C</code><br />
+<p><code class="c">C</code> <code class="f">F</code> <code class="c">C</code><br>
+<code class="c">C</code> <code class="g">G</code><br>
+<code class="g">G7</code> <code class="c">C</code><br>
 <code class="g">G</code> <code class="c">C</code></p>
-</section>
-<section id="verse-1-18" class="slide level2">
+</div></section>
+<section id="verse-1-18" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>There’s a <code class="c">C</code> dark and a <code
-class="f">F</code> troubled side of <code class="c">C</code> life<br />
-There’s a <code class="c">C</code> bright, there’s a sunny side <code
-class="g">G</code> too<br />
-Tho’ we <code class="g">G7</code> meet with the darkness and <code
-class="c">C</code> strife<br />
-The <code class="g">G</code> sunny side we also may <code
-class="c">C</code> view</p>
-</section>
-<section id="chorus-25" class="slide level2">
+<p>There’s a <code class="c">C</code> dark and a <code class="f">F</code> troubled side of <code class="c">C</code> life<br>
+There’s a <code class="c">C</code> bright, there’s a sunny side <code class="g">G</code> too<br>
+Tho’ we <code class="g">G7</code> meet with the darkness and <code class="c">C</code> strife<br>
+The <code class="g">G</code> sunny side we also may <code class="c">C</code> view</p>
+</div></section>
+<section id="chorus-25" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Keep on the sunny side <code
-class="f">F</code><br />
-always on the <code class="c">C</code> sunny side<br />
-Keep on the sunny side of <code class="g">G</code> life<br />
-<code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+<p><code class="c">C</code> Keep on the sunny side <code class="f">F</code><br>
+always on the <code class="c">C</code> sunny side<br>
+Keep on the sunny side of <code class="g">G</code> life<br>
+<code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
-</section>
-<section id="verse-2-18" class="slide level2">
+</div></section>
+<section id="verse-2-18" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Well the <code class="c">C</code> storm and its <code
-class="f">F</code> fury broke to<code class="c">C</code>day<br />
-Crushing <code class="c">C</code> hopes that we cherish so <code
-class="g">G</code> dear<br />
-Clouds and <code class="g">G7</code> storms will, in time, pass a<code
-class="c">C</code>way<br />
-The <code class="g">G7</code> sun again will shine bright and <code
-class="c">C</code> clear</p>
-</section>
-<section id="chorus-26" class="slide level2">
+<p>Well the <code class="c">C</code> storm and its <code class="f">F</code> fury broke to<code class="c">C</code>day<br>
+Crushing <code class="c">C</code> hopes that we cherish so <code class="g">G</code> dear<br>
+Clouds and <code class="g">G7</code> storms will, in time, pass a<code class="c">C</code>way<br>
+The <code class="g">G7</code> sun again will shine bright and <code class="c">C</code> clear</p>
+</div></section>
+<section id="chorus-26" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Keep on the sunny side<br />
+<p><code class="c">C</code> Keep on the sunny side<br>
 <code class="f">F</code> always on the <code class="c">C</code> sunny
-side<br />
-Keep on the sunny side of <code class="g">G</code> life<br />
-<code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+side<br>
+Keep on the sunny side of <code class="g">G</code> life<br>
+<code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
-</section>
-<section id="interlude-2" class="slide level2">
+</div></section>
+<section id="interlude-2" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code><br />
-<code class="c">C</code> <code class="g">G</code><br />
-<code class="g">G7</code> <code class="c">C</code><br />
+<p><code class="c">C</code> <code class="f">F</code> <code class="c">C</code><br>
+<code class="c">C</code> <code class="g">G</code><br>
+<code class="g">G7</code> <code class="c">C</code><br>
 <code class="g">G</code> <code class="c">C</code></p>
-</section>
-<section id="verse-3-12" class="slide level2">
+</div></section>
+<section id="verse-3-12" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p>Let us <code class="c">C</code> greet with a <code class="f">F</code>
-song of hope each <code class="c">C</code> day<br />
-Thou the <code class="c">C</code> moment be cloudy or <code
-class="g">G</code> fair<br />
-Let us <code class="g">G7</code> trust in our Saviour al<code
-class="c">C</code>ways<br />
-Who <code class="g">G7</code> keepeth everyone in His <code
-class="c">C</code> care</p>
-</section>
-<section id="chorus-27" class="slide level2">
+song of hope each <code class="c">C</code> day<br>
+Thou the <code class="c">C</code> moment be cloudy or <code class="g">G</code> fair<br>
+Let us <code class="g">G7</code> trust in our Saviour al<code class="c">C</code>ways<br>
+Who <code class="g">G7</code> keepeth everyone in His <code class="c">C</code> care</p>
+</div></section>
+<section id="chorus-27" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Keep on the sunny side<br />
+<p><code class="c">C</code> Keep on the sunny side<br>
 <code class="f">F</code> always on the <code class="c">C</code> sunny
-side<br />
-Keep on the sunny side of <code class="g">G</code> life<br />
-<code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+side<br>
+Keep on the sunny side of <code class="g">G</code> life<br>
+<code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
 <p><em>(Repeat)</em></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><em>(Fade out</em></p>
-<p><code class="c">C</code> It will help us every day<br />
-It will <code class="f">F</code> brighten all the <code
-class="c">C</code> way<br />
+<p><code class="c">C</code> It will help us every day<br>
+It will <code class="f">F</code> brighten all the <code class="c">C</code> way<br>
 If we’ll <code class="c">C</code> keep on the <code class="g">G</code>
 sunny side of <code class="c">C</code> life</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="lemon-tree-fools-garden" class="title-slide slide level1">
+<section id="lemon-tree-fools-garden" class="title-slide slide level1"><div class="slide-content">
 <h1>Lemon tree (Fool’s Garden)</h1>
 
-</section>
-<section id="instructions-4" class="slide level2">
+</div></section>
+<section id="instructions-4" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <p>Capo on 2nd fret</p>
 <pre><code>    |E A D G B e|
     |-----------|
 Bb  |x 1 3 3 3 1|</code></pre>
-</section>
-<section id="intro-14" class="slide level2">
+</div></section>
+<section id="intro-14" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Barre chords)</em></p>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code><br />
-<code class="g">Gm</code> <code class="a">Am</code> <code
-class="d">Dm</code></p>
-</section>
-<section id="verse-1-19" class="slide level2">
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code><br>
+<code class="g">Gm</code> <code class="a">Am</code> <code class="d">Dm</code></p>
+</div></section>
+<section id="verse-1-19" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> sitting here in a <code
-class="a">Am</code> boring room<br />
-It’s <code class="d">Dm</code> just another rainy sunday <code
-class="a">Am</code> afternoon<br />
-I’m <code class="d">Dm</code> wasting my time I got <code
-class="a">Am</code> nothing to do<br />
-I’m <code class="g">Gm</code> hanging around I’m <code
-class="a">Am</code> waiting for you</p>
-<p>But <code class="g">Gm</code> nothing ever happens <code
-class="a">Am</code><br />
+<p>I’m <code class="d">Dm</code> sitting here in a <code class="a">Am</code> boring room<br>
+It’s <code class="d">Dm</code> just another rainy sunday <code class="a">Am</code> afternoon<br>
+I’m <code class="d">Dm</code> wasting my time I got <code class="a">Am</code> nothing to do<br>
+I’m <code class="g">Gm</code> hanging around I’m <code class="a">Am</code> waiting for you</p>
+<p>But <code class="g">Gm</code> nothing ever happens <code class="a">Am</code><br>
 and I won<code class="d">Dm</code>der</p>
-</section>
-<section id="verse-2-19" class="slide level2">
+</div></section>
+<section id="verse-2-19" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> driving around <code
-class="a">Am</code> in my car<br />
-I’m <code class="d">Dm</code> driving too fast I’m <code
-class="a">Am</code> driving too far<br />
-I’d <code class="d">Dm</code> like to change my <code
-class="a">Am</code> point of view<br />
+<p>I’m <code class="d">Dm</code> driving around <code class="a">Am</code> in my car<br>
+I’m <code class="d">Dm</code> driving too fast I’m <code class="a">Am</code> driving too far<br>
+I’d <code class="d">Dm</code> like to change my <code class="a">Am</code> point of view<br>
 I <code class="g">Gm</code> feel so lonely I’m <code class="a">Am</code>
 waiting for you</p>
-<p>But <code class="g">Gm</code> nothing ever happens <code
-class="a">Am</code><br />
+<p>But <code class="g">Gm</code> nothing ever happens <code class="a">Am</code><br>
 and I won<code class="d">Dm</code>der</p>
-</section>
-<section id="chorus-28" class="slide level2">
+</div></section>
+<section id="chorus-28" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><em>(Open chords)</em></p>
 <p>I <code class="f">F</code> wonder how I <code class="c">C</code>
-wonder why<br />
-<code class="d">Dm</code> Yesterday you told me<br />
+wonder why<br>
+<code class="d">Dm</code> Yesterday you told me<br>
 ’bout the <code class="a">Am</code> blue blue sky</p>
-<p>And all <code class="b">Bb</code> that I can see <code
-class="c">C</code><br />
-Is just a yellow <code class="f">F</code> lemon tree <code
-class="c">C</code></p>
-</section>
-<section class="slide level2">
+<p>And all <code class="b">Bb</code> that I can see <code class="c">C</code><br>
+Is just a yellow <code class="f">F</code> lemon tree <code class="c">C</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>I’m <code class="f">F</code> turning my head <code class="c">C</code>
-up and down<br />
-I’m <code class="d">Dm</code> turning turning turning<br />
+up and down<br>
+I’m <code class="d">Dm</code> turning turning turning<br>
 turning <code class="a">Am</code> turning around</p>
-<p>And <code class="b">Bb</code> all that I can <code
-class="g">G7</code><br />
+<p>And <code class="b">Bb</code> all that I can <code class="g">G7</code><br>
 see is just a yellow <code class="c">C</code> lemon tree</p>
-</section>
-<section id="bridge-1-1" class="slide level2">
+</div></section>
+<section id="bridge-1-1" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
 <p><em>(Barre chords)</em></p>
-<p><code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code><br />
-<code class="g">Gm</code> <code class="a">Am</code> <code
-class="d">Dm</code><br />
+<p><code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code><br>
+<code class="g">Gm</code> <code class="a">Am</code> <code class="d">Dm</code><br>
 Da da da…</p>
-</section>
-<section id="verse-3-13" class="slide level2">
+</div></section>
+<section id="verse-3-13" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> sitting here I <code
-class="a">Am</code> miss the power<br />
+<p>I’m <code class="d">Dm</code> sitting here I <code class="a">Am</code> miss the power<br>
 I’d <code class="d">Dm</code> like to go out <code class="a">Am</code>
-taking a shower<br />
-But <code class="d">Dm</code> there’s a heavy cloud in<code
-class="a">Am</code>side my head<br />
-I <code class="g">Gm</code> feel so tired put my<code
-class="a">Am</code>self into bed</p>
-<p>Where <code class="g">Gm</code> nothing ever happens <code
-class="a">Am</code><br />
+taking a shower<br>
+But <code class="d">Dm</code> there’s a heavy cloud in<code class="a">Am</code>side my head<br>
+I <code class="g">Gm</code> feel so tired put my<code class="a">Am</code>self into bed</p>
+<p>Where <code class="g">Gm</code> nothing ever happens <code class="a">Am</code><br>
 and I won<code class="d">Dm</code>der</p>
-</section>
-<section id="bridge-2-1" class="slide level2">
+</div></section>
+<section id="bridge-2-1" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
 <p><em>(Open chords)</em></p>
 <p><code class="a">A7</code> Isolation <code class="d">Dm</code> is not
-good for me<br />
+good for me<br>
 <code class="c">C7</code> Isolation - <code class="f">F</code> I don’t
-want to<br />
+want to<br>
 <code class="a">A7</code> sit on a lemon tree</p>
-</section>
-<section id="verse-4-8" class="slide level2">
+</div></section>
+<section id="verse-4-8" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
 <p><em>(Barre chords)</em></p>
-<p>I’m <code class="d">Dm</code> steppin’ around in a <code
-class="a">Am</code> desert of joy<br />
-<code class="d">Dm</code> Baby anyhow I’ll get an<code
-class="a">Am</code>other toy</p>
-<p>And <code class="g">Gm</code> everything will happen<br />
+<p>I’m <code class="d">Dm</code> steppin’ around in a <code class="a">Am</code> desert of joy<br>
+<code class="d">Dm</code> Baby anyhow I’ll get an<code class="a">Am</code>other toy</p>
+<p>And <code class="g">Gm</code> everything will happen<br>
 <code class="a">Am</code> and you’ll won<code class="d">Dm</code>der</p>
-</section>
-<section id="chorus-29" class="slide level2">
+</div></section>
+<section id="chorus-29" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><em>(Open chords)</em></p>
 <p>I <code class="f">F</code> wonder how I <code class="c">C</code>
-wonder why<br />
-<code class="d">Dm</code> Yesterday you told me<br />
+wonder why<br>
+<code class="d">Dm</code> Yesterday you told me<br>
 ’bout the <code class="a">Am</code> blue blue sky</p>
-<p>And all <code class="b">Bb</code> that I can see <code
-class="c">C</code><br />
-Is just a yellow <code class="f">F</code> lemon tree <code
-class="c">C</code></p>
-</section>
-<section class="slide level2">
+<p>And all <code class="b">Bb</code> that I can see <code class="c">C</code><br>
+Is just a yellow <code class="f">F</code> lemon tree <code class="c">C</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>I’m <code class="f">F</code> turning my head <code class="c">C</code>
-up and down<br />
-I’m <code class="d">Dm</code> turning turning turning<br />
+up and down<br>
+I’m <code class="d">Dm</code> turning turning turning<br>
 turning <code class="a">Am</code> turning around</p>
-<p>And <code class="b">Bb</code> all that I can <code
-class="g">G7</code><br />
+<p>And <code class="b">Bb</code> all that I can <code class="g">G7</code><br>
 see is just a yellow <code class="c">C</code> lemon tree</p>
 <p>And I wonder I wonder</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p>I <code class="f">F</code> wonder how I <code class="c">C</code>
-wonder why<br />
-<code class="d">Dm</code> Yesterday you told me<br />
+wonder why<br>
+<code class="d">Dm</code> Yesterday you told me<br>
 ’bout the <code class="a">Am</code> blue blue sky</p>
-<p>And all <code class="b">Bb</code> that I can see <code
-class="c">C</code> <em>(3x)</em><br />
+<p>And all <code class="b">Bb</code> that I can see <code class="c">C</code> <em>(3x)</em><br>
 Is just a yellow <code class="f">F</code> lemon tree</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="morning-has-broken-cat-stevens"
-class="title-slide slide level1">
+<section id="morning-has-broken-cat-stevens" class="title-slide slide level1"><div class="slide-content">
 <h1>Morning has broken (Cat Stevens)</h1>
 
-</section>
-<section id="instructions-5" class="slide level2">
+</div></section>
+<section id="instructions-5" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>       |E A D G B e|
        |-----------|
@@ -2432,560 +2065,481 @@ D7sus4 |x x 0 2 1 3|
 F#     |2=4=4=3=2=2|
 F#m    |2=4=4=2=2=2|
 G7sus4 |x x 0 0 1 1|</code></pre>
-</section>
-<section id="intro-15" class="slide level2">
+</div></section>
+<section id="intro-15" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="d">D</code> <code class="g">G</code> <code
-class="a">A</code> <code class="f">F#</code> <code
-class="b">Bm</code><br />
-<code class="g">G7</code> <code class="c">C</code> <code
-class="f">F</code> <code class="c">C</code></p>
-</section>
-<section id="verse-1-20" class="slide level2">
+<p><code class="d">D</code> <code class="g">G</code> <code class="a">A</code> <code class="f">F#</code> <code class="b">Bm</code><br>
+<code class="g">G7</code> <code class="c">C</code> <code class="f">F</code> <code class="c">C</code></p>
+</div></section>
+<section id="verse-1-20" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Morning has <code class="c">C</code>brok<code
-class="d">Dm</code>en<br />
+<p>Morning has <code class="c">C</code>brok<code class="d">Dm</code>en<br>
 <code class="g">G</code> like the first <code class="f">F</code>
-morn<code class="c">C</code>ing<br />
+morn<code class="c">C</code>ing<br>
 <code class="c">C</code> Blackbird has <code class="e">Em</code>
-spok<code class="a">Am</code>en<br />
+spok<code class="a">Am</code>en<br>
 <code class="d">D7sus4</code> like the first <code class="g">G</code>
 bird</p>
 <p><code class="c">C</code> Praise for the <code class="f">F</code>
-singing<br />
+singing<br>
 <code class="c">C</code> praise for the <code class="a">Am</code>
-morn<code class="d">D</code>ing<br />
+morn<code class="d">D</code>ing<br>
 <code class="g">G</code> Praise for them <code class="c">C</code>
-spring<code class="f">F</code>ing<br />
+spring<code class="f">F</code>ing<br>
 <code class="g">G7</code> fresh from the <code class="c">C</code>
 world</p>
-</section>
-<section id="instrumental-1" class="slide level2">
+</div></section>
+<section id="instrumental-1" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="e">E</code> <code class="a">Am</code><br />
-<code class="g">G7</code> <code class="c">C</code> <code
-class="g">G7sus4</code></p>
-</section>
-<section id="verse-2-20" class="slide level2">
+<p><code class="f">F</code> <code class="g">G</code> <code class="e">E</code> <code class="a">Am</code><br>
+<code class="g">G7</code> <code class="c">C</code> <code class="g">G7sus4</code></p>
+</div></section>
+<section id="verse-2-20" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Sweet the rain’s <code class="c">C</code> new <code
-class="d">Dm</code> fall<br />
-<code class="g">G</code> sunlit from <code class="f">F</code> heav<code
-class="c">C</code>en<br />
+<p>Sweet the rain’s <code class="c">C</code> new <code class="d">Dm</code> fall<br>
+<code class="g">G</code> sunlit from <code class="f">F</code> heav<code class="c">C</code>en<br>
 <code class="c">C</code> Like the first <code class="e">Em</code> dew
-<code class="a">Am</code> fall<br />
+<code class="a">Am</code> fall<br>
 <code class="d">D7sus4</code> on the first <code class="g">G</code>
 grass</p>
 <p><code class="c">C</code> Praise for the <code class="f">F</code>
-sweetness<br />
-<code class="c">C</code> of the wet <code class="a">Am</code> gard<code
-class="d">D</code>en<br />
-<code class="g">G</code> Sprung in comp<code class="c">C</code>lete<code
-class="f">F</code>ness<br />
+sweetness<br>
+<code class="c">C</code> of the wet <code class="a">Am</code> gard<code class="d">D</code>en<br>
+<code class="g">G</code> Sprung in comp<code class="c">C</code>lete<code class="f">F</code>ness<br>
 <code class="g">G7</code> where his feet <code class="c">C</code>
 pass</p>
-</section>
-<section id="instrumental-2" class="slide level2">
+</div></section>
+<section id="instrumental-2" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="e">E</code> <code class="a">Am</code><br />
-<code class="f">F#</code> <code class="b">Bm</code> <code
-class="g">G</code> <code class="d">D</code><br />
+<p><code class="f">F</code> <code class="g">G</code> <code class="e">E</code> <code class="a">Am</code><br>
+<code class="f">F#</code> <code class="b">Bm</code> <code class="g">G</code> <code class="d">D</code><br>
 <code class="a">A7/D</code> <code class="d">D</code></p>
-</section>
-<section id="verse-3-14" class="slide level2">
+</div></section>
+<section id="verse-3-14" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Mine is the <code class="d">D</code> sun<code
-class="e">Em</code>light<br />
-<code class="a">A</code> mine is the <code class="g">G</code> morn<code
-class="d">D</code>ing<br />
+<p>Mine is the <code class="d">D</code> sun<code class="e">Em</code>light<br>
+<code class="a">A</code> mine is the <code class="g">G</code> morn<code class="d">D</code>ing<br>
 Born of the <code class="f">F#m</code> one <code class="b">Bm</code>
-light<br />
-<code class="e">E7</code> Eden saw <code class="a">A</code> play <code
-class="a">A7</code></p>
-<p><code class="d">D</code> Praise with el<code
-class="g">G</code>ation<br />
+light<br>
+<code class="e">E7</code> Eden saw <code class="a">A</code> play <code class="a">A7</code></p>
+<p><code class="d">D</code> Praise with el<code class="g">G</code>ation<br>
 <code class="d">D</code> praise every <code class="b">Bm</code>
-morn<code class="e">E</code>ing<br />
-<code class="a">A</code> God’s recre<code class="d">D</code>a<code
-class="g">G</code>tion<br />
+morn<code class="e">E</code>ing<br>
+<code class="a">A</code> God’s recre<code class="d">D</code>a<code class="g">G</code>tion<br>
 <code class="a">A7</code> of the new <code class="d">D</code> day</p>
-</section>
-<section id="instrumental-3" class="slide level2">
+</div></section>
+<section id="instrumental-3" class="slide level2"><div class="slide-content">
 <h2>Instrumental</h2>
-<p><code class="g">G</code> <code class="a">A</code> <code
-class="f">F#</code> <code class="b">Bm</code><br />
-<code class="g">G7</code> <code class="c">C</code> <code
-class="f">F</code> <code class="c">C</code></p>
-</section>
-<section id="verse-1-21" class="slide level2">
+<p><code class="g">G</code> <code class="a">A</code> <code class="f">F#</code> <code class="b">Bm</code><br>
+<code class="g">G7</code> <code class="c">C</code> <code class="f">F</code> <code class="c">C</code></p>
+</div></section>
+<section id="verse-1-21" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Morning has <code class="c">C</code>brok<code
-class="d">Dm</code>en<br />
+<p>Morning has <code class="c">C</code>brok<code class="d">Dm</code>en<br>
 <code class="g">G</code> like the first <code class="f">F</code>
-morn<code class="c">C</code>ing<br />
+morn<code class="c">C</code>ing<br>
 <code class="c">C</code> Blackbird has <code class="e">Em</code>
-spok<code class="a">Am</code>en<br />
+spok<code class="a">Am</code>en<br>
 <code class="d">D7sus4</code> like the first <code class="g">G</code>
 bird</p>
 <p><code class="c">C</code> Praise for the <code class="f">F</code>
-singing<br />
+singing<br>
 <code class="c">C</code> praise for the <code class="a">Am</code>
-morn<code class="d">D</code>ing<br />
+morn<code class="d">D</code>ing<br>
 <code class="g">G</code> Praise for them <code class="c">C</code>
-spring<code class="f">F</code>ing<br />
+spring<code class="f">F</code>ing<br>
 <code class="g">G7</code> fresh from the <code class="c">C</code>
 world</p>
-</section>
-<section id="outro-3" class="slide level2">
+</div></section>
+<section id="outro-3" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="f">F</code> <code class="g">G</code> <code
-class="e">E</code> <code class="a">Am</code><br />
-<code class="f">F#</code> <code class="b">Bm</code> <code
-class="g">G</code> <code class="d">D</code><br />
+<p><code class="f">F</code> <code class="g">G</code> <code class="e">E</code> <code class="a">Am</code><br>
+<code class="f">F#</code> <code class="b">Bm</code> <code class="g">G</code> <code class="d">D</code><br>
 <code class="a">A7/D</code> <code class="d">D</code></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="männer-sind-schweine-die-ärzte"
-class="title-slide slide level1">
+<section id="männer-sind-schweine-die-ärzte" class="title-slide slide level1"><div class="slide-content">
 <h1>Männer sind Schweine (Die Ärzte)</h1>
 
-</section>
-<section id="verse-1-22" class="slide level2">
+</div></section>
+<section id="verse-1-22" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Hal<code class="g">G</code>lo, mein Schatz, ich liebe Dich,<br />
-Du <code class="e">Em</code> bist die einzige für mich.<br />
-Die <code class="c">C</code> andern find’ ich alle doof,<br />
+<p>Hal<code class="g">G</code>lo, mein Schatz, ich liebe Dich,<br>
+Du <code class="e">Em</code> bist die einzige für mich.<br>
+Die <code class="c">C</code> andern find’ ich alle doof,<br>
 Des<code class="d">D</code>wegen mach ich Dir den Hof.</p>
-<p>Du <code class="g">G</code> bist so anders, ganz speziell,<br />
-Ich <code class="e">Em</code> merke sowas immer schnell.<br />
-Jetzt <code class="c">C</code> zieh Dich aus und leg Dich hin,<br />
+<p>Du <code class="g">G</code> bist so anders, ganz speziell,<br>
+Ich <code class="e">Em</code> merke sowas immer schnell.<br>
+Jetzt <code class="c">C</code> zieh Dich aus und leg Dich hin,<br>
 Weil <code class="d">D</code> ich so verliebt in Dich bin.</p>
-</section>
-<section id="bridge-1-2" class="slide level2">
+</div></section>
+<section id="bridge-1-2" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
-<p><code class="c">C</code> Gleich wird es dunkel, <code
-class="b">Bm</code> bald ist es Nacht,<br />
-Da <code class="c">C</code> ist ein Wort der Warnung angebracht! <code
-class="d">D</code></p>
-</section>
-<section id="chorus-1-6" class="slide level2">
+<p><code class="c">C</code> Gleich wird es dunkel, <code class="b">Bm</code> bald ist es Nacht,<br>
+Da <code class="c">C</code> ist ein Wort der Warnung angebracht! <code class="d">D</code></p>
+</div></section>
+<section id="chorus-1-6" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br />
-Sie wollen <code class="a">Am</code> alle das eine!<br />
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br>
+Sie wollen <code class="a">Am</code> alle das eine!<br>
 Weil <code class="c">C</code> Männer nun mal so <code class="d">D</code>
 sind.</p>
-</section>
-<section id="verse-2-21" class="slide level2">
+</div></section>
+<section id="verse-2-21" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>Ein <code class="g">G</code> Mann fühlt sich erst dann als
-Mann,<br />
-Wenn <code class="e">Em</code> er es Dir besorgen kann.<br />
-Er <code class="c">C</code> lügt, dass sich die Balken biegen.<br />
+Mann,<br>
+Wenn <code class="e">Em</code> er es Dir besorgen kann.<br>
+Er <code class="c">C</code> lügt, dass sich die Balken biegen.<br>
 <code class="d">D</code> Nur, um Dich ins Bett zu kriegen.</p>
-<p>Und <code class="g">G</code> dann am nächsten Morgen weiss er<br />
-<code class="e">Em</code> Nicht einmal mehr, wie Du heisst.<br />
-<code class="c">C</code> Rücksichtslos und ungehemmt,<br />
+<p>Und <code class="g">G</code> dann am nächsten Morgen weiss er<br>
+<code class="e">Em</code> Nicht einmal mehr, wie Du heisst.<br>
+<code class="c">C</code> Rücksichtslos und ungehemmt,<br>
 Ge<code class="d">D</code>fühle sind ihm völlig fremd.</p>
-</section>
-<section id="bridge-2-2" class="slide level2">
+</div></section>
+<section id="bridge-2-2" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
-<p><code class="c">C</code> Für ihn ist Liebe gleich <code
-class="b">Bm</code> Samenverlust,<br />
-<code class="c">C</code> Mädchen, sei Dir dessen stets bewusst! <code
-class="d">D</code></p>
-</section>
-<section id="chorus-2-6" class="slide level2">
+<p><code class="c">C</code> Für ihn ist Liebe gleich <code class="b">Bm</code> Samenverlust,<br>
+<code class="c">C</code> Mädchen, sei Dir dessen stets bewusst! <code class="d">D</code></p>
+</div></section>
+<section id="chorus-2-6" class="slide level2"><div class="slide-content">
 <h2>Chorus 2</h2>
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Frage nicht nach <code class="e">Em</code> Sonnenschein.<br />
-Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br />
-In jedem <code class="c">C</code> Mann steckt auch<br />
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Frage nicht nach <code class="e">Em</code> Sonnenschein.<br>
+Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br>
+In jedem <code class="c">C</code> Mann steckt auch<br>
 immer ein <code class="d">D</code> Schwein!</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Säue!<br />
-Glaube ihnen <code class="e">Em</code> nicht ein Wort!<br />
-Sie schwör’n Dir <code class="a">Am</code> ewige Treue<br />
-Und dann am <code class="c">C</code> nächsten Morgen<br />
+<p>Männer sind <code class="g">G</code> Säue!<br>
+Glaube ihnen <code class="e">Em</code> nicht ein Wort!<br>
+Sie schwör’n Dir <code class="a">Am</code> ewige Treue<br>
+Und dann am <code class="c">C</code> nächsten Morgen<br>
 sind sie fort. <code class="d">D</code></p>
-</section>
-<section id="verse-3-15" class="slide level2">
+</div></section>
+<section id="verse-3-15" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Und <code class="g">G</code> falls Du doch den Fehler machst<br />
-Und <code class="e">Em</code> Dir ’nen Ehemann anlachst.<br />
-Mu<code class="c">C</code>tiert dein Rosenkavalier<br />
+<p>Und <code class="g">G</code> falls Du doch den Fehler machst<br>
+Und <code class="e">Em</code> Dir ’nen Ehemann anlachst.<br>
+Mu<code class="c">C</code>tiert dein Rosenkavalier<br>
 Bald <code class="d">D</code> nach der Hochzeit auch zum Tier.</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Da <code class="g">G</code> zeigt er dann sein wahres Ich,<br />
-Ganz <code class="e">Em</code> unrasiert und widerlich.<br />
+<p>Da <code class="g">G</code> zeigt er dann sein wahres Ich,<br>
+Ganz <code class="e">Em</code> unrasiert und widerlich.<br>
 Trinkt <code class="c">C</code> Bier, sieht fern und wird schnell
-fett.<br />
+fett.<br>
 Und <code class="d">D</code> rülpst und furzt im Ehebett.</p>
-</section>
-<section id="bridge-3-1" class="slide level2">
+</div></section>
+<section id="bridge-3-1" class="slide level2"><div class="slide-content">
 <h2>Bridge 3</h2>
-<p><code class="c">C</code> Dann hast du King Kong <code
-class="b">Bm</code> zum Ehemann!<br />
+<p><code class="c">C</code> Dann hast du King Kong <code class="b">Bm</code> zum Ehemann!<br>
 Drum <code class="c">C</code> sag’ ich Dir - denk bitte stets daran:
 <code class="d">D</code></p>
-</section>
-<section id="chorus-4-1" class="slide level2">
+</div></section>
+<section id="chorus-4-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 4</h2>
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br />
-Sie wollen <code class="a">Am</code> alle das eine!<br />
-Für wahre <code class="c">C</code> Liebe sind sie blind <code
-class="d">D</code>.</p>
-</section>
-<section class="slide level2">
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Traue ihnen <code class="e">Em</code> nicht, mein Kind!<br>
+Sie wollen <code class="a">Am</code> alle das eine!<br>
+Für wahre <code class="c">C</code> Liebe sind sie blind <code class="d">D</code>.</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Ratten<br />
-Begegne ihnen <code class="e">Em</code> nur mit List<br />
-Sie wollen <code class="a">Am</code> alles begatten<br />
-Was nicht bei <code class="c">C</code> drei auf den Bäumen ist <code
-class="d">D</code></p>
-</section>
-<section class="slide level2">
+<p>Männer sind <code class="g">G</code> Ratten<br>
+Begegne ihnen <code class="e">Em</code> nur mit List<br>
+Sie wollen <code class="a">Am</code> alles begatten<br>
+Was nicht bei <code class="c">C</code> drei auf den Bäumen ist <code class="d">D</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Schweine!<br />
-Frage nicht nach <code class="e">Em</code> Sonnenschein.<br />
-Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br />
-In jedem <code class="c">C</code> Mann steckt auch immer ein <code
-class="d">D</code> Schwein!</p>
-</section>
-<section class="slide level2">
+<p>Männer sind <code class="g">G</code> Schweine!<br>
+Frage nicht nach <code class="e">Em</code> Sonnenschein.<br>
+Ausnahmen <code class="a">Am</code> gibt’s leider keine!<br>
+In jedem <code class="c">C</code> Mann steckt auch immer ein <code class="d">D</code> Schwein!</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Männer sind <code class="g">G</code> Autos<br />
-Nur ohne Re<code class="e">Em</code>serverad<br />
-Yeah, yeah, yeah, yeaääääää <code class="a">Am</code><br />
+<p>Männer sind <code class="g">G</code> Autos<br>
+Nur ohne Re<code class="e">Em</code>serverad<br>
+Yeah, yeah, yeah, yeaääääää <code class="a">Am</code><br>
 <code class="c">C</code> Uh-hu, uh-hu <code class="d">D</code></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="no-woman-no-cry-bob-marley"
-class="title-slide slide level1">
+<section id="no-woman-no-cry-bob-marley" class="title-slide slide level1"><div class="slide-content">
 <h1>No woman no cry (Bob Marley)</h1>
 
-</section>
-<section id="intro-16" class="slide level2">
+</div></section>
+<section id="intro-16" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="g">G/B</code> <code
-class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="chorus-30" class="slide level2">
+<p><code class="c">C</code> <code class="g">G/B</code> <code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> <code class="f">F</code> <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="chorus-30" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> No <code class="g">G/B</code> woman no cry
-<code class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
+<code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="verse-1-23" class="slide level2">
+</div></section>
+<section id="verse-1-23" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Said said<br />
-<code class="c">C</code> said I re<code class="g">G/B</code>member<br />
-<code class="a">Am</code> when we used to sit <code
-class="f">F</code><br />
+<p>Said said<br>
+<code class="c">C</code> said I re<code class="g">G/B</code>member<br>
+<code class="a">Am</code> when we used to sit <code class="f">F</code><br>
 <code class="c">C</code> In the govern<code class="g">G/B</code>ment
-yard<br />
+yard<br>
 in <code class="a">Am</code> trenchtown <code class="f">F</code></p>
 <p><code class="c">C</code> Oba-oba<code class="g">G/B</code>serving the
-<code class="a">Am</code> hypo<code class="f">F</code>crites<br />
-As they would <code class="c">C</code> mingle<br />
-with the good <code class="g">G/B</code> people we meet <code
-class="a">Am</code> <code class="f">F</code></p>
-</section>
-<section class="slide level2">
+<code class="a">Am</code> hypo<code class="f">F</code>crites<br>
+As they would <code class="c">C</code> mingle<br>
+with the good <code class="g">G/B</code> people we meet <code class="a">Am</code> <code class="f">F</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="c">C</code> good friends <code class="g">G/B</code> we
-had oh<br />
-<code class="a">Am</code> good friend we lost <code
-class="f">F</code><br />
-<code class="c">C</code> along <code class="g">G/B</code> the way <code
-class="a">Am</code> <code class="f">F</code></p>
+had oh<br>
+<code class="a">Am</code> good friend we lost <code class="f">F</code><br>
+<code class="c">C</code> along <code class="g">G/B</code> the way <code class="a">Am</code> <code class="f">F</code></p>
 <p><code class="c">C</code> In this bright <code class="g">G/B</code>
-future<br />
-you <code class="a">Am</code> cant forget your past <code
-class="f">F</code><br />
+future<br>
+you <code class="a">Am</code> cant forget your past <code class="f">F</code><br>
 <code class="c">C</code> So dry your tears <code class="g">G/B</code> I
 say <code class="a">Am</code> <code class="f">F</code></p>
-</section>
-<section id="chorus-31" class="slide level2">
+</div></section>
+<section id="chorus-31" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> No <code class="g">G/B</code> woman no cry
-<code class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-<p><del>No woman no cry</del><br />
+<code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+<p><del>No woman no cry</del><br>
 <strong><code class="c">C</code> Here <code class="g">G/B</code> little
-darlin’</strong><br />
+darlin’</strong><br>
 <strong><code class="a">Am</code> don’t shed no <code class="f">F</code>
-tears</strong><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="verse-1-24" class="slide level2">
+tears</strong><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-1-24" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>Said said<br />
-<code class="c">C</code> said I re<code class="g">G/B</code>member<br />
-<code class="a">Am</code> when we used to sit <code
-class="f">F</code><br />
+<p>Said said<br>
+<code class="c">C</code> said I re<code class="g">G/B</code>member<br>
+<code class="a">Am</code> when we used to sit <code class="f">F</code><br>
 <code class="c">C</code> In the govern<code class="g">G/B</code>ment
-yard<br />
+yard<br>
 in <code class="a">Am</code> trenchtown <code class="f">F</code></p>
 <p><code class="c">C</code> And then <code class="g">G/B</code>
-Georgie<br />
-would <code class="a">Am</code> make a fire light <code
-class="f">F</code><br />
+Georgie<br>
+would <code class="a">Am</code> make a fire light <code class="f">F</code><br>
 as it was <code class="c">C</code> log wood <code class="g">G/B</code>
-burnin<br />
-through the nights <code class="a">Am</code> <code
-class="f">F</code></p>
-</section>
-<section class="slide level2">
+burnin<br>
+through the nights <code class="a">Am</code> <code class="f">F</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
 <p><code class="c">C</code> Then we <code class="g">G/B</code> would
-cook<br />
-corn <code class="a">Am</code> meal porridge <code
-class="f">F</code><br />
+cook<br>
+corn <code class="a">Am</code> meal porridge <code class="f">F</code><br>
 <code class="c">C</code> of which I’ll <code class="g">G/B</code>
-share<br />
+share<br>
 with you <code class="a">Am</code> yeah <code class="f">F</code></p>
 <p><code class="c">C</code> My feet <code class="g">G/B</code> is my
-<code class="a">Am</code> only carriage <code class="f">F</code><br />
+<code class="a">Am</code> only carriage <code class="f">F</code><br>
 <code class="c">C</code> and so I’ve got <code class="g">G/B</code>
-to<br />
-push on through <code class="a">Am</code><br />
+to<br>
+push on through <code class="a">Am</code><br>
 But while I’m <code class="f">F</code> gone</p>
-</section>
-<section id="bridge-4" class="slide level2">
+</div></section>
+<section id="bridge-4" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p><code class="c">C</code> Everything’s gonna <code
-class="g">G/B</code> be alright<br />
+<p><code class="c">C</code> Everything’s gonna <code class="g">G/B</code> be alright<br>
 <code class="a">Am</code> Everything’s gonna <code class="f">F</code> be
 alright</p>
 <p><em>(x4)</em></p>
-</section>
-<section id="chorus-32" class="slide level2">
+</div></section>
+<section id="chorus-32" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> No <code class="g">G/B</code> woman no cry
-<code class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-<p><del>No woman no cry</del><br />
+<code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+<p><del>No woman no cry</del><br>
 <strong><code class="c">C</code> Here <code class="g">G/B</code> little
-darlin’</strong><br />
+darlin’</strong><br>
 <strong><code class="a">Am</code> don’t shed no <code class="f">F</code>
-tears</strong><br />
-<code class="c">C</code> No <code class="f">F</code> woman no cry <code
-class="c">C</code> <code class="g">G</code></p>
-</section>
-<section id="outro-4" class="slide level2">
+tears</strong><br>
+<code class="c">C</code> No <code class="f">F</code> woman no cry <code class="c">C</code> <code class="g">G</code></p>
+</div></section>
+<section id="outro-4" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="g">G/B</code> <code
-class="a">Am</code> <code class="f">F</code><br />
-<code class="c">C</code> <code class="f">F</code> <code
-class="c">C</code> <code class="g">G</code></p>
+<p><code class="c">C</code> <code class="g">G/B</code> <code class="a">Am</code> <code class="f">F</code><br>
+<code class="c">C</code> <code class="f">F</code> <code class="c">C</code> <code class="g">G</code></p>
 <p><em>(Repeat and fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="one-u2" class="title-slide slide level1">
+<section id="one-u2" class="title-slide slide level1"><div class="slide-content">
 <h1>One (U2)</h1>
 
-</section>
-<section id="intro-17" class="slide level2">
+</div></section>
+<section id="intro-17" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="d">Dsus2</code> <code
-class="f">FM7</code> <code class="g">G</code> <em>(x4)</em></p>
-</section>
-<section id="verse-1-25" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dsus2</code> <code class="f">FM7</code> <code class="g">G</code> <em>(x4)</em></p>
+</div></section>
+<section id="verse-1-25" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><code class="a">Am</code> Is it getting <code class="d">Dsus2</code>
-better?<br />
+better?<br>
 <code class="f">FM7</code> Or do you feel the <code class="g">G</code>
-same?<br />
+same?<br>
 <code class="a">Am</code> Will it make it <code class="d">Dsus2</code>
-easier on you?<br />
-Now <code class="f">FM7</code> you got someone to <code
-class="g">G</code> blame</p>
+easier on you?<br>
+Now <code class="f">FM7</code> you got someone to <code class="g">G</code> blame</p>
 <p>You say</p>
-</section>
-<section id="chorus-1-7" class="slide level2">
+</div></section>
+<section id="chorus-1-7" class="slide level2"><div class="slide-content">
 <h2>Chorus 1</h2>
 <p><code class="c">C</code> One love <code class="a">Am</code> One
-life<br />
+life<br>
 <code class="f">FM7</code> When it’s one need <code class="c">C</code>
-in the night<br />
+in the night<br>
 <code class="c">C</code>One love <code class="a">Am</code> We got to
-share it<br />
-<code class="f">FM7</code> It leaves you baby<br />
+share it<br>
+<code class="f">FM7</code> It leaves you baby<br>
 if you <code class="c">C</code> don’t care for it</p>
-<p><code class="a">Am</code> <code class="d">Dsus2</code> <code
-class="f">FM7</code> <code class="g">G</code></p>
-</section>
-<section id="verse-2-22" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dsus2</code> <code class="f">FM7</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-2-22" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> Did I disap<code
-class="d">Dsus2</code>point you?<br />
-<code class="f">FM7</code> Or leave a bad taste in your <code
-class="g">G</code> mouth?<br />
-<code class="a">Am</code> You act like you never <code
-class="d">Dsus2</code> had love<br />
-<code class="f">FM7</code> And you want me to go with<code
-class="g">G</code>out</p>
+<p><code class="a">Am</code> Did I disap<code class="d">Dsus2</code>point you?<br>
+<code class="f">FM7</code> Or leave a bad taste in your <code class="g">G</code> mouth?<br>
+<code class="a">Am</code> You act like you never <code class="d">Dsus2</code> had love<br>
+<code class="f">FM7</code> And you want me to go with<code class="g">G</code>out</p>
 <p>Well it’s</p>
-</section>
-<section id="bridge-1-3" class="slide level2">
+</div></section>
+<section id="bridge-1-3" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
 <p><code class="c">C</code> Too late <code class="a">Am</code>
-Tonight<br />
-<code class="f">FM7</code> To drag the past out in<code
-class="c">C</code>to the light<br />
+Tonight<br>
+<code class="f">FM7</code> To drag the past out in<code class="c">C</code>to the light<br>
 <code class="c">C</code> We’re one, but we’re <code class="a">Am</code>
-not the same<br />
-We got to <code class="f">FM7</code> carry each other<br />
+not the same<br>
+We got to <code class="f">FM7</code> carry each other<br>
 <code class="c">C</code> carry each other</p>
-<p><code class="a">Am</code> <code class="d">Dsus2</code> <code
-class="f">FM7</code> <code class="g">G</code></p>
-</section>
-<section id="verse-3-16" class="slide level2">
+<p><code class="a">Am</code> <code class="d">Dsus2</code> <code class="f">FM7</code> <code class="g">G</code></p>
+</div></section>
+<section id="verse-3-16" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> Have you come here for for<code
-class="d">Dsus2</code>giveness?<br />
-<code class="f">FM7</code> Have you come to raise <code
-class="g">G</code> the dead?<br />
-<code class="a">Am</code> Have you come here to play <code
-class="d">Dsus2</code> Jesus<br />
-<code class="f">FM7</code> To the lepers in your <code
-class="g">G</code> head?</p>
-</section>
-<section id="bridge-2-3" class="slide level2">
+<p><code class="a">Am</code> Have you come here for for<code class="d">Dsus2</code>giveness?<br>
+<code class="f">FM7</code> Have you come to raise <code class="g">G</code> the dead?<br>
+<code class="a">Am</code> Have you come here to play <code class="d">Dsus2</code> Jesus<br>
+<code class="f">FM7</code> To the lepers in your <code class="g">G</code> head?</p>
+</div></section>
+<section id="bridge-2-3" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
-<p><code class="c">C</code> Did I ask too much? <code
-class="a">Am</code> More than a lot?<br />
-<code class="f">FM7</code> You gave me nothing, now it’s <code
-class="c">C</code> all I got<br />
+<p><code class="c">C</code> Did I ask too much? <code class="a">Am</code> More than a lot?<br>
+<code class="f">FM7</code> You gave me nothing, now it’s <code class="c">C</code> all I got<br>
 <code class="c">C</code> We’re one, but we’re <code class="a">Am</code>
-not the same<br />
-Well we <code class="f">FM7</code> hurt each other<br />
+not the same<br>
+Well we <code class="f">FM7</code> hurt each other<br>
 then we <code class="c">C</code> do it again</p>
 <p>You say</p>
-</section>
-<section id="interlude-3" class="slide level2">
+</div></section>
+<section id="interlude-3" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><code class="c">C</code> Love is a temple <code class="a">Am</code>
-Love’s a higher law<br />
+Love’s a higher law<br>
 <code class="c">C</code> Love is a temple <code class="a">Am</code>
-Love’s the higher law<br />
-You <code class="c">C</code> ask me to enter<br />
+Love’s the higher law<br>
+You <code class="c">C</code> ask me to enter<br>
 but <code class="g">G</code> then you make me crawl</p>
-<p>And <code class="g">G</code> I can’t be holding on <code
-class="f">FM7</code><br />
-To what you got <code class="f">FM7</code><br />
+<p>And <code class="g">G</code> I can’t be holding on <code class="f">FM7</code><br>
+To what you got <code class="f">FM7</code><br>
 When all you got is hurt</p>
-</section>
-<section id="chorus-3-1" class="slide level2">
+</div></section>
+<section id="chorus-3-1" class="slide level2"><div class="slide-content">
 <h2>Chorus 3</h2>
 <p><code class="c">C</code> One love <code class="a">Am</code> One
-<del>life</del> <strong>blood</strong><br />
-<del>When it’s one need in the night</del><br />
-<strong><code class="f">FM7</code> One life, You got to <code
-class="c">C</code> do what you should</strong><br />
-<del>One love, we got to share it</del><br />
+<del>life</del> <strong>blood</strong><br>
+<del>When it’s one need in the night</del><br>
+<strong><code class="f">FM7</code> One life, You got to <code class="c">C</code> do what you should</strong><br>
+<del>One love, we got to share it</del><br>
 <strong><code class="c">C</code> One life <code class="a">Am</code> with
-each other</strong><br />
-<del>It leaves you baby</del><br />
-<code class="f">FM7</code> Sisters<br />
-<del>if you don’t care for it</del><br />
+each other</strong><br>
+<del>It leaves you baby</del><br>
+<code class="f">FM7</code> Sisters<br>
+<del>if you don’t care for it</del><br>
 <strong><code class="c">C</code> Brothers</strong></p>
-</section>
-<section id="outro-5" class="slide level2">
+</div></section>
+<section id="outro-5" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="c">C</code> One life, but we’re <code
-class="a">Am</code> not the same<br />
-We got to <code class="f">FM7</code> carry each other, car<code
-class="c">C</code>ry each other</p>
-<p>One <code class="c">C</code> <code class="a">Am</code> One <code
-class="f">FM7</code> <code class="c">C</code><br />
+<p><code class="c">C</code> One life, but we’re <code class="a">Am</code> not the same<br>
+We got to <code class="f">FM7</code> carry each other, car<code class="c">C</code>ry each other</p>
+<p>One <code class="c">C</code> <code class="a">Am</code> One <code class="f">FM7</code> <code class="c">C</code><br>
 <em>(Repeat several times and fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="rivers-of-babylon-boney-m."
-class="title-slide slide level1">
+<section id="rivers-of-babylon-boney-m." class="title-slide slide level1"><div class="slide-content">
 <h1>Rivers of Babylon (Boney M.)</h1>
 
-</section>
-<section id="intro-18" class="slide level2">
+</div></section>
+<section id="intro-18" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Vocals only)</em></p>
 <p>Mmmh <code class="g">G</code> mmmh <code class="g">G</code> mmmh
-<code class="d">D7</code> mmmh <code class="g">G</code><br />
-Uuuh <code class="g">G</code> uuuh <code class="g">G</code> uuuh <code
-class="d">D7</code> uuuh <code class="g">G</code></p>
-</section>
-<section id="chorus-33" class="slide level2">
+<code class="d">D7</code> mmmh <code class="g">G</code><br>
+Uuuh <code class="g">G</code> uuuh <code class="g">G</code> uuuh <code class="d">D7</code> uuuh <code class="g">G</code></p>
+</div></section>
+<section id="chorus-33" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>By the rivers of <code class="g">G</code> Babylon<br />
-there we sat down<br />
-Ye-eah we <code class="d">D7</code> wept<br />
+<p>By the rivers of <code class="g">G</code> Babylon<br>
+there we sat down<br>
+Ye-eah we <code class="d">D7</code> wept<br>
 when we remembered Zi<code class="g">G</code>on</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="verse-1-26" class="slide level2">
+</div></section>
+<section id="verse-1-26" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>(When the wicked)<br />
-<code class="g">G</code> Carried us away in cap<code
-class="g">G7</code>tivity<br />
-Re<code class="c">C</code>quired from us a song <code
-class="g">G</code><br />
-Now how shall we sing the lord’s song<br />
+<p>(When the wicked)<br>
+<code class="g">G</code> Carried us away in cap<code class="g">G7</code>tivity<br>
+Re<code class="c">C</code>quired from us a song <code class="g">G</code><br>
+Now how shall we sing the lord’s song<br>
 in a stra<code class="d">D7</code>nge <code class="g">G</code> land</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="interlude-4" class="slide level2">
+</div></section>
+<section id="interlude-4" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p>Mmmh <code class="g">G</code> mmmh <code class="g">G</code> mmmh
 <code class="d">D7</code> mmmh <code class="g">G</code></p>
-</section>
-<section id="bridge-5" class="slide level2">
+</div></section>
+<section id="bridge-5" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>Let the <code class="g">G</code> words of our <code
-class="d">D7</code> mouth<br />
-and the medi<code class="g">G</code>tations of our heart <code
-class="d">D7</code><br />
-Be acc<code class="g">G</code>eptable in thy sight <code
-class="d">D7</code>here to<code class="g">G</code>night</p>
+<p>Let the <code class="g">G</code> words of our <code class="d">D7</code> mouth<br>
+and the medi<code class="g">G</code>tations of our heart <code class="d">D7</code><br>
+Be acc<code class="g">G</code>eptable in thy sight <code class="d">D7</code>here to<code class="g">G</code>night</p>
 <p><em>(x2)</em></p>
-</section>
-<section id="chorus-34" class="slide level2">
+</div></section>
+<section id="chorus-34" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>By the rivers of <code class="g">G</code> Babylon<br />
-there we sat down<br />
-Ye-eah we <code class="d">D7</code> wept<br />
+<p>By the rivers of <code class="g">G</code> Babylon<br>
+there we sat down<br>
+Ye-eah we <code class="d">D7</code> wept<br>
 when we remembered Zi<code class="g">G</code>on</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="road-to-mandalay-robbie-williams"
-class="title-slide slide level1">
+<section id="road-to-mandalay-robbie-williams" class="title-slide slide level1"><div class="slide-content">
 <h1>Road to Mandalay (Robbie Williams)</h1>
 
-</section>
-<section id="instructions-6" class="slide level2">
+</div></section>
+<section id="instructions-6" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <p>Capo on 3rd fret</p>
 <pre><code>       |E A D G B e|
@@ -2998,381 +2552,317 @@ F/A    |x 0 3 2 1 1|
 G7     |3 2 0 0 3 1|
 
 X Stop playing</code></pre>
-</section>
-<section id="verse-1-27" class="slide level2">
+</div></section>
+<section id="verse-1-27" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="d">Dm</code> Save me from drowning in the sea <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> Beat me up on the beach<br />
-<code class="d">Dm</code>What a lovely holiday <code
-class="e">E7(1)</code><br />
-There’s nothing funny left to say <code class="a">Asus</code> <code
-class="a">Am</code></p>
-<p><code class="d">Dm</code> This sombre song would drain the sun <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> But it won’t shine until it’s sung<br />
-<code class="d">Dm</code> No water running in the stream <code
-class="e">E7(2)</code><br />
-The saddest place we’ve ever seen <code class="a">A7sus4</code> <code
-class="a">A7</code></p>
-</section>
-<section id="bridge-1-4" class="slide level2">
+<p><code class="d">Dm</code> Save me from drowning in the sea <code class="d">Dm6</code><br>
+<code class="a">Am</code> Beat me up on the beach<br>
+<code class="d">Dm</code>What a lovely holiday <code class="e">E7(1)</code><br>
+There’s nothing funny left to say <code class="a">Asus</code> <code class="a">Am</code></p>
+<p><code class="d">Dm</code> This sombre song would drain the sun <code class="d">Dm6</code><br>
+<code class="a">Am</code> But it won’t shine until it’s sung<br>
+<code class="d">Dm</code> No water running in the stream <code class="e">E7(2)</code><br>
+The saddest place we’ve ever seen <code class="a">A7sus4</code> <code class="a">A7</code></p>
+</div></section>
+<section id="bridge-1-4" class="slide level2"><div class="slide-content">
 <h2>Bridge 1</h2>
-<p><code class="f">F/A</code> Everything I touched was gol<code
-class="g">G7</code>den<br />
-Everything I loved got <code class="c">C</code> broken<br />
+<p><code class="f">F/A</code> Everything I touched was gol<code class="g">G7</code>den<br>
+Everything I loved got <code class="c">C</code> broken<br>
 On the road to Mandalay</p>
-<p><code class="f">F</code> Every mistake I’ve ever made <code
-class="e">Em</code><br />
-Has been rehashed and then re<code class="d">Dm</code>played<br />
+<p><code class="f">F</code> Every mistake I’ve ever made <code class="e">Em</code><br>
+Has been rehashed and then re<code class="d">Dm</code>played<br>
 As I got lost along the way <code class="g">G</code></p>
-</section>
-<section id="chorus-35" class="slide level2">
+</div></section>
+<section id="chorus-35" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="x">X</code> Bum bum bum <code class="d">Dm</code> ba da
-dum bum bum <code class="g">G</code><br />
-Bum bum bum <code class="c">C</code> ba da dum bum bum <code
-class="a">Am</code></p>
-<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code
-class="g">G</code><br />
+dum bum bum <code class="g">G</code><br>
+Bum bum bum <code class="c">C</code> ba da dum bum bum <code class="a">Am</code></p>
+<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code class="g">G</code><br>
 Bum ba dum <code class="a">Am</code></p>
-</section>
-<section id="verse-2-23" class="slide level2">
+</div></section>
+<section id="verse-2-23" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="d">Dm</code> There’s nothing left for you to give <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> The truth is all that you’re left with<br />
-<code class="d">Dm</code> Twenty paces then at dawn <code
-class="e">E7(1)</code><br />
-We will <code class="e">E7</code> die and be reborn <code
-class="a">Asus</code> <code class="a">Am</code></p>
-<p><code class="d">Dm</code> I like to sleep beneath the trees <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> Have the universe at one with me<br />
-<code class="d">Dm</code> Look down the barrel of a gun <code
-class="e">E7(2)</code><br />
-And feel the moon replace the sun <code class="a">A7sus4</code> <code
-class="a">A7</code></p>
-</section>
-<section id="bridge-2-4" class="slide level2">
+<p><code class="d">Dm</code> There’s nothing left for you to give <code class="d">Dm6</code><br>
+<code class="a">Am</code> The truth is all that you’re left with<br>
+<code class="d">Dm</code> Twenty paces then at dawn <code class="e">E7(1)</code><br>
+We will <code class="e">E7</code> die and be reborn <code class="a">Asus</code> <code class="a">Am</code></p>
+<p><code class="d">Dm</code> I like to sleep beneath the trees <code class="d">Dm6</code><br>
+<code class="a">Am</code> Have the universe at one with me<br>
+<code class="d">Dm</code> Look down the barrel of a gun <code class="e">E7(2)</code><br>
+And feel the moon replace the sun <code class="a">A7sus4</code> <code class="a">A7</code></p>
+</div></section>
+<section id="bridge-2-4" class="slide level2"><div class="slide-content">
 <h2>Bridge 2</h2>
-<p><code class="f">F/A</code> Everything we’ve ever sto<code
-class="g">G7</code>len<br />
-Has been lost returned or <code class="c">C</code> broken<br />
+<p><code class="f">F/A</code> Everything we’ve ever sto<code class="g">G7</code>len<br>
+Has been lost returned or <code class="c">C</code> broken<br>
 No more dragons left to slay</p>
-<p><code class="f">F</code> Every mistake I’ve ever made <code
-class="e">Em</code><br />
-Has been rehashed and then re<code class="d">Dm</code>played<br />
+<p><code class="f">F</code> Every mistake I’ve ever made <code class="e">Em</code><br>
+Has been rehashed and then re<code class="d">Dm</code>played<br>
 As I got lost along the way <code class="g">G</code></p>
-</section>
-<section id="chorus-36" class="slide level2">
+</div></section>
+<section id="chorus-36" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="x">X</code> Bum bum bum <code class="d">Dm</code> ba da
-dum bum bum <code class="g">G</code><br />
-Bum bum bum <code class="c">C</code> ba da dum bum bum <code
-class="a">Am</code></p>
-<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code
-class="g">G</code><br />
+dum bum bum <code class="g">G</code><br>
+Bum bum bum <code class="c">C</code> ba da dum bum bum <code class="a">Am</code></p>
+<p>Bum bum bum <code class="f">F</code> ba da dum, bum bum <code class="g">G</code><br>
 Bum ba dum <code class="a">Am</code></p>
 <p><em>(x3)</em></p>
-</section>
-<section id="solo" class="slide level2">
+</div></section>
+<section id="solo" class="slide level2"><div class="slide-content">
 <h2>Solo</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="d">Dm</code> <code class="g">G</code> <code
-class="c">C</code> <code class="a">Am</code> <code class="f">F</code>
+<p><code class="d">Dm</code> <code class="g">G</code> <code class="c">C</code> <code class="a">Am</code> <code class="f">F</code>
 <code class="g">G</code> <code class="a">Am</code></p>
-</section>
-<section id="outro-6" class="slide level2">
+</div></section>
+<section id="outro-6" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="d">Dm</code> Save me from drowning in the sea <code
-class="d">Dm6</code><br />
-<code class="a">Am</code> Beat me up on the beach<br />
-<code class="d">Dm</code>What a lovely holiday <code
-class="e">E7(1)</code><br />
+<p><code class="d">Dm</code> Save me from drowning in the sea <code class="d">Dm6</code><br>
+<code class="a">Am</code> Beat me up on the beach<br>
+<code class="d">Dm</code>What a lovely holiday <code class="e">E7(1)</code><br>
 There’s nothing funny left to say <code class="a">Am</code></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="road-trippin-red-hot-chili-peppers"
-class="title-slide slide level1">
+<section id="road-trippin-red-hot-chili-peppers" class="title-slide slide level1"><div class="slide-content">
 <h1>Road trippin’ (Red Hot Chili Peppers)</h1>
 
-</section>
-<section id="intro-19" class="slide level2">
+</div></section>
+<section id="intro-19" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="e">Em</code> <code class="c">C</code> <code
-class="b">B</code> <em>(x2)</em></p>
-</section>
-<section id="verse-1-28" class="slide level2">
+<p><code class="e">Em</code> <code class="c">C</code> <code class="b">B</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-1-28" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="e">Em</code> Road trippin with my two<br />
-<code class="c">C</code> favorite all<code class="b">B</code>ies<br />
-<code class="e">Em</code> Fully loaded we got<br />
+<p><code class="e">Em</code> Road trippin with my two<br>
+<code class="c">C</code> favorite all<code class="b">B</code>ies<br>
+<code class="e">Em</code> Fully loaded we got<br>
 <code class="c">C</code> snacks and supp<code class="b">B</code>lies</p>
-<p><code class="e">Em</code> It’s time to leave this town<br />
-It’s <code class="c">C</code> time to steal away <code
-class="b">B</code><br />
-<code class="e">Em</code> Let’s go get lost<br />
-any<code class="c">C</code>where in the U.S.A. <code
-class="b">B</code></p>
-</section>
-<section class="slide level2">
+<p><code class="e">Em</code> It’s time to leave this town<br>
+It’s <code class="c">C</code> time to steal away <code class="b">B</code><br>
+<code class="e">Em</code> Let’s go get lost<br>
+any<code class="c">C</code>where in the U.S.A. <code class="b">B</code></p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="e">Em</code> Let’s go get lost<br />
+<p><code class="e">Em</code> Let’s go get lost<br>
 let’s go get <code class="c">C</code> lost <code class="b">B</code></p>
-<p><code class="e">Em</code> Blue you sit so pretty<br />
-<code class="c">C</code> West of the one <code class="b">B</code><br />
-<code class="e">Em</code> Sparkles light with yellow <code
-class="c">C</code> icing<br />
-Just a <code class="b">B</code> mirror for the sun <code
-class="e">Em</code></p>
-</section>
-<section id="chorus-37" class="slide level2">
+<p><code class="e">Em</code> Blue you sit so pretty<br>
+<code class="c">C</code> West of the one <code class="b">B</code><br>
+<code class="e">Em</code> Sparkles light with yellow <code class="c">C</code> icing<br>
+Just a <code class="b">B</code> mirror for the sun <code class="e">Em</code></p>
+</div></section>
+<section id="chorus-37" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> Just a <code class="b">B</code> mirror for
-the <code class="e">Em</code> sun<br />
+the <code class="e">Em</code> sun<br>
 <code class="c">C</code> Just a <code class="b">B</code> mirror for
-the<br />
-<code class="a">Am</code> Sun <code class="g">G/B</code> <code
-class="c">C</code> <code class="d">D</code></p>
+the<br>
+<code class="a">Am</code> Sun <code class="g">G/B</code> <code class="c">C</code> <code class="d">D</code></p>
 <p><code class="a">Am</code> These smiling <code class="g">G/B</code>
-eyes<br />
-are just a <code class="c">C</code> mirror for <code
-class="d">D</code></p>
-</section>
-<section id="verse-2-24" class="slide level2">
+eyes<br>
+are just a <code class="c">C</code> mirror for <code class="d">D</code></p>
+</div></section>
+<section id="verse-2-24" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="e">Em</code> So much has come before<br />
+<p><code class="e">Em</code> So much has come before<br>
 those <code class="c">C</code> battles lost and <code class="b">B</code>
-won<br />
-<code class="e">Em</code> This life is shining<br />
-more for<code class="c">C</code>ever in the sun <code
-class="b">B</code></p>
-<p><code class="e">Em</code> Now let us check our heads<br />
-And <code class="c">C</code> let us check the surf <code
-class="b">B</code><br />
-<code class="e">Em</code> Staying high and dry’s more <code
-class="c">C</code> trouble<br />
-than it’s <code class="b">B</code> worth in the sun <code
-class="e">Em</code></p>
-</section>
-<section id="chorus-38" class="slide level2">
+won<br>
+<code class="e">Em</code> This life is shining<br>
+more for<code class="c">C</code>ever in the sun <code class="b">B</code></p>
+<p><code class="e">Em</code> Now let us check our heads<br>
+And <code class="c">C</code> let us check the surf <code class="b">B</code><br>
+<code class="e">Em</code> Staying high and dry’s more <code class="c">C</code> trouble<br>
+than it’s <code class="b">B</code> worth in the sun <code class="e">Em</code></p>
+</div></section>
+<section id="chorus-38" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> Just a <code class="b">B</code> mirror for
-the <code class="e">Em</code> sun<br />
+the <code class="e">Em</code> sun<br>
 <code class="c">C</code> Just a <code class="b">B</code> mirror for
-the<br />
-<code class="a">Am</code> Sun <code class="g">G/B</code> <code
-class="c">C</code> <code class="d">D</code></p>
+the<br>
+<code class="a">Am</code> Sun <code class="g">G/B</code> <code class="c">C</code> <code class="d">D</code></p>
 <p><code class="a">Am</code> These smiling <code class="g">G/B</code>
-eyes<br />
-are just a <code class="c">C</code> mirror for <code
-class="d">D</code></p>
-</section>
-<section id="interlude-5" class="slide level2">
+eyes<br>
+are just a <code class="c">C</code> mirror for <code class="d">D</code></p>
+</div></section>
+<section id="interlude-5" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="e">Em</code> <code class="a">A</code> <code
-class="c">C</code> <code class="d">D</code> <code class="e">Em</code>
-<code class="a">A</code> <code class="c">C</code> <code
-class="b">Bdim</code> <em>(x2)</em></p>
+<p><code class="e">Em</code> <code class="a">A</code> <code class="c">C</code> <code class="d">D</code> <code class="e">Em</code>
+<code class="a">A</code> <code class="c">C</code> <code class="b">Bdim</code> <em>(x2)</em></p>
 <p><code class="b">Bdim</code> <em>(x4)</em></p>
-</section>
-<section id="verse-3-17" class="slide level2">
+</div></section>
+<section id="verse-3-17" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="e">Em</code> In Big Sur we take some<br />
-<code class="c">C</code> time to linger on <code
-class="b">B</code><br />
-<code class="e">Em</code> We three hunky dory’s got<br />
+<p><code class="e">Em</code> In Big Sur we take some<br>
+<code class="c">C</code> time to linger on <code class="b">B</code><br>
+<code class="e">Em</code> We three hunky dory’s got<br>
 <code class="c">C</code> our snake<code class="b">B</code>finger on</p>
-<p><code class="e">Em</code> Now let us drink the stars<br />
-<code class="c">C</code> It’s time to steal away <code
-class="b">B</code><br />
-<code class="e">Em</code> Let’s go get lost<br />
+<p><code class="e">Em</code> Now let us drink the stars<br>
+<code class="c">C</code> It’s time to steal away <code class="b">B</code><br>
+<code class="e">Em</code> Let’s go get lost<br>
 <del>anywhere</del> <strong>right <code class="c">C</code> here</strong>
 in the U.S.A. <code class="b">B</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="e">Em</code> Let’s go get lost<br />
+<p><code class="e">Em</code> Let’s go get lost<br>
 let’s go get <code class="c">C</code> lost <code class="b">B</code></p>
-<p><code class="e">Em</code> Blue you sit so pretty<br />
-<code class="c">C</code> West of the one <code class="b">B</code><br />
-<code class="e">Em</code> Sparkles light with yellow <code
-class="c">C</code> icing<br />
-Just a <code class="b">B</code> mirror for the sun <code
-class="e">Em</code></p>
-</section>
-<section id="chorus-39" class="slide level2">
+<p><code class="e">Em</code> Blue you sit so pretty<br>
+<code class="c">C</code> West of the one <code class="b">B</code><br>
+<code class="e">Em</code> Sparkles light with yellow <code class="c">C</code> icing<br>
+Just a <code class="b">B</code> mirror for the sun <code class="e">Em</code></p>
+</div></section>
+<section id="chorus-39" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><code class="c">C</code> Just a <code class="b">B</code> mirror for
-the <code class="e">Em</code> sun<br />
+the <code class="e">Em</code> sun<br>
 <code class="c">C</code> Just a <code class="b">B</code> mirror for
-the<br />
-<code class="a">Am</code> Sun <code class="g">G/B</code> <code
-class="c">C</code> <code class="d">D</code></p>
+the<br>
+<code class="a">Am</code> Sun <code class="g">G/B</code> <code class="c">C</code> <code class="d">D</code></p>
 <p><code class="a">Am</code> These smiling <code class="g">G/B</code>
-eyes<br />
+eyes<br>
 are just a <code class="c">C</code> mirror for <code class="d">D</code>
 <em>(x3)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="s-zündhölzli-mani-matter" class="title-slide slide level1">
+<section id="s-zündhölzli-mani-matter" class="title-slide slide level1"><div class="slide-content">
 <h1>S Zündhölzli (Mani Matter)</h1>
 
-</section>
-<section id="verse-1-29" class="slide level2">
+</div></section>
+<section id="verse-1-29" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>I han es <code class="c">C</code>Zündhölzli azündet<br />
-Und das <code class="g">G7</code> het e Flamme gäh<br />
-Und i <code class="a">Am</code> ha für d’Zigarette<br />
+<p>I han es <code class="c">C</code>Zündhölzli azündet<br>
+Und das <code class="g">G7</code> het e Flamme gäh<br>
+Und i <code class="a">Am</code> ha für d’Zigarette<br>
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
-<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
-Und <code class="c">C</code> uf e Teppich cho<br />
-Und es <code class="g">G7</code> hätt no fasch<br />
+<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br>
+Und <code class="c">C</code> uf e Teppich cho<br>
+Und es <code class="g">G7</code> hätt no fasch<br>
 Es Loch i Teppich <code class="c">C</code> gäh dervo</p>
-</section>
-<section id="verse-2-25" class="slide level2">
+</div></section>
+<section id="verse-2-25" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Ja me <code class="c">C</code> weiss was cha passiere<br />
-We me <code class="g">G7</code> nid ufpasst mit Füür<br />
-Und für d’<code class="a">Am</code>Gluet ar Zigarette<br />
+<p>Ja me <code class="c">C</code> weiss was cha passiere<br>
+We me <code class="g">G7</code> nid ufpasst mit Füür<br>
+Und für d’<code class="a">Am</code>Gluet ar Zigarette<br>
 Isch e <code class="e">E</code> Teppich doch de z’tüür</p>
-<p>Und vom <code class="f">F</code> Teppich hätt - oh Grus<br />
-Chönne ds <code class="c">C</code> Füür i ds ganze Hus<br />
-Und wär <code class="g">G7</code> weiss, was da<br />
+<p>Und vom <code class="f">F</code> Teppich hätt - oh Grus<br>
+Chönne ds <code class="c">C</code> Füür i ds ganze Hus<br>
+Und wär <code class="g">G7</code> weiss, was da<br>
 Nid alles no wär <code class="c">C</code> worde drus</p>
-</section>
-<section id="verse-3-18" class="slide level2">
+</div></section>
+<section id="verse-3-18" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>S’hätt e <code class="c">C</code> Brand gäh im Quartier<br />
-Und s’hätti d’<code class="g">G7</code>Füürwehr müesse cho<br />
-Hätti <code class="a">Am</code> ghornet i de Strasse<br />
+<p>S’hätt e <code class="c">C</code> Brand gäh im Quartier<br>
+Und s’hätti d’<code class="g">G7</code>Füürwehr müesse cho<br>
+Hätti <code class="a">Am</code> ghornet i de Strasse<br>
 Und dr <code class="e">E</code> Schluuch vom Wage gno</p>
-<p>Und sie <code class="f">F</code> hätte Wasser gsprützt<br />
-Und das <code class="c">C</code> hätt de glych nüt gnützt<br />
-Und die <code class="g">G7</code> ganzi Stadt hätt brönnt<br />
+<p>Und sie <code class="f">F</code> hätte Wasser gsprützt<br>
+Und das <code class="c">C</code> hätt de glych nüt gnützt<br>
+Und die <code class="g">G7</code> ganzi Stadt hätt brönnt<br>
 Es hätt se <code class="c">C</code> nüt meh gschützt</p>
-</section>
-<section id="verse-4-9" class="slide level2">
+</div></section>
+<section id="verse-4-9" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
-<p>Und d’Lüt <code class="c">C</code> wären umegsprunge<br />
-I dr <code class="g">G7</code> Angscht um Hab und Guet<br />
-Hätte <code class="a">Am</code> gmeint s’heig eine Füür gleit<br />
+<p>Und d’Lüt <code class="c">C</code> wären umegsprunge<br>
+I dr <code class="g">G7</code> Angscht um Hab und Guet<br>
+Hätte <code class="a">Am</code> gmeint s’heig eine Füür gleit<br>
 Hätte ds <code class="e">E</code> Sturmgwehr gno ir Wuet</p>
-<p>Alls hätt <code class="f">F</code> brüelet: Wär isch tschuld?<br />
-Ds ganze <code class="c">C</code> Land i eim Tumult<br />
-Dass me <code class="g">G7</code> gschosse hätt<br />
+<p>Alls hätt <code class="f">F</code> brüelet: Wär isch tschuld?<br>
+Ds ganze <code class="c">C</code> Land i eim Tumult<br>
+Dass me <code class="g">G7</code> gschosse hätt<br>
 Uf d’Bundesrät am <code class="c">C</code> Rednerpult</p>
-</section>
-<section id="verse-5-7" class="slide level2">
+</div></section>
+<section id="verse-5-7" class="slide level2"><div class="slide-content">
 <h2>Verse 5</h2>
-<p>D’UNO <code class="c">C</code> hätt interveniert<br />
-Und d’UNO-<code class="g">G7</code>Gägner sofort o<br />
-Für ir <code class="a">Am</code> Schwyz dr Fride z’rette<br />
+<p>D’UNO <code class="c">C</code> hätt interveniert<br>
+Und d’UNO-<code class="g">G7</code>Gägner sofort o<br>
+Für ir <code class="a">Am</code> Schwyz dr Fride z’rette<br>
 Wäre <code class="e">E</code> beid mit Panzer cho</p>
-<p>S’hätt sech <code class="f">F</code> usdehnt nadisna<br />
-Uf Eu<code class="c">C</code>ropa, Afrika<br />
-S’hätt e <code class="g">G7</code> Wältchrieg gäh<br />
+<p>S’hätt sech <code class="f">F</code> usdehnt nadisna<br>
+Uf Eu<code class="c">C</code>ropa, Afrika<br>
+S’hätt e <code class="g">G7</code> Wältchrieg gäh<br>
 Und d’Mönschheit wär jitz <code class="c">C</code> nümme da</p>
-</section>
-<section id="verse-6-5" class="slide level2">
+</div></section>
+<section id="verse-6-5" class="slide level2"><div class="slide-content">
 <h2>Verse 6</h2>
-<p>I han es <code class="c">C</code> Zündhölzli azündet<br />
-Und das <code class="g">G7</code> het e Flamme gäh<br />
-Und i <code class="a">Am</code> ha für d’Zigarette<br />
+<p>I han es <code class="c">C</code> Zündhölzli azündet<br>
+Und das <code class="g">G7</code> het e Flamme gäh<br>
+Und i <code class="a">Am</code> ha für d’Zigarette<br>
 Welle <code class="e">E</code> Füür vom Hölzli näh</p>
-<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br />
-Und <code class="c">C</code> uf e Teppich cho -<br />
-<del>Und es hätt no fasch…</del> Gottsei<code
-class="g">G7</code>dank<br />
+<p>Aber ds <code class="f">F</code> Hölzli isch dervogspickt<br>
+Und <code class="c">C</code> uf e Teppich cho -<br>
+<del>Und es hätt no fasch…</del> Gottsei<code class="g">G7</code>dank<br>
 Dass i’s vom Teppich wider <code class="c">C</code> furt ha gno</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="sittin-on-the-dock-of-the-bay-otis-redding"
-class="title-slide slide level1">
+<section id="sittin-on-the-dock-of-the-bay-otis-redding" class="title-slide slide level1"><div class="slide-content">
 <h1>Sittin’ on the dock of the bay (Otis Redding)</h1>
 
-</section>
-<section id="verse-1-30" class="slide level2">
+</div></section>
+<section id="verse-1-30" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="g">G</code> Sittin’ in the mornin’ sun <code
-class="b">B7</code><br />
-I’ll be <code class="c">C</code> sittin’ when the evenin’ comes <code
-class="a">A</code><br />
-<code class="g">G</code> Watching the ships roll in <code
-class="b">B7</code><br />
-And then I <code class="c">C</code> watch ’em roll away again <code
-class="a">A</code> yeah</p>
-</section>
-<section id="chorus-40" class="slide level2">
+<p><code class="g">G</code> Sittin’ in the mornin’ sun <code class="b">B7</code><br>
+I’ll be <code class="c">C</code> sittin’ when the evenin’ comes <code class="a">A</code><br>
+<code class="g">G</code> Watching the ships roll in <code class="b">B7</code><br>
+And then I <code class="c">C</code> watch ’em roll away again <code class="a">A</code> yeah</p>
+</div></section>
+<section id="chorus-40" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>I’m <code class="g">G</code> sittin’ on the dock of the <code
-class="e">E</code> bay<br />
-Watching the <code class="g">G</code> tide roll <code
-class="e">E</code>away, ooo<br />
-I’m just <code class="g">G</code> sittin’ on the dock of the <code
-class="a">A</code> bay<br />
+<p>I’m <code class="g">G</code> sittin’ on the dock of the <code class="e">E</code> bay<br>
+Watching the <code class="g">G</code> tide roll <code class="e">E</code>away, ooo<br>
+I’m just <code class="g">G</code> sittin’ on the dock of the <code class="a">A</code> bay<br>
 Wastin’ <code class="g">G</code> time <code class="e">E</code></p>
-</section>
-<section id="verse-2-26" class="slide level2">
+</div></section>
+<section id="verse-2-26" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>I <code class="g">G</code> left my home in <code class="b">B7</code>
-Georgia<br />
-<code class="c">C</code> Headed for the ’Frisco Bay <code
-class="a">A</code><br />
-<code class="g">G</code> ’Cause I’ve had nothing to <code
-class="b">B7</code> live for<br />
-And look like <code class="c">C</code> nothin’s gonna come my way <code
-class="a">A</code></p>
-</section>
-<section id="chorus-41" class="slide level2">
+Georgia<br>
+<code class="c">C</code> Headed for the ’Frisco Bay <code class="a">A</code><br>
+<code class="g">G</code> ’Cause I’ve had nothing to <code class="b">B7</code> live for<br>
+And look like <code class="c">C</code> nothin’s gonna come my way <code class="a">A</code></p>
+</div></section>
+<section id="chorus-41" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><del>I’m sittin’</del> <strong>So I’m just gonna <code
-class="g">G</code> sit</strong> on the dock of the <code
-class="e">E</code> bay<br />
-Watching the <code class="g">G</code> tide roll <code
-class="e">E</code>away, ooh<br />
+<p><del>I’m sittin’</del> <strong>So I’m just gonna <code class="g">G</code> sit</strong> on the dock of the <code class="e">E</code> bay<br>
+Watching the <code class="g">G</code> tide roll <code class="e">E</code>away, ooh<br>
 <del>I’m just</del> <strong>Ooo I’m</strong> <code class="g">G</code>
-sittin’ on the dock of the <code class="a">A</code> bay<br />
+sittin’ on the dock of the <code class="a">A</code> bay<br>
 Wastin’ <code class="g">G</code> time <code class="e">E</code></p>
-</section>
-<section id="bridge-6" class="slide level2">
+</div></section>
+<section id="bridge-6" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><code class="g">G</code> Looks like <code class="d">D</code>
-nothing’s <code class="c">C</code> gonna change <code
-class="g">G</code><br />
+nothing’s <code class="c">C</code> gonna change <code class="g">G</code><br>
 <code class="g">G</code> Everything <code class="d">D</code> still
-remains <code class="c">C</code> the same <code class="g">G</code><br />
-<code class="g">G</code> I can’t <code class="d">D</code> do what <code
-class="c">C</code> ten people <code class="g">G</code> tell me to
-do<br />
-So I <code class="f">F</code> guess I’ll remain the <code
-class="d">D</code> same, yes</p>
-</section>
-<section id="chorus-42" class="slide level2">
+remains <code class="c">C</code> the same <code class="g">G</code><br>
+<code class="g">G</code> I can’t <code class="d">D</code> do what <code class="c">C</code> ten people <code class="g">G</code> tell me to
+do<br>
+So I <code class="f">F</code> guess I’ll remain the <code class="d">D</code> same, yes</p>
+</div></section>
+<section id="chorus-42" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><strong>Now</strong> I’m <code class="g">G</code> sitting on the dock
-of the <code class="e">E</code> bay<br />
-Watching the <code class="g">G</code> tide roll <code
-class="e">E</code>away, ooh<br />
+of the <code class="e">E</code> bay<br>
+Watching the <code class="g">G</code> tide roll <code class="e">E</code>away, ooh<br>
 <del>I’m just</del> <strong>Ooo I’m</strong> <code class="g">G</code>
-sittin’ on the dock of the <code class="a">A</code> bay<br />
+sittin’ on the dock of the <code class="a">A</code> bay<br>
 Wastin’ <code class="g">G</code> time <code class="e">E</code></p>
 <p><em>(Repeat and whistle, fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="something-stupid-robbie-williams"
-class="title-slide slide level1">
+<section id="something-stupid-robbie-williams" class="title-slide slide level1"><div class="slide-content">
 <h1>Something stupid (Robbie Williams)</h1>
 
-</section>
-<section id="instructions-7" class="slide level2">
+</div></section>
+<section id="instructions-7" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>Sounds best with some barre chords:
 
@@ -3392,600 +2882,547 @@ G6 |3 2 0 0 3 0|
 And some more chords:
 
 D+ |x x 0 3 3 2| To switch from D, point pinky on G string</code></pre>
-</section>
-<section id="verse-1-31" class="slide level2">
+</div></section>
+<section id="verse-1-31" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p>I <code class="g">G6</code> know I stand in line<br />
-until you think you have the time<br />
-to spend an <code class="a">Am</code> evening with me <code
-class="d">D7</code> <code class="a">Am</code> <code
-class="d">D7</code></p>
-<p>And <code class="a">Am</code> if we go some<code
-class="d">D7</code>place to dance<br />
-I <code class="a">Am</code> know that there’s a chance <code
-class="d">D7</code><br />
+<p>I <code class="g">G6</code> know I stand in line<br>
+until you think you have the time<br>
+to spend an <code class="a">Am</code> evening with me <code class="d">D7</code> <code class="a">Am</code> <code class="d">D7</code></p>
+<p>And <code class="a">Am</code> if we go some<code class="d">D7</code>place to dance<br>
+I <code class="a">Am</code> know that there’s a chance <code class="d">D7</code><br>
 you won’t be <code class="g">G6</code> leaving with me</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Then <code class="g">G</code> afterwards we drop<br />
-into a <code class="g">G7</code> quiet little place<br />
-and have a <code class="c">C</code> drink or two <code
-class="e">Eb</code></p>
+<p>Then <code class="g">G</code> afterwards we drop<br>
+into a <code class="g">G7</code> quiet little place<br>
+and have a <code class="c">C</code> drink or two <code class="e">Eb</code></p>
 <p>And <code class="a">Am</code> then I go and <code class="d">D7</code>
-spoil it all<br />
+spoil it all<br>
 by <code class="a">Am</code> saying something <code class="d">D7</code>
-stupid<br />
+stupid<br>
 like: “I <code class="g">G6</code> love you”</p>
-</section>
-<section id="bridge-7" class="slide level2">
+</div></section>
+<section id="bridge-7" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>I can <code class="g">G</code> see it in your eyes<br />
-that you de<code class="g">G7</code>spise the same old lies<br />
+<p>I can <code class="g">G</code> see it in your eyes<br>
+that you de<code class="g">G7</code>spise the same old lies<br>
 you heard the <code class="c">C</code> night before</p>
-<p>And <code class="a">A7</code> though it’s just a line to you<br />
-For me it’s true and<br />
-never seemed so <code class="d">D</code> right before <code
-class="d">D+</code></p>
-</section>
-<section id="verse-2-27" class="slide level2">
+<p>And <code class="a">A7</code> though it’s just a line to you<br>
+For me it’s true and<br>
+never seemed so <code class="d">D</code> right before <code class="d">D+</code></p>
+</div></section>
+<section id="verse-2-27" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>I <code class="g">G6</code> practice every day<br />
-to find some clever lines to say to make<br />
-the <code class="a">Am</code> meaning come through <code
-class="d">D7</code> <code class="a">Am</code> <code
-class="d">D7</code></p>
-<p>But <code class="a">Am</code> then I think I’ll <code
-class="d">D7</code> wait until<br />
-the <code class="a">Am</code> evening gets late <code
-class="d">D7</code><br />
+<p>I <code class="g">G6</code> practice every day<br>
+to find some clever lines to say to make<br>
+the <code class="a">Am</code> meaning come through <code class="d">D7</code> <code class="a">Am</code> <code class="d">D7</code></p>
+<p>But <code class="a">Am</code> then I think I’ll <code class="d">D7</code> wait until<br>
+the <code class="a">Am</code> evening gets late <code class="d">D7</code><br>
 and I’m <code class="g">G6</code> alone with you</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>The <code class="g">G</code> time is right<br />
-your perfume fills my <code class="g">G7</code> head<br />
-the stars get red<br />
-and oh the <code class="c">C</code> night’s so blue <code
-class="e">Eb</code></p>
+<p>The <code class="g">G</code> time is right<br>
+your perfume fills my <code class="g">G7</code> head<br>
+the stars get red<br>
+and oh the <code class="c">C</code> night’s so blue <code class="e">Eb</code></p>
 <p>And <code class="a">Am</code> then I go and <code class="d">D7</code>
-spoil it all<br />
+spoil it all<br>
 by <code class="a">Am</code> saying something <code class="d">D7</code>
-stupid<br />
+stupid<br>
 like: “I <code class="g">G6</code> love you”</p>
-</section>
-<section id="bridge-8" class="slide level2">
+</div></section>
+<section id="bridge-8" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
 <p><em>(Instrumental, maybe add whistling)</em></p>
-<p><code class="g">G</code> <code class="g">G7</code> <code
-class="c">C</code><br />
-<code class="a">A7</code> <code class="d">D</code> <code
-class="d">D+</code></p>
-</section>
-<section id="verse-2-28" class="slide level2">
+<p><code class="g">G</code> <code class="g">G7</code> <code class="c">C</code><br>
+<code class="a">A7</code> <code class="d">D</code> <code class="d">D+</code></p>
+</div></section>
+<section id="verse-2-28" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>I <code class="g">G6</code> practice every day<br />
-to find some clever lines to say to make<br />
-the <code class="a">Am</code> meaning come through <code
-class="d">D7</code> <code class="a">Am</code> <code
-class="d">D7</code></p>
-<p>But <code class="a">Am</code> then I think I’ll <code
-class="d">D7</code> wait until<br />
-the <code class="a">Am</code> evening gets late <code
-class="d">D7</code><br />
+<p>I <code class="g">G6</code> practice every day<br>
+to find some clever lines to say to make<br>
+the <code class="a">Am</code> meaning come through <code class="d">D7</code> <code class="a">Am</code> <code class="d">D7</code></p>
+<p>But <code class="a">Am</code> then I think I’ll <code class="d">D7</code> wait until<br>
+the <code class="a">Am</code> evening gets late <code class="d">D7</code><br>
 and I’m <code class="g">G6</code> alone with you</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>The <code class="g">G</code> time is right<br />
-your perfume fills my <code class="g">G7</code> head<br />
-the stars get red<br />
-and oh the <code class="c">C</code> night’s so blue <code
-class="e">Eb</code></p>
+<p>The <code class="g">G</code> time is right<br>
+your perfume fills my <code class="g">G7</code> head<br>
+the stars get red<br>
+and oh the <code class="c">C</code> night’s so blue <code class="e">Eb</code></p>
 <p>And <code class="a">Am</code> then I go and <code class="d">D7</code>
-spoil it all<br />
+spoil it all<br>
 by <code class="a">Am</code> saying something <code class="d">D7</code>
-stupid<br />
-like: “I <code class="g">G</code> love you” <code
-class="e">Eb</code></p>
+stupid<br>
+like: “I <code class="g">G</code> love you” <code class="e">Eb</code></p>
 <p>I <code class="g">G</code> love you <code class="e">Eb</code>
 <em>(Repeat and fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="somewhere-over-the-rainbow-israël-kamakawiwoole"
-class="title-slide slide level1">
+<section id="somewhere-over-the-rainbow-israël-kamakawiwoole" class="title-slide slide level1"><div class="slide-content">
 <h1>Somewhere over the rainbow (Israël Kamakawiwo’ole)</h1>
 
-</section>
-<section id="intro-20" class="slide level2">
+</div></section>
+<section id="intro-20" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="c">C</code> <code class="g">G</code> <code
-class="a">Am</code> <code class="f">F</code> <em>(repeat)</em></p>
+<p><code class="c">C</code> <code class="g">G</code> <code class="a">Am</code> <code class="f">F</code> <em>(repeat)</em></p>
 <p><code class="c">C</code> Ooo-ooo <code class="e">Em</code>
-ooo-ooo<br />
-<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br />
-<code class="f">F</code> Ooo-ooo <code class="e">E7</code> ooo-ooo<br />
+ooo-ooo<br>
+<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br>
+<code class="f">F</code> Ooo-ooo <code class="e">E7</code> ooo-ooo<br>
 <code class="a">Am</code> ooo-ooo <code class="f">F</code> ooo-ooo</p>
-</section>
-<section id="verse-1-32" class="slide level2">
+</div></section>
+<section id="verse-1-32" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><code class="c">C</code> Somewhere <code class="e">Em</code> over the
-rainbow<br />
-<code class="f">F</code> way up <code class="c">C</code> high<br />
+rainbow<br>
+<code class="f">F</code> way up <code class="c">C</code> high<br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dream of<br />
+you dream of<br>
 <code class="g">G</code> once in a lulla<code class="a">Am</code>by
 <code class="f">F</code></p>
 <p>Oh <code class="c">C</code> somewhere <code class="e">Em</code> over
-the rainbow<br />
-<code class="f">F</code> blue birds <code class="c">C</code> fly<br />
+the rainbow<br>
+<code class="f">F</code> blue birds <code class="c">C</code> fly<br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dream of<br />
+you dream of<br>
 <code class="g">G</code> dreams really do come <code class="a">Am</code>
 true <code class="f">F</code></p>
-</section>
-<section id="verse-2-29" class="slide level2">
+</div></section>
+<section id="verse-2-29" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Some<code class="c">C</code>day i’ll wish upon a star<br />
-<code class="g">G</code> To wake up where the clouds are far<br />
+<p>Some<code class="c">C</code>day i’ll wish upon a star<br>
+<code class="g">G</code> To wake up where the clouds are far<br>
 be<code class="a">Am</code>hind <code class="f">F</code> me</p>
-<p>Where <code class="c">C</code> trouble melts like lemon drops<br />
-<code class="g">G</code> High above the chimney tops<br />
-that’s <code class="a">Am</code> where<br />
+<p>Where <code class="c">C</code> trouble melts like lemon drops<br>
+<code class="g">G</code> High above the chimney tops<br>
+that’s <code class="a">Am</code> where<br>
 you’ll <code class="f">F</code> find me</p>
-</section>
-<section id="interlude-1-1" class="slide level2">
+</div></section>
+<section id="interlude-1-1" class="slide level2"><div class="slide-content">
 <h2>Interlude 1</h2>
 <p>Oh <code class="c">C</code> somewhere <code class="e">Em</code> over
-the rainbow<br />
-<code class="f">F</code> blue birds <code class="c">C</code> fly<br />
+the rainbow<br>
+<code class="f">F</code> blue birds <code class="c">C</code> fly<br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dare to oh<br />
+you dare to oh<br>
 <code class="g">G</code> why oh why can’t <code class="a">Am</code> I?
 <code class="f">F</code></p>
-</section>
-<section id="verse-3-19" class="slide level2">
+</div></section>
+<section id="verse-3-19" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p>Well I see <code class="c">C</code> trees of <code
-class="e">Em</code> green and<br />
-<code class="f">F</code> Red roses <code class="c">C</code> too<br />
+<p>Well I see <code class="c">C</code> trees of <code class="e">Em</code> green and<br>
+<code class="f">F</code> Red roses <code class="c">C</code> too<br>
 <code class="f">F</code> I’ll watch them <code class="c">C</code> bloom
-for<br />
+for<br>
 <code class="e">E7</code> me and <code class="a">Am</code> you</p>
-<p>And I <code class="f">F</code> think to myself<br />
+<p>And I <code class="f">F</code> think to myself<br>
 <code class="g">G</code> what a wonderful <code class="a">Am</code>
 world <code class="f">F</code></p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p>Well I see <code class="c">C</code> skies of <code
-class="e">Em</code> blue and I see<br />
-<code class="f">F</code> clouds of <code class="c">C</code> white<br />
+<p>Well I see <code class="c">C</code> skies of <code class="e">Em</code> blue and I see<br>
+<code class="f">F</code> clouds of <code class="c">C</code> white<br>
 And the <code class="f">F</code> brightness of <code class="c">C</code>
-day<br />
+day<br>
 <code class="e">E7</code> I like the <code class="a">Am</code> dark</p>
-<p>And I <code class="f">F</code> think to myself<br />
+<p>And I <code class="f">F</code> think to myself<br>
 <code class="g">G</code> what a wonderful <code class="c">C</code> world
 <code class="f">F</code> <code class="c">C</code></p>
-</section>
-<section id="bridge-9" class="slide level2">
+</div></section>
+<section id="bridge-9" class="slide level2"><div class="slide-content">
 <h2>Bridge</h2>
-<p>The <code class="g">G</code> colours of the rainbow<br />
-so <code class="c">C</code> pretty in the sky<br />
-Are <code class="g">G</code> also on the faces<br />
+<p>The <code class="g">G</code> colours of the rainbow<br>
+so <code class="c">C</code> pretty in the sky<br>
+Are <code class="g">G</code> also on the faces<br>
 of <code class="c">C</code> people passing bye</p>
 <p>See <code class="f">F</code> friends shaking <code class="c">C</code>
-hands<br />
+hands<br>
 saying <code class="f">F</code> how do you <code class="c">C</code>
-do?<br />
+do?<br>
 <code class="f">F</code> They’re really <code class="c">C</code>
-saying<br />
+saying<br>
 <code class="d">Dm7</code> I - I love <code class="d">D</code> you</p>
-</section>
-<section id="interlude-2-1" class="slide level2">
+</div></section>
+<section id="interlude-2-1" class="slide level2"><div class="slide-content">
 <h2>Interlude 2</h2>
 <p>I hear <code class="c">C</code> babies <code class="e">Em</code> cry
-and I<br />
-<code class="f">F</code> watch them <code class="c">C</code> grow<br />
+and I<br>
+<code class="f">F</code> watch them <code class="c">C</code> grow<br>
 <code class="f">F</code> They’ll learn much <code class="c">C</code>
-more<br />
+more<br>
 <code class="e">E7</code> than we’ll <code class="a">Am</code> know</p>
-<p>And I <code class="f">F</code> think to myself<br />
+<p>And I <code class="f">F</code> think to myself<br>
 <code class="g">G</code> what a wonderful <code class="a">Am</code>
 world <code class="f">F</code> world</p>
-</section>
-<section id="verse-2-30" class="slide level2">
+</div></section>
+<section id="verse-2-30" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Some<code class="c">C</code>day i’ll wish upon a star<br />
-<code class="g">G</code> To wake up where the clouds are far<br />
+<p>Some<code class="c">C</code>day i’ll wish upon a star<br>
+<code class="g">G</code> To wake up where the clouds are far<br>
 be<code class="a">Am</code>hind <code class="f">F</code> me</p>
-<p>Where <code class="c">C</code> trouble melts like lemon drops<br />
-<code class="g">G</code> High above the chimney tops<br />
-that’s <code class="a">Am</code> where<br />
+<p>Where <code class="c">C</code> trouble melts like lemon drops<br>
+<code class="g">G</code> High above the chimney tops<br>
+that’s <code class="a">Am</code> where<br>
 you’ll <code class="f">F</code> find me</p>
-</section>
-<section id="interlude-1-2" class="slide level2">
+</div></section>
+<section id="interlude-1-2" class="slide level2"><div class="slide-content">
 <h2>Interlude 1</h2>
 <p><code class="c">C</code> Oh somewhere <code class="e">Em</code> over
-the rainbow<br />
-<del>blue birds fly</del><br />
+the rainbow<br>
+<del>blue birds fly</del><br>
 <strong><code class="f">F</code> way up <code class="c">C</code>
-high</strong><br />
+high</strong><br>
 <code class="f">F</code> And the <code class="c">C</code> dreams that
-you dare to<br />
+you dare to<br>
 <code class="g">G</code> why oh why can’t <code class="a">Am</code> I?
 <code class="f">F</code></p>
-</section>
-<section id="outro-7" class="slide level2">
+</div></section>
+<section id="outro-7" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
 <p><code class="c">C</code> Ooo-ooo <code class="e">Em</code>
-ooo-ooo<br />
-<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br />
-<code class="f">F</code> ooo-ooo <code class="e">E7</code> ooo-ooo<br />
+ooo-ooo<br>
+<code class="f">F</code> ooo-ooo <code class="c">C</code> ooo-ooo<br>
+<code class="f">F</code> ooo-ooo <code class="e">E7</code> ooo-ooo<br>
 <code class="a">Am</code> ooo-a-eh-a <code class="f">F</code>
 a-a-a-a-a</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="summer-wine-nancy-sinatra-lee-hazlewood"
-class="title-slide slide level1">
+<section id="summer-wine-nancy-sinatra-lee-hazlewood" class="title-slide slide level1"><div class="slide-content">
 <h1>Summer wine (Nancy Sinatra &amp; Lee Hazlewood)</h1>
 
-</section>
-<section id="intro-frauen" class="slide level2">
-<h2>Intro <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="intro-frauen" class="slide level2"><div class="slide-content">
+<h2>Intro <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
 <p><code class="a">Am</code> (x4)</p>
-</section>
-<section id="verse-1-männer" class="slide level2">
-<h2>Verse 1 <em>(Männer)</em></h2>
-<p><code class="a">Am</code> I walked in town on silver<br />
-<code class="g">G</code> spurs that jingled to<br />
-<code class="a">Am</code> A song that I had only<br />
+</div></section>
+<section id="verse-1-männer" class="slide level2"><div class="slide-content">
+<h2>Verse 1 <em>(Männer)</em>
+</h2>
+<p><code class="a">Am</code> I walked in town on silver<br>
+<code class="g">G</code> spurs that jingled to<br>
+<code class="a">Am</code> A song that I had only<br>
 <code class="g">G</code> sang to just a few</p>
-<p><code class="d">Dm</code> She saw my silver spurs and<br />
-<code class="a">Am</code> said let’s pass some time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> She saw my silver spurs and<br>
+<code class="a">Am</code> said let’s pass some time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="chorus-frauen" class="slide level2">
-<h2>Chorus <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="chorus-frauen" class="slide level2"><div class="slide-content">
+<h2>Chorus <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
-<p><code class="d">Dm</code> Take off your silver spurs and<br />
-<code class="a">Am</code> help me pass the time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> Take off your silver spurs and<br>
+<code class="a">Am</code> help me pass the time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="verse-2-männer" class="slide level2">
-<h2>Verse 2 <em>(Männer)</em></h2>
-<p><code class="a">Am</code> My eyes grew heavy and my<br />
-<code class="g">G</code> lips they could not speak<br />
-<code class="a">Am</code> I tried to get up but I<br />
+</div></section>
+<section id="verse-2-männer" class="slide level2"><div class="slide-content">
+<h2>Verse 2 <em>(Männer)</em>
+</h2>
+<p><code class="a">Am</code> My eyes grew heavy and my<br>
+<code class="g">G</code> lips they could not speak<br>
+<code class="a">Am</code> I tried to get up but I<br>
 <code class="g">G</code> couldn’t find my feet</p>
-<p><code class="d">Dm</code> She reassured me with an<br />
-<code class="a">Am</code> unfamiliar line<br />
-<code class="d">Dm</code> And then she gave to me<br />
+<p><code class="d">Dm</code> She reassured me with an<br>
+<code class="a">Am</code> unfamiliar line<br>
+<code class="d">Dm</code> And then she gave to me<br>
 <code class="a">Am</code> more summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="chorus-frauen-1" class="slide level2">
-<h2>Chorus <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="chorus-frauen-1" class="slide level2"><div class="slide-content">
+<h2>Chorus <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
-<p><code class="d">Dm</code> Take off your silver spurs and<br />
-<code class="a">Am</code> help me pass the time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> Take off your silver spurs and<br>
+<code class="a">Am</code> help me pass the time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="verse-2-männer-1" class="slide level2">
-<h2>Verse 2 <em>(Männer)</em></h2>
-<p><code class="a">Am</code> When I woke up the sun was<br />
-<code class="g">G</code> shining in my eyes<br />
-<code class="a">Am</code> My silver spurs were gone<br />
+</div></section>
+<section id="verse-2-männer-1" class="slide level2"><div class="slide-content">
+<h2>Verse 2 <em>(Männer)</em>
+</h2>
+<p><code class="a">Am</code> When I woke up the sun was<br>
+<code class="g">G</code> shining in my eyes<br>
+<code class="a">Am</code> My silver spurs were gone<br>
 my <code class="g">G</code> head felt twice its size</p>
-<p><code class="d">Dm</code> She took my silver spurs<br />
-a <code class="a">Am</code> dollar and a dime<br />
-<code class="d">Dm</code> And left me cravin’ for <code
-class="a">Am</code> more summer wine</p>
+<p><code class="d">Dm</code> She took my silver spurs<br>
+a <code class="a">Am</code> dollar and a dime<br>
+<code class="d">Dm</code> And left me cravin’ for <code class="a">Am</code> more summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="chorus-frauen-2" class="slide level2">
-<h2>Chorus <em>(Frauen)</em></h2>
-<p><code class="a">Am</code> Strawberries, cherries and an<br />
-<code class="g">G</code> angel’s kiss in spring<br />
-<code class="a">Am</code> My summer wine is really<br />
+</div></section>
+<section id="chorus-frauen-2" class="slide level2"><div class="slide-content">
+<h2>Chorus <em>(Frauen)</em>
+</h2>
+<p><code class="a">Am</code> Strawberries, cherries and an<br>
+<code class="g">G</code> angel’s kiss in spring<br>
+<code class="a">Am</code> My summer wine is really<br>
 <code class="g">G</code> made from all these things</p>
-<p><code class="d">Dm</code> Take off your silver spurs and<br />
-<code class="a">Am</code> help me pass the time<br />
-<code class="d">Dm</code> And I will give to you <code
-class="a">Am</code> summer wine</p>
+<p><code class="d">Dm</code> Take off your silver spurs and<br>
+<code class="a">Am</code> help me pass the time<br>
+<code class="d">Dm</code> And I will give to you <code class="a">Am</code> summer wine</p>
 <p><code class="g">G</code>Ohhh<code class="e">Em</code>oh summer wine
 <code class="a">Am</code></p>
-</section>
-<section id="outro-8" class="slide level2">
+</div></section>
+<section id="outro-8" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="a">Am</code> <code class="g">G</code> <code
-class="a">Am</code> <code class="g">G</code><br />
-<code class="d">Dm</code> <code class="a">Am</code> <code
-class="d">Dm</code> <code class="a">Am</code></p>
-</section>
+<p><code class="a">Am</code> <code class="g">G</code> <code class="a">Am</code> <code class="g">G</code><br>
+<code class="d">Dm</code> <code class="a">Am</code> <code class="d">Dm</code> <code class="a">Am</code></p>
+</div></section>
 </section>
 <section>
-<section id="the-river-is-flowing-indian-summer"
-class="title-slide slide level1">
+<section id="the-river-is-flowing-indian-summer" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ The river is flowing (Indian Summer)</h1>
 
-</section>
-<section id="verse-1-33" class="slide level2">
+</div></section>
+<section id="verse-1-33" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><em>(Chords sequence remains the same)</em></p>
 <p>The <code class="a">Am</code> river is <code class="c">C</code>
-flowing<br />
+flowing<br>
 <code class="g">G</code> flowing in <code class="a">Am</code>
-growing<br />
-the river is flowing<br />
+growing<br>
+the river is flowing<br>
 back to the sea</p>
-<p>Mother Earth is caring me<br />
-her child I will always be<br />
-Mother Earth is caring me<br />
+<p>Mother Earth is caring me<br>
+her child I will always be<br>
+Mother Earth is caring me<br>
 back to the sea</p>
-</section>
-<section id="verse-2-31" class="slide level2">
+</div></section>
+<section id="verse-2-31" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>The <code class="a">Am</code> Moon she <code class="c">C</code> is
-waiting<br />
+waiting<br>
 <code class="g">G</code> waxing and <code class="a">Am</code>
-waning<br />
-the Moon she is waiting<br />
+waning<br>
+the Moon she is waiting<br>
 for us to be free</p>
-<p>Sister Moon watch over me<br />
-a child I will always be<br />
-Sister Moon watch over me<br />
+<p>Sister Moon watch over me<br>
+a child I will always be<br>
+Sister Moon watch over me<br>
 until we are free</p>
-</section>
-<section id="verse-3-20" class="slide level2">
+</div></section>
+<section id="verse-3-20" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
 <p>The <code class="a">Am</code> Sun he <code class="c">C</code> is
-shining<br />
+shining<br>
 <code class="g">G</code> brightly he’s <code class="a">Am</code>
-shining<br />
-the Sun he is shining<br />
+shining<br>
+the Sun he is shining<br>
 lightning the way</p>
-<p>Father Sun shine over me<br />
-your child I will always be<br />
-father Sun shine over me<br />
+<p>Father Sun shine over me<br>
+your child I will always be<br>
+father Sun shine over me<br>
 until we can see</p>
-</section>
-<section id="verse-4-10" class="slide level2">
+</div></section>
+<section id="verse-4-10" class="slide level2"><div class="slide-content">
 <h2>Verse 4</h2>
 <p>The <code class="a">Am</code> Fire <code class="c">C</code> is
-burning<br />
+burning<br>
 <code class="g">G</code> destroying and <code class="a">Am</code>
-healing<br />
-the Fire is burning<br />
+healing<br>
+the Fire is burning<br>
 for us to get pure</p>
-<p>Violet Flame burn over me<br />
-a child I will always be<br />
-violet Flame burn over me<br />
+<p>Violet Flame burn over me<br>
+a child I will always be<br>
+violet Flame burn over me<br>
 until we are pure</p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="verdammt-ich-lieb-dich-matthias-reim"
-class="title-slide slide level1">
+<section id="verdammt-ich-lieb-dich-matthias-reim" class="title-slide slide level1"><div class="slide-content">
 <h1>Verdammt ich lieb dich (Matthias Reim)</h1>
 
-</section>
-<section id="verse-1-34" class="slide level2">
+</div></section>
+<section id="verse-1-34" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p>Ich <code class="a">Am</code> ziehe durch die Straßen bis nach
-Mitternacht<br />
-hab das früher auch gern gemacht<br />
+Mitternacht<br>
+hab das früher auch gern gemacht<br>
 dich <code class="g">G</code> brauch ich dafür <code class="a">Am</code>
 nicht!</p>
 <p>Ich <code class="a">Am</code> sitze am Tresen, trinke noch ’n
-Bier<br />
-früher war’n wir oft gemeinsam hier<br />
-das <code class="g">G</code> macht mir, macht mir <code
-class="a">Am</code> nichts!</p>
-</section>
-<section class="slide level2">
+Bier<br>
+früher war’n wir oft gemeinsam hier<br>
+das <code class="g">G</code> macht mir, macht mir <code class="a">Am</code> nichts!</p>
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="c">C</code> Gegenüber sitzt ‘n Typ wie’n Bär<br />
+<p><code class="c">C</code> Gegenüber sitzt ‘n Typ wie’n Bär<br>
 ich <code class="g">G</code> stell’ mir vor, wenn das dein Neuer
-wär’<br />
+wär’<br>
 Das <code class="a">Am</code> juckt mich <code class="g">G</code>
 überhaupt <code class="a">Am</code> nicht.</p>
 <p>Auf <code class="c">C</code> einmal packt’s mich, ich geh auf ihn
-zu<br />
+zu<br>
 und <code class="g">G</code> mach ihn an: “Lass meine Frau in
-Ruh!”<br />
+Ruh!”<br>
 Er <code class="a">Am</code> fragt nur: <code class="g">G</code> “Hast
 du’n <code class="a">Am</code> Stich?”</p>
-<p>Und ich <code class="f">F</code> denke schon wieder nur an <code
-class="g">G</code> dich…</p>
-</section>
-<section id="chorus-43" class="slide level2">
+<p>Und ich <code class="f">F</code> denke schon wieder nur an <code class="g">G</code> dich…</p>
+</div></section>
+<section id="chorus-43" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
 <p><em>(x2: gently first time, then repeat intensively)</em></p>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br>
 ich lieb’ dich <code class="g">G</code> nicht.</p>
-<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
-brauch’ dich <code class="a">Am</code> nicht. <code
-class="g">G</code></p>
-<p>Verdammt, ich <code class="c">C</code> will dich,<br />
-ich will dich <code class="g">G</code> nicht,<br />
-Ich <code class="f">F</code> will dich nicht verli<code
-class="a">Am</code>er’n!</p>
-</section>
-<section id="verse-2-32" class="slide level2">
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br>
+brauch’ dich <code class="a">Am</code> nicht. <code class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br>
+ich will dich <code class="g">G</code> nicht,<br>
+Ich <code class="f">F</code> will dich nicht verli<code class="a">Am</code>er’n!</p>
+</div></section>
+<section id="verse-2-32" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
 <p>So <code class="a">Am</code> langsam fällt mir alles wieder
-ein:<br />
-Ich wollt doch nur’n bisschen freier sein.<br />
-Jetzt <code class="g">G</code> bin ich’s - oder <code
-class="a">Am</code> nicht?</p>
-<p>Ich <code class="a">Am</code> passte nicht in deine heile Welt<br />
-doch die und du ist, was mir jetzt so fehlt<br />
+ein:<br>
+Ich wollt doch nur’n bisschen freier sein.<br>
+Jetzt <code class="g">G</code> bin ich’s - oder <code class="a">Am</code> nicht?</p>
+<p>Ich <code class="a">Am</code> passte nicht in deine heile Welt<br>
+doch die und du ist, was mir jetzt so fehlt<br>
 ich <code class="g">G</code> glaub das einfach <code class="a">Am</code>
 nicht.</p>
-</section>
-<section class="slide level2">
+</div></section>
+<section class="slide level2"><div class="slide-content">
 
-<p><code class="c">C</code> Gegenüber steht ’n Telefon<br />
-es <code class="g">G</code> lacht mich ständig an voll Hohn<br />
+<p><code class="c">C</code> Gegenüber steht ’n Telefon<br>
+es <code class="g">G</code> lacht mich ständig an voll Hohn<br>
 Es <code class="a">Am</code> klingelt, <code class="g">G</code> klingelt
 aber <code class="a">Am</code> nicht.</p>
-<p><code class="c">C</code> Sieben Bier, zuviel geraucht<br />
-das <code class="g">G</code> ist es, was ein Mann so braucht,<br />
+<p><code class="c">C</code> Sieben Bier, zuviel geraucht<br>
+das <code class="g">G</code> ist es, was ein Mann so braucht,<br>
 Doch <code class="f">F</code> niemand, <code class="g">G</code> niemand
 sagt: “Hör auf”. <code class="a">Am</code></p>
-<p>Und ich <code class="f">F</code> denke schon wieder nur an <code
-class="g">G</code> dich…</p>
-</section>
-<section id="chorus-44" class="slide level2">
+<p>Und ich <code class="f">F</code> denke schon wieder nur an <code class="g">G</code> dich…</p>
+</div></section>
+<section id="chorus-44" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br>
 ich lieb’ dich <code class="g">G</code> nicht.</p>
-<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
-brauch’ dich <code class="a">Am</code> nicht. <code
-class="g">G</code></p>
-<p>Verdammt, ich <code class="c">C</code> will dich,<br />
-ich will dich <code class="g">G</code> nicht,<br />
-Ich <code class="f">F</code> will dich nicht verli<code
-class="a">Am</code>er’n! - Ooooh!</p>
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br>
+brauch’ dich <code class="a">Am</code> nicht. <code class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br>
+ich will dich <code class="g">G</code> nicht,<br>
+Ich <code class="f">F</code> will dich nicht verli<code class="a">Am</code>er’n! - Ooooh!</p>
 <p><em>(Repeat and fade)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="whats-up-4-non-blondes" class="title-slide slide level1">
+<section id="whats-up-4-non-blondes" class="title-slide slide level1"><div class="slide-content">
 <h1>Whats up (4 Non Blondes)</h1>
 
-</section>
-<section id="intro-21" class="slide level2">
+</div></section>
+<section id="intro-21" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="d">D</code> <code class="e">Em</code> <code
-class="g">G</code> <code class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse-1-35" class="slide level2">
+<p><code class="d">D</code> <code class="e">Em</code> <code class="g">G</code> <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse-1-35" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="d">D</code> Twenty-five years and my life is still<br />
-<code class="e">Em</code> Trying to get up that great big hill<br />
-Of <code class="g">G</code> hope for a destina<code
-class="d">D</code>tion</p>
+<p><code class="d">D</code> Twenty-five years and my life is still<br>
+<code class="e">Em</code> Trying to get up that great big hill<br>
+Of <code class="g">G</code> hope for a destina<code class="d">D</code>tion</p>
 <p>I <code class="d">D</code> realized quickly when I knew I
-should<br />
+should<br>
 That the world <code class="e">Em</code> was made of this
-brotherhood<br />
-Of man, <code class="g">G</code> for whatever that means <code
-class="d">D</code></p>
-</section>
-<section id="pre-chorus-2" class="slide level2">
+brotherhood<br>
+Of man, <code class="g">G</code> for whatever that means <code class="d">D</code></p>
+</div></section>
+<section id="pre-chorus-2" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
 <p>And so I <code class="d">D</code> cry sometimes when I’m lying in
-bed<br />
+bed<br>
 Just to <code class="e">Em</code> get it all out, what’s in my
-head<br />
-and I <code class="g">G</code> - I am feeling a little pecu<code
-class="d">D</code>liar</p>
+head<br>
+and I <code class="g">G</code> - I am feeling a little pecu<code class="d">D</code>liar</p>
 <p>And so I <code class="d">D</code> wake in the morning and I step
-outside<br />
+outside<br>
 and I <code class="e">Em</code> take a deep breath and I get real high
-and<br />
+and<br>
 I <code class="g">G</code> scream at the top of my lungs:</p>
 <p>“What’s going <code class="d">D</code> on?”</p>
-</section>
-<section id="chorus-45" class="slide level2">
+</div></section>
+<section id="chorus-45" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code><br />
-And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code></p>
-</section>
-<section id="interlude-6" class="slide level2">
+<p>And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code><br>
+And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code></p>
+</div></section>
+<section id="interlude-6" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
-<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code
-class="g">G</code> Ooh <code class="d">D</code> <em>(x2)</em></p>
-</section>
-<section id="verse" class="slide level2">
+<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code class="g">G</code> Ooh <code class="d">D</code> <em>(x2)</em></p>
+</div></section>
+<section id="verse" class="slide level2"><div class="slide-content">
 <h2>Verse</h2>
-<p>And I try, <code class="d">D</code> oh my Aod do I try <code
-class="e">Em</code><br />
-I try all the time, <code class="g">G</code> in this institu<code
-class="d">D</code>tion<br />
-And I pray, <code class="d">D</code> oh my god do I pray <code
-class="e">Em</code><br />
-I pray every single day <code class="g">G</code><br />
+<p>And I try, <code class="d">D</code> oh my Aod do I try <code class="e">Em</code><br>
+I try all the time, <code class="g">G</code> in this institu<code class="d">D</code>tion<br>
+And I pray, <code class="d">D</code> oh my god do I pray <code class="e">Em</code><br>
+I pray every single day <code class="g">G</code><br>
 For a revo<code class="d">D</code>lution</p>
-</section>
-<section id="pre-chorus-3" class="slide level2">
+</div></section>
+<section id="pre-chorus-3" class="slide level2"><div class="slide-content">
 <h2>Pre-Chorus</h2>
 <p>And so I <code class="d">D</code> cry sometimes when I’m lying in
-bed<br />
+bed<br>
 Just to <code class="e">Em</code> get it all out, what’s in my
-head<br />
-and I <code class="g">G</code> - I am feeling a little pecu<code
-class="d">D</code>liar</p>
+head<br>
+and I <code class="g">G</code> - I am feeling a little pecu<code class="d">D</code>liar</p>
 <p>And so I <code class="d">D</code> wake in the morning and I step
-outside<br />
+outside<br>
 and I <code class="e">Em</code> take a deep breath and I get real high
-and<br />
+and<br>
 I <code class="g">G</code> scream at the top of my lungs:</p>
 <p>“What’s going <code class="d">D</code> on?”</p>
-</section>
-<section id="chorus-46" class="slide level2">
+</div></section>
+<section id="chorus-46" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p>And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code><br />
-And I said <code class="d">D</code> “Heyeyeyeyey <code
-class="e">Em</code> Heyeyey”<br />
-I said “Hey, <code class="g">G</code> what’s going on?” <code
-class="d">D</code></p>
+<p>And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code><br>
+And I said <code class="d">D</code> “Heyeyeyeyey <code class="e">Em</code> Heyeyey”<br>
+I said “Hey, <code class="g">G</code> what’s going on?” <code class="d">D</code></p>
 <p><em>(Repeat)</em></p>
-</section>
-<section id="interlude-7" class="slide level2">
+</div></section>
+<section id="interlude-7" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
-<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code
-class="g">G</code> Ooh <code class="d">D</code></p>
-</section>
-<section id="outro-9" class="slide level2">
+<p><code class="d">D</code> Ooh <code class="e">Em</code> Ooh <code class="g">G</code> Ooh <code class="d">D</code></p>
+</div></section>
+<section id="outro-9" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="d">D</code> Twenty-five years and my life is still<br />
-<code class="e">Em</code> Trying to get up that great big hill<br />
-Of <code class="g">G</code> hope for a destina<code
-class="d">D</code>tion</p>
-</section>
+<p><code class="d">D</code> Twenty-five years and my life is still<br>
+<code class="e">Em</code> Trying to get up that great big hill<br>
+Of <code class="g">G</code> hope for a destina<code class="d">D</code>tion</p>
+</div></section>
 </section>
 <section>
-<section id="wild-world-cat-stevens" class="title-slide slide level1">
+<section id="wild-world-cat-stevens" class="title-slide slide level1"><div class="slide-content">
 <h1>Wild world (Cat Stevens)</h1>
 
-</section>
-<section id="instructions-8" class="slide level2">
+</div></section>
+<section id="instructions-8" class="slide level2"><div class="slide-content">
 <h2>Instructions</h2>
 <pre><code>     |E A D G B e|
      |-----------|
@@ -4000,188 +3437,170 @@ G |---2p0-------|--------------|
 D |------3p2p0--|--------------|
 A |-----------3-|---0-3-3-3-0-3|
 E |------------3|3-3---------3-|</code></pre>
-</section>
-<section id="intro-22" class="slide level2">
+</div></section>
+<section id="intro-22" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
-<p><code class="a">Am</code> <code class="d">D/F#</code> <code
-class="g">G</code> <code class="c">C</code> <code class="f">F</code>
-<code class="d">Dm</code> <code class="e">E</code> <code
-class="e">Esus4</code> <code class="e">E</code><br />
+<p><code class="a">Am</code> <code class="d">D/F#</code> <code class="g">G</code> <code class="c">C</code> <code class="f">F</code>
+<code class="d">Dm</code> <code class="e">E</code> <code class="e">Esus4</code> <code class="e">E</code><br>
 La la la…</p>
-</section>
-<section id="verse-1-36" class="slide level2">
+</div></section>
+<section id="verse-1-36" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
 <p><code class="a">Am</code> Now that I’ve <code class="d">D/F#</code>
-lost everything to <code class="g">G</code> you<br />
-You say you <code class="c">C</code> wanna start something <code
-class="f">F</code> new<br />
-And it’s <code class="d">Dm</code> breaking my heart you’re <code
-class="e">E</code> leaving<br />
-Baby I’m <code class="e">Esus4</code> griev<code
-class="e">E</code>ing</p>
-<p>But <code class="a">Am</code> if you wanna <code
-class="d">D/F#</code> leave take good <code class="g">G</code>
-care<br />
+lost everything to <code class="g">G</code> you<br>
+You say you <code class="c">C</code> wanna start something <code class="f">F</code> new<br>
+And it’s <code class="d">Dm</code> breaking my heart you’re <code class="e">E</code> leaving<br>
+Baby I’m <code class="e">Esus4</code> griev<code class="e">E</code>ing</p>
+<p>But <code class="a">Am</code> if you wanna <code class="d">D/F#</code> leave take good <code class="g">G</code>
+care<br>
 Hope you have a <code class="c">C</code> lot of nice things to wear
-<code class="f">F</code><br />
-But then a <code class="d">Dm</code> lot of nice things turn<br />
-<code class="e">E</code> bad out<code class="e">E7</code>there <code
-class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
+<code class="f">F</code><br>
+But then a <code class="d">Dm</code> lot of nice things turn<br>
+<code class="e">E</code> bad out<code class="e">E7</code>there <code class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 <code class="g">G5</code></p>
-</section>
-<section id="chorus-47" class="slide level2">
+</div></section>
+<section id="chorus-47" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> It’s hard to get by<br>
 <code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> I’ll always remember you<br>
 <code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
-</section>
-<section id="verse-2-33" class="slide level2">
+</div></section>
+<section id="verse-2-33" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p><code class="a">Am</code> You know I’ve seen a <code
-class="d">D/F#</code> lot of<br />
-what the world can <code class="g">G</code> do<br />
-And it’s <code class="c">C</code> breaking my heart in <code
-class="f">F</code> two<br />
-’cause I <code class="d">Dm</code> never want to see you <code
-class="e">E</code> sad girl<br />
+<p><code class="a">Am</code> You know I’ve seen a <code class="d">D/F#</code> lot of<br>
+what the world can <code class="g">G</code> do<br>
+And it’s <code class="c">C</code> breaking my heart in <code class="f">F</code> two<br>
+’cause I <code class="d">Dm</code> never want to see you <code class="e">E</code> sad girl<br>
 Don’t be a <code class="e">Esus4</code> bad <code class="e">E</code>
 girl</p>
-<p>But <code class="a">Am</code> if you wanna <code
-class="d">D/F#</code> leave take good <code class="g">G</code>
-care<br />
+<p>But <code class="a">Am</code> if you wanna <code class="d">D/F#</code> leave take good <code class="g">G</code>
+care<br>
 Hope you make a <code class="c">C</code> lot of nice friends out there
-<code class="f">F</code><br />
-But just re<code class="d">Dm</code>member there’s a lot of bad<br />
-<code class="e">E</code> and be<code class="e">E7</code>ware <code
-class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
+<code class="f">F</code><br>
+But just re<code class="d">Dm</code>member there’s a lot of bad<br>
+<code class="e">E</code> and be<code class="e">E7</code>ware <code class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 <code class="g">G5</code></p>
-</section>
-<section id="chorus-48" class="slide level2">
+</div></section>
+<section id="chorus-48" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> It’s hard to get by<br>
 <code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> I’ll always remember you<br>
 <code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
-</section>
-<section id="verse-3-21" class="slide level2">
+</div></section>
+<section id="verse-3-21" class="slide level2"><div class="slide-content">
 <h2>Verse 3</h2>
-<p><code class="a">Am</code> <code class="d">D/F#</code> <code
-class="g">G</code> <code class="c">C</code> <code class="f">F</code>
-<code class="d">Dm</code> <code class="e">E</code> <code
-class="e">Esus4</code> <code class="e">E</code><br />
+<p><code class="a">Am</code> <code class="d">D/F#</code> <code class="g">G</code> <code class="c">C</code> <code class="f">F</code>
+<code class="d">Dm</code> <code class="e">E</code> <code class="e">Esus4</code> <code class="e">E</code><br>
 La la la… Baby I love you</p>
-<p>But <code class="a">Am</code> if you wanna <code
-class="d">D/F#</code> leave take good <code class="g">G</code>
-care<br />
+<p>But <code class="a">Am</code> if you wanna <code class="d">D/F#</code> leave take good <code class="g">G</code>
+care<br>
 Hope you make a <code class="c">C</code> lot of nice friends out there
-<code class="f">F</code><br />
-But just re<code class="d">Dm</code>member there’s a lot of bad<br />
-<code class="e">E</code> and be<code class="e">E7</code>ware <code
-class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
+<code class="f">F</code><br>
+But just re<code class="d">Dm</code>member there’s a lot of bad<br>
+<code class="e">E</code> and be<code class="e">E7</code>ware <code class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 <code class="g">G5</code></p>
-</section>
-<section id="chorus-49" class="slide level2">
+</div></section>
+<section id="chorus-49" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> It’s hard to get by<br>
 <code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br>
 it’s a <code class="f">F</code> wild world <code class="c">C</code>
-<em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you<br />
+<em>(Riff 1)</em><br>
+<code class="g">G</code> I’ll always remember you<br>
 <code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code> <em>(1st time
 only)</em></p>
 <p><em>(Repeat)</em></p>
-</section>
+</div></section>
 </section>
 <section>
-<section id="wish-you-were-here-pink-floyd"
-class="title-slide slide level1">
+<section id="wish-you-were-here-pink-floyd" class="title-slide slide level1"><div class="slide-content">
 <h1>❤️ Wish you were here (Pink Floyd)</h1>
 
-</section>
-<section id="intro-23" class="slide level2">
+</div></section>
+<section id="intro-23" class="slide level2"><div class="slide-content">
 <h2>Intro</h2>
 <p><em>(Instrumental)</em></p>
-<p><code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="a">A</code> <code class="e">Em</code><br />
+<p><code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="a">A</code> <code class="e">Em</code><br>
 <code class="a">A</code> <code class="g">G</code></p>
 <p><em>(Repeat with solo)</em></p>
-</section>
-<section id="verse-1-37" class="slide level2">
+</div></section>
+<section id="verse-1-37" class="slide level2"><div class="slide-content">
 <h2>Verse 1</h2>
-<p><code class="c">C</code> So, so you think you can <code
-class="d">D</code> tell<br />
-heaven from <code class="a">Am</code> hell?<br />
+<p><code class="c">C</code> So, so you think you can <code class="d">D</code> tell<br>
+heaven from <code class="a">Am</code> hell?<br>
 Blue skies from <code class="g">G</code> pain?</p>
-<p>Can you tell a green <code class="d">D</code> field<br />
-from a cold steel <code class="c">C</code> rail?<br />
-A smile from a <code class="a">Am</code> veil?<br />
+<p>Can you tell a green <code class="d">D</code> field<br>
+from a cold steel <code class="c">C</code> rail?<br>
+A smile from a <code class="a">Am</code> veil?<br>
 Do you think you can <code class="g">G</code> tell?</p>
-</section>
-<section id="verse-2-34" class="slide level2">
+</div></section>
+<section id="verse-2-34" class="slide level2"><div class="slide-content">
 <h2>Verse 2</h2>
-<p>Did they get you to <code class="c">C</code> trade<br />
-your heroes for <code class="d">D</code> ghosts?<br />
-Hot ashes for <code class="a">Am</code> trees?<br />
+<p>Did they get you to <code class="c">C</code> trade<br>
+your heroes for <code class="d">D</code> ghosts?<br>
+Hot ashes for <code class="a">Am</code> trees?<br>
 Hot air for a <code class="g">G</code> cool breeze?</p>
-<p>Cold comfort for <code class="d">D</code> change?<br />
-And did you ex<code class="c">C</code>change<br />
-a walk-on part in the <code class="a">Am</code> war<br />
+<p>Cold comfort for <code class="d">D</code> change?<br>
+And did you ex<code class="c">C</code>change<br>
+a walk-on part in the <code class="a">Am</code> war<br>
 for a lead role in a <code class="g">G</code> cage?</p>
-</section>
-<section id="interlude-8" class="slide level2">
+</div></section>
+<section id="interlude-8" class="slide level2"><div class="slide-content">
 <h2>Interlude</h2>
-<p><code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="a">A</code> <code class="e">Em</code><br />
+<p><code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="a">A</code> <code class="e">Em</code><br>
 <code class="a">A</code> <code class="g">G</code></p>
-</section>
-<section id="chorus-50" class="slide level2">
+</div></section>
+<section id="chorus-50" class="slide level2"><div class="slide-content">
 <h2>Chorus</h2>
-<p><code class="c">C</code> How I wish<br />
-how I wish you were <code class="d">D</code> here<br />
-We’re just <code class="a">Am</code> two lost souls<br />
-swimming in a fishbowl<br />
+<p><code class="c">C</code> How I wish<br>
+how I wish you were <code class="d">D</code> here<br>
+We’re just <code class="a">Am</code> two lost souls<br>
+swimming in a fishbowl<br>
 <code class="g">G</code> year after year</p>
-<p><code class="d">D</code> Running over the same old ground<br />
-<code class="c">C</code> what have we found?<br />
-The same old <code class="a">Am</code> fears<br />
+<p><code class="d">D</code> Running over the same old ground<br>
+<code class="c">C</code> what have we found?<br>
+The same old <code class="a">Am</code> fears<br>
 Wish you were <code class="g">G</code> here</p>
-</section>
-<section id="outro-10" class="slide level2">
+</div></section>
+<section id="outro-10" class="slide level2"><div class="slide-content">
 <h2>Outro</h2>
-<p><code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="g">G</code> <code class="e">Em</code><br />
-<code class="a">A</code> <code class="e">Em</code><br />
+<p><code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="g">G</code> <code class="e">Em</code><br>
+<code class="a">A</code> <code class="e">Em</code><br>
 <code class="a">A</code> <code class="g">G</code></p>
 <p><em>(Fade out slowly)</em></p>
-</section>
+</div></section>
 </section>
     </div>
   </div>

--- a/print.html
+++ b/print.html
@@ -3826,12 +3826,13 @@ class="g">G</code> dich…</p>
 <section id="chorus-43" class="slide level2">
 <h2>Chorus</h2>
 <p><em>(x2: gently first time, then repeat intensively)</em></p>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich, ich lieb’ dich
-<code class="g">G</code> nicht.<br />
-Verdammt, ich <code class="d">Dm</code> brauch’ dich, brauch’ dich <code
-class="a">Am</code> nicht. <code class="g">G</code><br />
-Verdammt, ich <code class="c">C</code> will dich, ich will dich <code
-class="g">G</code> nicht,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+ich lieb’ dich <code class="g">G</code> nicht.</p>
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
+brauch’ dich <code class="a">Am</code> nicht. <code
+class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br />
+ich will dich <code class="g">G</code> nicht,<br />
 Ich <code class="f">F</code> will dich nicht verli<code
 class="a">Am</code>er’n!</p>
 </section>
@@ -3862,12 +3863,13 @@ class="g">G</code> dich…</p>
 </section>
 <section id="chorus-44" class="slide level2">
 <h2>Chorus</h2>
-<p>Verdammt, ich <code class="c">C</code> lieb’ dich, ich lieb’ dich
-<code class="g">G</code> nicht.<br />
-Verdammt, ich <code class="d">Dm</code> brauch’ dich, brauch’ dich <code
-class="a">Am</code> nicht. <code class="g">G</code><br />
-Verdammt, ich <code class="c">C</code> will dich, ich will dich <code
-class="g">G</code> nicht,<br />
+<p>Verdammt, ich <code class="c">C</code> lieb’ dich,<br />
+ich lieb’ dich <code class="g">G</code> nicht.</p>
+<p>Verdammt, ich <code class="d">Dm</code> brauch’ dich,<br />
+brauch’ dich <code class="a">Am</code> nicht. <code
+class="g">G</code></p>
+<p>Verdammt, ich <code class="c">C</code> will dich,<br />
+ich will dich <code class="g">G</code> nicht,<br />
 Ich <code class="f">F</code> will dich nicht verli<code
 class="a">Am</code>er’n! - Ooooh!</p>
 <p><em>(Repeat and fade)</em></p>
@@ -4029,17 +4031,17 @@ class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 </section>
 <section id="chorus-47" class="slide level2">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by <code class="f">F</code>
-just upon a <code class="c">C</code> smile<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> It’s hard to get by<br />
+<code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> I’ll always remember you<br />
+<code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-2-33" class="slide level2">
@@ -4065,17 +4067,17 @@ class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 </section>
 <section id="chorus-48" class="slide level2">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by <code class="f">F</code>
-just upon a <code class="c">C</code> smile<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> It’s hard to get by<br />
+<code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> I’ll always remember you<br />
+<code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code></p>
 </section>
 <section id="verse-3-21" class="slide level2">
@@ -4097,17 +4099,17 @@ class="g">G</code> <code class="g">G7</code> <code class="g">G6</code>
 </section>
 <section id="chorus-49" class="slide level2">
 <h2>Chorus</h2>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> It’s hard to get by <code class="f">F</code>
-just upon a <code class="c">C</code> smile<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> It’s hard to get by<br />
+<code class="f">F</code> just upon a <code class="c">C</code> smile
 <code class="g">G</code> <em>(Riff 2)</em></p>
-<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby it’s
-a <code class="f">F</code> wild world<br />
-<code class="c">C</code> <em>(Riff 1)</em><br />
-<code class="g">G</code> I’ll always remember you <code
-class="f">F</code> like a <code class="c">C</code> child girl<br />
+<p><code class="c">C</code> Oh <code class="g">G</code> baby, baby<br />
+it’s a <code class="f">F</code> wild world <code class="c">C</code>
+<em>(Riff 1)</em><br />
+<code class="g">G</code> I’ll always remember you<br />
+<code class="f">F</code> like a <code class="c">C</code> child girl
 <code class="d">Dm</code> <code class="e">E</code> <em>(1st time
 only)</em></p>
 <p><em>(Repeat)</em></p>
@@ -4237,7 +4239,7 @@ Wish you were <code class="g">G</code> here</p>
 
         // Disables the default reveal.js slide layout (scaling and centering)
         // so that you can use custom CSS layout
-        disableLayout: false,
+        disableLayout: true,
 
         // Vertical centering of slides
         center: true,
@@ -4332,13 +4334,6 @@ Wish you were <code class="g">G</code> here</p>
         // devices. It is advisable to set this to a lower number than
         // viewDistance in order to save resources.
         mobileViewDistance: 2,
-
-        // The "normal" size of the presentation, aspect ratio will be preserved
-        // when the presentation is scaled to fit different resolutions. Can be
-        // specified using percentage units.
-        width: 960,
-
-        height: 640,
 
         // reveal.js plugins
         plugins: []

--- a/style/body-controls.html
+++ b/style/body-controls.html
@@ -1,10 +1,12 @@
-<div id="bottom-left-controls">
-  <button id="toggle-chords-visibility"></button>
-  <button id="show-qr"></button>
-  <button id="master-mode"></button>
+<div id="top-left-controls" class="controls-group">
+  <a href="#/1" id="go-to-toc" class="ctrl"></a>
+  <button id="toggle-chords-visibility" class="ctrl"></button>
 </div>
-<a href="#" id="toggle-theme"></a>
-<a href="#/1" id="go-to-toc"></a>
+<div id="top-right-controls" class="controls-group">
+  <button id="show-qr" class="ctrl"></button>
+  <button id="master-mode" class="ctrl"></button>
+  <a href="#" id="toggle-theme" class="ctrl"></a>
+</div>
 <script>
   document.getElementById('toggle-chords-visibility').addEventListener('click', function() {
     document.body.classList.toggle('chords-hidden');

--- a/style/night.css
+++ b/style/night.css
@@ -1,16 +1,12 @@
-#bottom-left-controls {
+.controls-group {
   position: fixed;
-  bottom: 2.5em;
-  left: 2em;
   z-index: 100;
   display: flex;
   align-items: center;
   gap: 0.75em;
 }
 
-#toggle-chords-visibility,
-#master-mode,
-#show-qr {
+.ctrl {
   position: relative;
   opacity: 0.75;
   background: none;
@@ -19,10 +15,14 @@
   cursor: pointer;
   font-family: inherit;
   line-height: 1;
+  text-decoration: none;
+}
+
+.ctrl::before {
+  font-size: 3em;
 }
 
 #toggle-chords-visibility::before {
-  font-size: 3em;
   content: '🎹';
 }
 
@@ -79,31 +79,21 @@ section#TOC::-webkit-scrollbar-thumb {
   border: 3px solid var(--scrollbarBG);
 }
 
-a#go-to-toc {
-  position: fixed;
-  top: 2em;
-  left: 1.5em;
-  z-index: 100;
-  opacity: 0.75;
-  text-decoration: none;
+#top-left-controls {
+  top: 1em;
+  left: 1em;
+}
+
+#top-right-controls {
+  top: 1em;
+  right: 1em;
 }
 
 a#go-to-toc::before {
-  font-size: 3em;
   content: '📖'
 }
 
-a#toggle-theme {
-  position: fixed;
-  top: 2em;
-  right: 1.5em;
-  z-index: 100;
-  opacity: 0.75;
-  text-decoration: none;
-}
-
 a#toggle-theme::before {
-  font-size: 3em;
   content: '🌙';
 }
 
@@ -116,7 +106,6 @@ a#toggle-theme::before {
 }
 
 #master-mode::before {
-  font-size: 3em;
   content: '🚀';
 }
 
@@ -129,7 +118,6 @@ a#toggle-theme::before {
 }
 
 #show-qr::before {
-  font-size: 3em;
   content: '🔗';
 }
 

--- a/style/shared.css
+++ b/style/shared.css
@@ -1,13 +1,17 @@
+.reveal section .slide-content {
+  padding: 10px;
+}
+
 .reveal section h1 {
   font-size: 2em;
 }
 
 .reveal section h2 {
-  font-size: 1.41em;
+  font-size: 1.5em;
 }
 
 .reveal section h3 {
-  font-size: 1.03em;
+  font-size: 1.25em;
 }
 
 .reveal section code {

--- a/style/shared.css
+++ b/style/shared.css
@@ -1,5 +1,13 @@
 .reveal section h1 {
-  font-size: 3em;
+  font-size: 2em;
+}
+
+.reveal section h2 {
+  font-size: 1.41em;
+}
+
+.reveal section h3 {
+  font-size: 1.03em;
 }
 
 .reveal section code {

--- a/style/shared.css
+++ b/style/shared.css
@@ -40,3 +40,17 @@
   max-height: initial;
   text-align: left;
 }
+
+.reveal section.slide.level2 .slide-content {
+  white-space: nowrap;
+}
+
+section.stack {
+  flex-direction: column;
+  justify-content: center;
+}
+
+section.slide.level2 {
+  display: flex;
+  justify-content: center;
+}

--- a/style/slide-zoom.js
+++ b/style/slide-zoom.js
@@ -1,0 +1,29 @@
+(function () {
+  function fitSlide(section) {
+    if (!section || !section.classList.contains('level2')) return;
+    var content = section.querySelector('.slide-content');
+    if (!content) return;
+
+    content.style.zoom = 1;
+
+    var contentW = content.scrollWidth;
+    var contentH = content.scrollHeight;
+    var availW   = window.innerWidth;
+    var availH   = window.innerHeight;
+
+    if (!contentW || !contentH) return;
+
+    content.style.zoom = Math.min(availW / contentW, availH / contentH);
+  }
+
+  window.addEventListener('load', function () {
+    if (!window.Reveal) return;
+
+    Reveal.on('ready',        function (e) { fitSlide(e.currentSlide); });
+    Reveal.on('slidechanged', function (e) { fitSlide(e.currentSlide); });
+
+    window.addEventListener('resize', function () {
+      fitSlide(Reveal.getCurrentSlide());
+    });
+  });
+})();

--- a/style/slide-zoom.js
+++ b/style/slide-zoom.js
@@ -1,6 +1,8 @@
 (function () {
   function fitSlide(section) {
-    if (!section || !section.classList.contains('level2')) return;
+    if (!section) return;
+    var isSlide = section.id === 'title-slide' || section.classList.contains('level1') || section.classList.contains('level2');
+    if (!isSlide) return;
     var content = section.querySelector('.slide-content');
     if (!content) return;
 
@@ -21,9 +23,8 @@
 
     Reveal.on('ready',        function (e) { fitSlide(e.currentSlide); });
     Reveal.on('slidechanged', function (e) { fitSlide(e.currentSlide); });
+    window.addEventListener('resize', function () { fitSlide(Reveal.getCurrentSlide()); });
 
-    window.addEventListener('resize', function () {
-      fitSlide(Reveal.getCurrentSlide());
-    });
+    if (Reveal.isReady()) fitSlide(Reveal.getCurrentSlide());
   });
 })();


### PR DESCRIPTION
## Summary

- Switch to `disableLayout: true` with `.slide-content` wrappers for full CSS control over slide layout
- Add dynamic slide zoom that fits content to the viewport
- Reduce h1/h2/h3 font sizes to ~2/3 of Reveal.js theme defaults
- Disable built-in navigation arrows (`controls: false`)
- Reorganize UI buttons into top-left (📖 🎹) and top-right (📱 🚀 🌙) corner groups
- Extract shared `.ctrl` and `.controls-group` CSS classes to eliminate duplication

## Test plan

- [ ] Slides display correctly with content scaled to fit
- [ ] 📖 TOC and 🎹 chord-toggle appear top-left
- [ ] 📱 QR, 🚀 master-mode, 🌙 theme-toggle appear top-right
- [ ] Chord visibility toggle works
- [ ] Master mode / multiplex still works
- [ ] Theme switching (dark/bright) still works
- [ ] No Reveal navigation arrows visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)